### PR TITLE
feat(canvas): add workload terminal pane

### DIFF
--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/danielgtaylor/huma/v2 v2.35.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/cors v1.2.2
+	github.com/golang-jwt/jwt/v5 v5.2.2
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/joho/godotenv v1.5.1
 	k8s.io/api v0.35.1
 	k8s.io/apimachinery v0.35.1
@@ -27,7 +29,6 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
@@ -36,9 +37,11 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/apps/api/go.sum
+++ b/apps/api/go.sum
@@ -8,6 +8,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danielgtaylor/huma/v2 v2.35.0 h1:FRg3FgVKcMogVhbNY7FjyTwk+p/orLBR3hQBvXXg7dw=
 github.com/danielgtaylor/huma/v2 v2.35.0/go.mod h1:3elp5brzdyyZsPlDVvf6w8RLnklKp3abolr+5op3fP0=
@@ -47,6 +49,8 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
@@ -68,6 +72,8 @@ github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa1
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
+github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -76,6 +82,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -71,6 +71,7 @@ func main() {
 
 	// Register API routes (with OpenAPI docs)
 	k8s.Register(api)
+	k8s.RegisterExecWebSocket(router)
 	ap.Register(api)
 	auth.Register(api)
 	project.Register(api)

--- a/apps/api/route/k8s/exec_ws.go
+++ b/apps/api/route/k8s/exec_ws.go
@@ -1,0 +1,194 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"sealos/api/middleware"
+	k8ssvc "sealos/api/service/k8s"
+)
+
+const (
+	execMessageTypeInit  = "init"
+	execMessageTypeInput = "input"
+	execMessageTypeError = "error"
+	execMessageTypeReady = "ready"
+	execMessageTypeClose = "close"
+)
+
+type execClientMessage struct {
+	Command    []string `json:"command,omitempty"`
+	Container  string   `json:"container,omitempty"`
+	Kubeconfig string   `json:"kubeconfig,omitempty"`
+	Name       string   `json:"name,omitempty"`
+	Namespace  string   `json:"namespace,omitempty"`
+	Type       string   `json:"type"`
+	Value      string   `json:"value,omitempty"`
+}
+
+type execServerMessage struct {
+	Container string `json:"container,omitempty"`
+	Message   string `json:"message,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Pod       string `json:"pod,omitempty"`
+	Type      string `json:"type"`
+	Value     string `json:"value,omitempty"`
+}
+
+var execUpgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
+
+func RegisterExecWebSocket(router interface {
+	HandleFunc(pattern string, handlerFn http.HandlerFunc)
+}) {
+	router.HandleFunc("/api/k8s/v1alpha1/exec", execWebSocketHandler)
+}
+
+func execWebSocketHandler(w http.ResponseWriter, r *http.Request) {
+	conn, err := execUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	_ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+	var initMsg execClientMessage
+	if err := conn.ReadJSON(&initMsg); err != nil {
+		writeExecError(conn, "invalid terminal init message")
+		return
+	}
+	_ = conn.SetReadDeadline(time.Time{})
+	if initMsg.Type != execMessageTypeInit {
+		writeExecError(conn, "first terminal message must be init")
+		return
+	}
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	restConfig, cfg, err := middleware.RestConfigFromAuth("Bearer " + initMsg.Kubeconfig)
+	if err != nil {
+		writeExecError(conn, "invalid kubeconfig")
+		return
+	}
+	gvr := middleware.PodsGVR()
+	resolved, err := middleware.ResolveContext(cfg, middleware.ResolveOptions{
+		Namespace:        initMsg.Namespace,
+		AllNamespaces:    false,
+		DefaultNamespace: "",
+		AdminCheckGVR:    &gvr,
+	})
+	if err != nil {
+		writeExecError(conn, "failed to resolve Kubernetes context")
+		return
+	}
+
+	stdinReader, stdinWriter := io.Pipe()
+	outputWriter := &webSocketExecWriter{conn: conn}
+	target, err := k8ssvc.ResolveAPWorkloadExecTarget(ctx, restConfig, k8ssvc.APWorkloadExecTargetOptions{
+		Command:   initMsg.Command,
+		Container: initMsg.Container,
+		Name:      initMsg.Name,
+		Namespace: resolved.Namespace,
+	})
+	if err != nil {
+		writeExecError(conn, execErrorMessage(err))
+		return
+	}
+
+	if err := conn.WriteJSON(execServerMessage{
+		Container: target.Container,
+		Namespace: target.Namespace,
+		Pod:       target.Pod,
+		Type:      execMessageTypeReady,
+	}); err != nil {
+		return
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		defer stdinReader.Close()
+		done <- k8ssvc.StreamPodExec(ctx, restConfig, target, stdinReader, outputWriter, outputWriter)
+	}()
+
+	readDone := make(chan error, 1)
+	go func() {
+		defer stdinWriter.Close()
+		for {
+			var msg execClientMessage
+			if err := conn.ReadJSON(&msg); err != nil {
+				readDone <- err
+				return
+			}
+			switch msg.Type {
+			case execMessageTypeInput:
+				if _, err := io.WriteString(stdinWriter, msg.Value); err != nil {
+					readDone <- err
+					return
+				}
+			case execMessageTypeClose:
+				readDone <- nil
+				return
+			}
+		}
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			writeExecError(conn, err.Error())
+		}
+	case <-readDone:
+		cancel()
+		if err := <-done; err != nil && !errors.Is(err, context.Canceled) {
+			writeExecError(conn, err.Error())
+		}
+	case <-ctx.Done():
+		cancel()
+	}
+}
+
+func execErrorMessage(err error) string {
+	switch {
+	case errors.Is(err, k8ssvc.ErrNoExecPodFound):
+		return "No running pod was found for this workload."
+	default:
+		message := strings.TrimSpace(err.Error())
+		if message == "" {
+			return "Terminal connection failed."
+		}
+		return message
+	}
+}
+
+func writeExecError(conn *websocket.Conn, message string) {
+	_ = conn.WriteJSON(execServerMessage{
+		Message: message,
+		Type:    execMessageTypeError,
+	})
+}
+
+type webSocketExecWriter struct {
+	conn *websocket.Conn
+}
+
+func (w *webSocketExecWriter) Write(p []byte) (int, error) {
+	message := execServerMessage{
+		Type:  "output",
+		Value: string(p),
+	}
+	if err := w.conn.WriteJSON(message); err != nil {
+		return 0, fmt.Errorf("write terminal output: %w", err)
+	}
+	return len(p), nil
+}

--- a/apps/api/service/k8s/exec.go
+++ b/apps/api/service/k8s/exec.go
@@ -1,0 +1,172 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+const APWorkloadExecDefaultCommand = `clear; (bash || ash || sh)`
+
+var ErrNoExecPodFound = errors.New("no running pod found for workload")
+
+type APWorkloadExecTargetOptions struct {
+	Command   []string
+	Container string
+	Name      string
+	Namespace string
+}
+
+type APWorkloadExecTarget struct {
+	Command   []string
+	Container string
+	Namespace string
+	Pod       string
+}
+
+func ResolveAPWorkloadExecTarget(
+	ctx context.Context,
+	restConfig *rest.Config,
+	opts APWorkloadExecTargetOptions,
+) (APWorkloadExecTarget, error) {
+	target := APWorkloadExecTarget{
+		Command:   append([]string(nil), opts.Command...),
+		Container: strings.TrimSpace(opts.Container),
+		Namespace: strings.TrimSpace(opts.Namespace),
+	}
+	name := strings.TrimSpace(opts.Name)
+	if target.Namespace == "" || name == "" {
+		return target, fmt.Errorf("workload name and namespace are required")
+	}
+	if len(target.Command) == 0 {
+		target.Command = []string{"/bin/sh", "-c", APWorkloadExecDefaultCommand}
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return target, err
+	}
+
+	pods, err := clientset.CoreV1().Pods(target.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=" + name,
+	})
+	if err != nil {
+		return target, err
+	}
+
+	pod := selectExecPod(pods.Items)
+	if pod == nil {
+		return target, ErrNoExecPodFound
+	}
+	target.Pod = pod.Name
+	target.Container = resolveExecContainer(*pod, target.Container, name)
+	if target.Container == "" {
+		return target, fmt.Errorf("pod %q has no containers", pod.Name)
+	}
+	return target, nil
+}
+
+func selectExecPod(pods []corev1.Pod) *corev1.Pod {
+	var fallback *corev1.Pod
+	for i := range pods {
+		pod := &pods[i]
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		if fallback == nil {
+			fallback = pod
+		}
+		if pod.Status.Phase == corev1.PodRunning {
+			return pod
+		}
+	}
+	return fallback
+}
+
+func resolveExecContainer(pod corev1.Pod, requested string, workloadName string) string {
+	if requested != "" {
+		for _, container := range pod.Spec.Containers {
+			if container.Name == requested {
+				return requested
+			}
+		}
+	}
+	for _, container := range pod.Spec.Containers {
+		if container.Name == workloadName {
+			return workloadName
+		}
+	}
+	if len(pod.Spec.Containers) > 0 {
+		return pod.Spec.Containers[0].Name
+	}
+	return ""
+}
+
+func StreamPodExec(
+	ctx context.Context,
+	restConfig *rest.Config,
+	target APWorkloadExecTarget,
+	stdin io.Reader,
+	stdout io.Writer,
+	stderr io.Writer,
+) error {
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	req := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(target.Pod).
+		Namespace(target.Namespace).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Command:   target.Command,
+			Container: target.Container,
+			Stderr:    true,
+			Stdin:     true,
+			Stdout:    true,
+			TTY:       true,
+		}, scheme.ParameterCodec)
+
+	executor, err := remotecommand.NewSPDYExecutor(restConfig, "POST", req.URL())
+	if err != nil {
+		return err
+	}
+
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- executor.StreamWithContext(streamCtx, remotecommand.StreamOptions{
+			Stdin:  stdin,
+			Stdout: stdout,
+			Stderr: stderr,
+			Tty:    true,
+		})
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		cancel()
+		select {
+		case err := <-done:
+			return err
+		case <-time.After(2 * time.Second):
+			return ctx.Err()
+		}
+	}
+}

--- a/apps/ui/src/app/project/[uid]/page.tsx
+++ b/apps/ui/src/app/project/[uid]/page.tsx
@@ -26,12 +26,14 @@ import {
   ProjectCanvasSidePaneSlot,
   resolveProjectCanvasSidePaneEntry,
 } from "@/lib/project-canvas/panels/project-canvas-side-pane-slot";
+import { WorkloadTerminalPane } from "@/lib/project-canvas/panels/workload-terminal-panel";
 import { telemetryTargetFromCanvasNode } from "@/lib/project-canvas/telemetry/workload-telemetry-node";
 import { WorkloadTelemetryProvider } from "@/lib/project-canvas/telemetry/workload-telemetry-react";
 import type { ProjectSidePaneSurface } from "@/lib/project-side-pane/controller";
 import { useProjectSidePaneSurface } from "@/lib/project-side-pane/react";
 import { projectCanvasEntryForAssistantIntent } from "@/lib/project-side-pane/surface-intents";
 import { kubeconfigAtom, namespaceAtom } from "@/store/auth-store";
+import { WORKLOAD_PANE } from "@/store/canvas-store";
 
 const GITHUB_DEPLOYMENT_PANE_QUERY_KEY = "githubDeployment" as const;
 const DATABASE_DEPLOYMENT_PANE_QUERY_KEY = "databaseDeployment" as const;
@@ -152,8 +154,10 @@ export default function ProjectUidPage() {
     [selectedNode]
   );
   const selectedDatabaseData = databaseNodeDataFromNode(selectedNode);
+  const terminalPlaneOpen =
+    workloadPane === WORKLOAD_PANE.terminal && selectedNode != null;
   const canvasResourcePaneOpen = Boolean(
-    workloadPane ?? databasePane ?? entryPane
+    (terminalPlaneOpen ? null : workloadPane) ?? databasePane ?? entryPane
   );
   const canvasSidePaneEntry = resolveProjectCanvasSidePaneEntry({
     databaseDeploymentPaneOpen,
@@ -350,6 +354,12 @@ export default function ProjectUidPage() {
                     resourcePane={canvasResourcePane}
                   />
                   {settingsLeaveGuardDialog}
+                  {terminalPlaneOpen ? (
+                    <WorkloadTerminalPane
+                      node={selectedNode}
+                      onClose={closeResourcePane}
+                    />
+                  ) : null}
                 </Canvas.Flow>
               </div>
             </Canvas.Root>

--- a/apps/ui/src/hooks/use-project-canvas.ts
+++ b/apps/ui/src/hooks/use-project-canvas.ts
@@ -556,6 +556,9 @@ export function useProjectCanvas(
           setEntryPane(null).catch(() => undefined);
           setServiceUid(uid ?? "").catch(() => undefined);
           setWorkloadPane(pane).catch(() => undefined);
+          if (pane !== WORKLOAD_PANE.terminal) {
+            onResourcePaneOpen?.();
+          }
         });
       };
 
@@ -597,28 +600,23 @@ export function useProjectCanvas(
         ...(data.actions?.quickActions ?? {}),
         calendar: {
           disabled: !hasUrlActions,
-          onClick: hasUrlActions
-            ? () => select(WORKLOAD_PANE.history)
-            : undefined,
+          onClick: () => select(WORKLOAD_PANE.history),
         },
         console: {
-          disabled: true,
+          disabled: !hasUrlActions,
+          onClick: () => select(WORKLOAD_PANE.terminal),
         },
         logs: {
           disabled: !hasUrlActions,
-          onClick: hasUrlActions ? () => select(WORKLOAD_PANE.logs) : undefined,
+          onClick: () => select(WORKLOAD_PANE.logs),
         },
         events: {
           disabled: !hasUrlActions,
-          onClick: hasUrlActions
-            ? () => select(WORKLOAD_PANE.events)
-            : undefined,
+          onClick: () => select(WORKLOAD_PANE.events),
         },
         metrics: {
           disabled: !hasUrlActions,
-          onClick: hasUrlActions
-            ? () => select(WORKLOAD_PANE.metrics)
-            : undefined,
+          onClick: () => select(WORKLOAD_PANE.metrics),
         },
       };
 
@@ -646,6 +644,7 @@ export function useProjectCanvas(
       deleteWorkload,
       handleAddDbDsnReferenceIntentConsumed,
       onPendingApDbReferencesStart,
+      onResourcePaneOpen,
       options?.shareToken,
       pendingAddDbDsnReferenceIntent,
       pauseWorkload,
@@ -1036,7 +1035,11 @@ export function useProjectCanvas(
           const nextEntryPane = entryPaneModeForNodeClick(node);
           const nextServiceUid = projectCanvasNodeServiceUid(node);
           const nextResourcePaneOpen = Boolean(
-            nextWorkloadPane ?? nextDatabasePane ?? nextEntryPane
+            (nextWorkloadPane === WORKLOAD_PANE.terminal
+              ? null
+              : nextWorkloadPane) ??
+              nextDatabasePane ??
+              nextEntryPane
           );
           const selectNode = () => {
             frontCanvasNode(node);

--- a/apps/ui/src/lib/project-canvas/panels/workload-pane-mode.ts
+++ b/apps/ui/src/lib/project-canvas/panels/workload-pane-mode.ts
@@ -14,7 +14,8 @@ export function normalizeWorkloadPaneMode(
     value === WORKLOAD_PANE.history ||
     value === WORKLOAD_PANE.logs ||
     value === WORKLOAD_PANE.metrics ||
-    value === WORKLOAD_PANE.settings
+    value === WORKLOAD_PANE.settings ||
+    value === WORKLOAD_PANE.terminal
   ) {
     return value;
   }

--- a/apps/ui/src/lib/project-canvas/panels/workload-terminal-panel.tsx
+++ b/apps/ui/src/lib/project-canvas/panels/workload-terminal-panel.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { Button } from "@workspace/ui/components/button";
+import type { ContainerNodeStates } from "@workspace/ui/components/container-node/container-node";
+import type { Node } from "@xyflow/react";
+import { useAtomValue } from "jotai";
+import { Circle, SquareTerminal, X } from "lucide-react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { containerStatesFromNode } from "@/lib/project-canvas/flow/container-node-workload";
+import { kubeconfigAtom, namespaceAtom } from "@/store/auth-store";
+import { workloadTerminalWebSocketUrl } from "./workload-terminal-url";
+
+type TerminalStatus = "connecting" | "closed" | "error" | "ready";
+
+interface TerminalLine {
+  id: number;
+  tone?: "error" | "muted" | "success";
+  value: string;
+}
+
+interface TerminalServerMessage {
+  container?: string;
+  message?: string;
+  namespace?: string;
+  pod?: string;
+  type: "close" | "error" | "output" | "ready";
+  value?: string;
+}
+
+function terminalTitle(states: ContainerNodeStates | null): string {
+  return states?.name?.trim() || "Terminal";
+}
+
+function terminalSubtitle({
+  container,
+  pod,
+  states,
+  status,
+}: {
+  container: string;
+  pod: string;
+  states: ContainerNodeStates | null;
+  status: TerminalStatus;
+}) {
+  const image = states?.image?.trim();
+  const target = pod && container ? `${pod} / ${container}` : "Resolving pod";
+  if (status === "ready") {
+    return image ? `${target} - ${image}` : target;
+  }
+  if (status === "error") {
+    return "Terminal connection failed";
+  }
+  if (status === "closed") {
+    return "Terminal session closed";
+  }
+  return image ? `Connecting - ${image}` : "Connecting";
+}
+
+let terminalLineId = 0;
+
+function nextTerminalLineId() {
+  terminalLineId += 1;
+  return terminalLineId;
+}
+
+function terminalLineClassName(tone: TerminalLine["tone"]): string {
+  switch (tone) {
+    case "error":
+      return "whitespace-pre-wrap text-red-300";
+    case "success":
+      return "whitespace-pre-wrap text-emerald-300";
+    case "muted":
+      return "whitespace-pre-wrap text-zinc-400";
+    default:
+      return "whitespace-pre-wrap text-zinc-100";
+  }
+}
+
+function appendOutput(lines: TerminalLine[], value: string): TerminalLine[] {
+  const chunks = value.replace(/\r/g, "").split("\n");
+  const next = [...lines];
+  chunks.forEach((chunk, index) => {
+    if (index === 0 && next.length > 0) {
+      const last = next.at(-1);
+      if (last !== undefined) {
+        next[next.length - 1] = { ...last, value: `${last.value}${chunk}` };
+      }
+      return;
+    }
+    next.push({ id: nextTerminalLineId(), value: chunk });
+  });
+  return next.slice(-500);
+}
+
+function parseTerminalMessage(data: MessageEvent["data"]) {
+  const raw = typeof data === "string" ? data : "";
+  if (raw === "") {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as TerminalServerMessage;
+  } catch {
+    return {
+      type: "output" as const,
+      value: raw,
+    };
+  }
+}
+
+export const WorkloadTerminalPane = memo(function WorkloadTerminalPane({
+  node,
+  onClose,
+}: {
+  node: Node;
+  onClose: () => void;
+}) {
+  const kubeconfig = useAtomValue(kubeconfigAtom);
+  const ns = useAtomValue(namespaceAtom).trim();
+  const states = containerStatesFromNode(node);
+  const namespace = states?.namespace?.trim() || ns;
+  const name = states?.name?.trim() ?? "";
+  const [container, setContainer] = useState("");
+  const [input, setInput] = useState("");
+  const [lines, setLines] = useState<TerminalLine[]>([]);
+  const [pod, setPod] = useState("");
+  const [status, setStatus] = useState<TerminalStatus>("connecting");
+  const socketRef = useRef<WebSocket | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  const canConnect =
+    kubeconfig.trim() !== "" && namespace !== "" && name !== "";
+  const subtitle = useMemo(
+    () => terminalSubtitle({ container, pod, states, status }),
+    [container, pod, states, status]
+  );
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({
+      top: scrollRef.current.scrollHeight,
+    });
+  });
+
+  useEffect(() => {
+    setLines([]);
+    setPod("");
+    setContainer("");
+    if (!canConnect) {
+      setStatus("error");
+      setLines([
+        {
+          id: nextTerminalLineId(),
+          tone: "error",
+          value: "Missing kubeconfig, namespace, or workload name.",
+        },
+      ]);
+      return;
+    }
+
+    let active = true;
+    const socket = new WebSocket(workloadTerminalWebSocketUrl());
+    socketRef.current = socket;
+    setStatus("connecting");
+    setLines([
+      {
+        id: nextTerminalLineId(),
+        tone: "muted",
+        value: `Connecting to ${name}...`,
+      },
+    ]);
+
+    socket.addEventListener("open", () => {
+      if (!active) {
+        socket.close();
+        return;
+      }
+      socket.send(
+        JSON.stringify({
+          kubeconfig,
+          name,
+          namespace,
+          type: "init",
+        })
+      );
+    });
+
+    socket.addEventListener("message", (event) => {
+      if (!active) {
+        return;
+      }
+      const message = parseTerminalMessage(event.data);
+      if (message === null) {
+        return;
+      }
+      if (message.type === "ready") {
+        setPod(message.pod ?? "");
+        setContainer(message.container ?? "");
+        setStatus("ready");
+        setLines((current) => [
+          ...current,
+          {
+            id: nextTerminalLineId(),
+            tone: "success",
+            value: `Connected to ${message.pod ?? name}${message.container ? ` (${message.container})` : ""}`,
+          },
+        ]);
+        return;
+      }
+      if (message.type === "error") {
+        setStatus("error");
+        setLines((current) => [
+          ...current,
+          {
+            id: nextTerminalLineId(),
+            tone: "error",
+            value: message.message ?? "Terminal error.",
+          },
+        ]);
+        return;
+      }
+      if (message.type === "output") {
+        setLines((current) => appendOutput(current, message.value ?? ""));
+      }
+    });
+
+    socket.addEventListener("close", () => {
+      if (!active) {
+        return;
+      }
+      setStatus((current) => (current === "error" ? current : "closed"));
+    });
+
+    socket.addEventListener("error", () => {
+      if (!active) {
+        return;
+      }
+      setStatus("error");
+      setLines((current) => [
+        ...current,
+        {
+          id: nextTerminalLineId(),
+          tone: "error",
+          value: "WebSocket connection failed.",
+        },
+      ]);
+    });
+
+    return () => {
+      active = false;
+      socketRef.current = null;
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify({ type: "close" }));
+        socket.close();
+      }
+    };
+  }, [canConnect, kubeconfig, name, namespace]);
+
+  const sendInput = useCallback(
+    (value: string) => {
+      if (value === "") {
+        return;
+      }
+      const socket = socketRef.current;
+      if (socket?.readyState !== WebSocket.OPEN || status !== "ready") {
+        return;
+      }
+      socket.send(JSON.stringify({ type: "input", value }));
+    },
+    [status]
+  );
+
+  return (
+    <section
+      aria-label="Container instance terminal"
+      className="pointer-events-auto absolute inset-x-0 bottom-0 z-20 flex h-[38%] min-h-72 flex-col border-resource-pane-input border-t bg-[#10131a]/98 shadow-[0_-18px_60px_rgba(0,0,0,0.36)] backdrop-blur"
+      data-slot="workload-terminal-plane"
+    >
+      <header className="flex h-15 shrink-0 items-center gap-3 border-resource-pane-input border-b px-6">
+        <SquareTerminal aria-hidden className="size-4 shrink-0 text-blue-500" />
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-3">
+            <h2 className="truncate font-semibold text-lg text-zinc-100">
+              {terminalTitle(states)}
+            </h2>
+            <span className="inline-flex min-w-0 items-center gap-2 text-sm text-zinc-400">
+              <Circle
+                aria-hidden
+                className="size-3 shrink-0 fill-emerald-500 text-emerald-500"
+              />
+              <span className="truncate">{subtitle}</span>
+            </span>
+          </div>
+        </div>
+        <Button
+          aria-label="Close workload terminal"
+          className="size-8 rounded-md text-zinc-200 hover:bg-white/10"
+          onClick={onClose}
+          size="icon"
+          type="button"
+          variant="ghost"
+        >
+          <X aria-hidden className="size-4" />
+        </Button>
+      </header>
+      <div
+        className="min-h-0 flex-1 overflow-auto px-6 py-4 font-mono text-[13px] text-zinc-100 leading-6"
+        ref={scrollRef}
+      >
+        {lines.map((line) => (
+          <div className={terminalLineClassName(line.tone)} key={line.id}>
+            {line.value || " "}
+          </div>
+        ))}
+      </div>
+      <form
+        className="flex min-w-0 items-center gap-2 border-resource-pane-input border-t px-6 py-3"
+        onSubmit={(event) => {
+          event.preventDefault();
+          sendInput(`${input}\n`);
+          setInput("");
+        }}
+      >
+        <span className="shrink-0 font-mono text-blue-400 text-sm">$</span>
+        <input
+          autoComplete="off"
+          className="min-w-0 flex-1 bg-transparent font-mono text-sm text-zinc-100 outline-none placeholder:text-zinc-600 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={status !== "ready"}
+          onChange={(event) => setInput(event.target.value)}
+          placeholder={
+            status === "ready" ? "Type a command..." : "Connecting terminal..."
+          }
+          value={input}
+        />
+      </form>
+    </section>
+  );
+});
+
+WorkloadTerminalPane.displayName = "WorkloadTerminalPane";

--- a/apps/ui/src/lib/project-canvas/panels/workload-terminal-url.ts
+++ b/apps/ui/src/lib/project-canvas/panels/workload-terminal-url.ts
@@ -1,0 +1,20 @@
+import { API_ROUTES } from "@workspace/api/constants";
+
+const LOCALHOST_PORT_PATTERN = /:\d+$/;
+
+function apiOrigin(): string {
+  const configured = process.env.NEXT_PUBLIC_API_URL?.trim();
+  if (configured) {
+    return configured;
+  }
+  if (typeof window !== "undefined") {
+    return window.location.origin.replace(LOCALHOST_PORT_PATTERN, ":9000");
+  }
+  return "http://localhost:9000";
+}
+
+export function workloadTerminalWebSocketUrl(): string {
+  const url = new URL(API_ROUTES.k8s.exec, apiOrigin());
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  return url.href;
+}

--- a/apps/ui/src/store/canvas-store.test.ts
+++ b/apps/ui/src/store/canvas-store.test.ts
@@ -82,6 +82,7 @@ test("workload panel mode distinguishes AP pane URL values", () => {
   assert.equal(normalizeWorkloadPaneMode("metrics"), "metrics");
   assert.equal(normalizeWorkloadPaneMode("logs"), "logs");
   assert.equal(normalizeWorkloadPaneMode("history"), "history");
+  assert.equal(normalizeWorkloadPaneMode("terminal"), "terminal");
   assert.equal(normalizeWorkloadPaneMode("Settings"), null);
 });
 

--- a/apps/ui/src/store/canvas-store.tsx
+++ b/apps/ui/src/store/canvas-store.tsx
@@ -17,7 +17,7 @@ import { canvasNodeSelectionKey } from "@/lib/project-canvas/nodes/resource-iden
 /** nuqs key for the selected workload card (Kubernetes `metadata.uid`). */
 export const CANVAS_SERVICE_QUERY_KEY = "service" as const;
 
-/** nuqs key for the AP / Container Node action pane (`?apPane=settings|metrics|logs|history`). */
+/** nuqs key for the AP / Container Node action pane (`?apPane=settings|metrics|terminal|logs|history`). */
 export const WORKLOAD_PANE_QUERY_KEY = "apPane" as const;
 
 /** nuqs key for the database action pane (`?dbPane=settings|metrics`). */
@@ -32,6 +32,7 @@ export const WORKLOAD_PANE = {
   logs: "logs",
   metrics: "metrics",
   settings: "settings",
+  terminal: "terminal",
 } as const;
 
 export const DATABASE_PANE = {

--- a/packages/api/src/constants.ts
+++ b/packages/api/src/constants.ts
@@ -20,6 +20,7 @@ export const API_ROUTES = {
     getRoot: "/api/k8s/v1alpha1",
     describe: "/api/k8s/v1alpha1/describe",
     logs: "/api/k8s/v1alpha1/logs",
+    exec: "/api/k8s/v1alpha1/exec",
     top: "/api/k8s/v1alpha1/top",
     apply: "/api/k8s/v1alpha1/apply",
     delete: "/api/k8s/v1alpha1/delete",


### PR DESCRIPTION
## Summary
- add a backend WebSocket endpoint that execs into AP workload pods using the user kubeconfig
- add a bottom canvas terminal plane opened from the container console action
- keep terminal out of the right-side resource pane while preserving `apPane=terminal` URL state

## Validation
- `go test ./...` in `apps/api`
- `bun check`
- `bun typecheck`
- `bun test apps/ui/src/store/canvas-store.test.ts`

## Notes
- local `main` was confirmed up to date with `origin/main` before commit/push
- manual browser check confirmed the terminal renders as a bottom plane and does not open the right-side resource pane