### PR TITLE
Add static skill workflow pane

### DIFF
--- a/apps/ui/src/app/project/[uid]/page.tsx
+++ b/apps/ui/src/app/project/[uid]/page.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { DatabaseDeploymentPane } from "@/components/database-deployment-pane";
 import { DockerDeploymentPane } from "@/components/docker-deployment-pane";
 import { GitHubDeploymentPane } from "@/components/github-deployment-pane";
+import { SkillLibraryPane } from "@/components/skill-library-pane";
 import { useProjectCanvas } from "@/hooks/use-project-canvas";
 import { useProjectCanvasLayout } from "@/hooks/use-project-canvas-layout";
 import { useProjectServices } from "@/hooks/use-project-services";
@@ -42,6 +43,7 @@ import { DATABASE_PANE, WORKLOAD_PANE } from "@/store/canvas-store";
 const GITHUB_DEPLOYMENT_PANE_QUERY_KEY = "githubDeployment" as const;
 const DATABASE_DEPLOYMENT_PANE_QUERY_KEY = "databaseDeployment" as const;
 const DOCKER_DEPLOYMENT_PANE_QUERY_KEY = "dockerDeployment" as const;
+const SKILL_LIBRARY_PANE_QUERY_KEY = "skillLibrary" as const;
 
 export default function ProjectUidPage() {
   const params = useParams<{ uid: string }>();
@@ -114,6 +116,10 @@ export default function ProjectUidPage() {
     DOCKER_DEPLOYMENT_PANE_QUERY_KEY,
     parseAsBoolean.withDefault(false)
   );
+  const [skillLibraryPaneOpen, setSkillLibraryPaneOpen] = useQueryState(
+    SKILL_LIBRARY_PANE_QUERY_KEY,
+    parseAsBoolean.withDefault(false)
+  );
   const replaceDeploymentWithResourcePane = useCallback(() => {
     setPreferredCanvasSidePaneEntry("resource");
     Promise.resolve(setGithubDeploymentPaneOpen(false)).catch(() => undefined);
@@ -121,10 +127,12 @@ export default function ProjectUidPage() {
       () => undefined
     );
     Promise.resolve(setDockerDeploymentPaneOpen(false)).catch(() => undefined);
+    Promise.resolve(setSkillLibraryPaneOpen(false)).catch(() => undefined);
   }, [
     setDatabaseDeploymentPaneOpen,
     setDockerDeploymentPaneOpen,
     setGithubDeploymentPaneOpen,
+    setSkillLibraryPaneOpen,
   ]);
 
   const {
@@ -187,6 +195,7 @@ export default function ProjectUidPage() {
           githubDeploymentPaneOpen,
           preferredEntry: preferredCanvasSidePaneEntry,
           resourcePaneOpen: canvasResourcePaneOpen,
+          skillLibraryPaneOpen,
         });
   const closeDatabaseDeploymentPane = useCallback(() => {
     Promise.resolve(setDatabaseDeploymentPaneOpen(false)).catch(
@@ -199,6 +208,9 @@ export default function ProjectUidPage() {
   const closeDockerDeploymentPane = useCallback(() => {
     Promise.resolve(setDockerDeploymentPaneOpen(false)).catch(() => undefined);
   }, [setDockerDeploymentPaneOpen]);
+  const closeSkillLibraryPane = useCallback(() => {
+    Promise.resolve(setSkillLibraryPaneOpen(false)).catch(() => undefined);
+  }, [setSkillLibraryPaneOpen]);
   const openDatabaseDeploymentPane = useCallback(() => {
     requestResourcePaneReplacement(() => {
       setPreferredCanvasSidePaneEntry("databaseDeployment");
@@ -208,6 +220,7 @@ export default function ProjectUidPage() {
       Promise.resolve(setGithubDeploymentPaneOpen(false)).catch(
         () => undefined
       );
+      Promise.resolve(setSkillLibraryPaneOpen(false)).catch(() => undefined);
       Promise.resolve(setDatabaseDeploymentPaneOpen(true)).catch(
         () => undefined
       );
@@ -217,6 +230,7 @@ export default function ProjectUidPage() {
     setDatabaseDeploymentPaneOpen,
     setDockerDeploymentPaneOpen,
     setGithubDeploymentPaneOpen,
+    setSkillLibraryPaneOpen,
   ]);
   const openDockerDeploymentPane = useCallback(() => {
     requestResourcePaneReplacement(() => {
@@ -227,6 +241,7 @@ export default function ProjectUidPage() {
       Promise.resolve(setGithubDeploymentPaneOpen(false)).catch(
         () => undefined
       );
+      Promise.resolve(setSkillLibraryPaneOpen(false)).catch(() => undefined);
       Promise.resolve(setDockerDeploymentPaneOpen(true)).catch(() => undefined);
     });
   }, [
@@ -234,6 +249,7 @@ export default function ProjectUidPage() {
     setDatabaseDeploymentPaneOpen,
     setDockerDeploymentPaneOpen,
     setGithubDeploymentPaneOpen,
+    setSkillLibraryPaneOpen,
   ]);
   const openGithubDeploymentPane = useCallback(() => {
     requestResourcePaneReplacement(() => {
@@ -244,6 +260,7 @@ export default function ProjectUidPage() {
       Promise.resolve(setDockerDeploymentPaneOpen(false)).catch(
         () => undefined
       );
+      Promise.resolve(setSkillLibraryPaneOpen(false)).catch(() => undefined);
       Promise.resolve(setGithubDeploymentPaneOpen(true)).catch(() => undefined);
     });
   }, [
@@ -251,6 +268,28 @@ export default function ProjectUidPage() {
     setDatabaseDeploymentPaneOpen,
     setDockerDeploymentPaneOpen,
     setGithubDeploymentPaneOpen,
+    setSkillLibraryPaneOpen,
+  ]);
+  const openSkillLibraryPane = useCallback(() => {
+    requestResourcePaneReplacement(() => {
+      setPreferredCanvasSidePaneEntry("skillLibrary");
+      Promise.resolve(setDatabaseDeploymentPaneOpen(false)).catch(
+        () => undefined
+      );
+      Promise.resolve(setDockerDeploymentPaneOpen(false)).catch(
+        () => undefined
+      );
+      Promise.resolve(setGithubDeploymentPaneOpen(false)).catch(
+        () => undefined
+      );
+      Promise.resolve(setSkillLibraryPaneOpen(true)).catch(() => undefined);
+    });
+  }, [
+    requestResourcePaneReplacement,
+    setDatabaseDeploymentPaneOpen,
+    setDockerDeploymentPaneOpen,
+    setGithubDeploymentPaneOpen,
+    setSkillLibraryPaneOpen,
   ]);
   const projectCanvasSidePaneSurface = useMemo<ProjectSidePaneSurface>(
     () => ({
@@ -267,6 +306,10 @@ export default function ProjectUidPage() {
           openDockerDeploymentPane();
           return { status: "handled" as const };
         }
+        if (entry?.kind === "skillLibrary") {
+          openSkillLibraryPane();
+          return { status: "handled" as const };
+        }
         if (entry?.kind !== "githubDeployment") {
           return { status: "ignored" as const };
         }
@@ -278,6 +321,7 @@ export default function ProjectUidPage() {
       openDatabaseDeploymentPane,
       openDockerDeploymentPane,
       openGithubDeploymentPane,
+      openSkillLibraryPane,
       uid,
     ]
   );
@@ -374,6 +418,9 @@ export default function ProjectUidPage() {
                       />
                     }
                     resourcePane={canvasResourcePane}
+                    skillLibraryPane={
+                      <SkillLibraryPane onClose={closeSkillLibraryPane} />
+                    }
                   />
                   <CanvasActionSurface
                     action={canvasAction}

--- a/apps/ui/src/app/project/page.tsx
+++ b/apps/ui/src/app/project/page.tsx
@@ -5,9 +5,10 @@ import { SidePanePresence } from "@workspace/ui/components/side-pane";
 import { cn } from "@workspace/ui/lib/utils";
 import { useAtomValue } from "jotai";
 import { useRouter } from "next/navigation";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { ProjectCreationPane } from "@/components/project-creation-pane";
+import { SkillLibraryPane } from "@/components/skill-library-pane";
 import { useProjectCreator } from "@/hooks/use-project-creator";
 import { useProjectsExplorer } from "@/hooks/use-projects-explorer";
 import type { ProjectSidePaneSurface } from "@/lib/project-side-pane/controller";
@@ -49,26 +50,39 @@ export default function ProjectIndexPage() {
     namespace: ns,
     onProjectCreated,
   });
+  const [skillLibraryPaneOpen, setSkillLibraryPaneOpen] = useState(false);
+  const openProjectCreationPane = useCallback(
+    (entryMode?: Parameters<typeof openCreationPane>[0]) => {
+      setSkillLibraryPaneOpen(false);
+      openCreationPane(entryMode);
+    },
+    [openCreationPane]
+  );
 
   const projectListSidePaneSurface = useMemo<ProjectSidePaneSurface>(
     () => ({
       id: "project-list",
       openAssistantIntent: (intent) => {
         const entry = projectListEntryForAssistantIntent(intent);
+        if (entry?.kind === "skillLibrary") {
+          onCreationPaneOpenChange(false);
+          setSkillLibraryPaneOpen(true);
+          return { status: "handled" as const };
+        }
         if (entry?.kind !== "projectCreation") {
           return { status: "ignored" as const };
         }
-        openCreationPane(entry.entryMode);
+        openProjectCreationPane(entry.entryMode);
         return { status: "handled" as const };
       },
     }),
-    [openCreationPane]
+    [onCreationPaneOpenChange, openProjectCreationPane]
   );
   useProjectSidePaneSurface(projectListSidePaneSurface);
 
   const explorerActions = useMemo(
-    () => ({ ...actions, onNewProject: openCreationPane }),
-    [actions, openCreationPane]
+    () => ({ ...actions, onNewProject: openProjectCreationPane }),
+    [actions, openProjectCreationPane]
   );
 
   return (
@@ -100,7 +114,7 @@ export default function ProjectIndexPage() {
       <div
         className={cn(
           "relative flex min-h-0 flex-1 flex-col items-center gap-4 px-[52px] pt-[52px] pb-6 transition-[padding] duration-200 ease-out motion-reduce:transition-none",
-          creationPaneOpen && "xl:pr-[40rem]"
+          (creationPaneOpen || skillLibraryPaneOpen) && "xl:pr-[40rem]"
         )}
       >
         <ProjectExplorer.Root actions={explorerActions} states={states}>
@@ -120,6 +134,11 @@ export default function ProjectIndexPage() {
             onClose={() => onCreationPaneOpenChange(false)}
             resetKey={creatorResetKey}
           />
+        ) : null}
+      </SidePanePresence>
+      <SidePanePresence>
+        {skillLibraryPaneOpen ? (
+          <SkillLibraryPane onClose={() => setSkillLibraryPaneOpen(false)} />
         ) : null}
       </SidePanePresence>
     </div>

--- a/apps/ui/src/components/project-workspace-layout.tsx
+++ b/apps/ui/src/components/project-workspace-layout.tsx
@@ -229,6 +229,7 @@ function ProjectAssistantChatSession({
   onDockerIntent,
   onCreateThread,
   onGithubIntent,
+  onSkillIntent,
   onSelectThread,
 }: {
   bootstrap: Pick<AssistantSessionPayload, "chatId" | "messages">;
@@ -240,6 +241,7 @@ function ProjectAssistantChatSession({
   onDockerIntent: () => void;
   onCreateThread: () => Promise<void>;
   onGithubIntent: () => void;
+  onSkillIntent: () => void;
   onSelectThread: (threadId: string) => Promise<void>;
 }) {
   const router = useRouter();
@@ -598,6 +600,7 @@ function ProjectAssistantChatSession({
                   <Chat.DatabaseDeployButton
                     onComposerAction={onDatabaseIntent}
                   />
+                  <Chat.SkillLibraryButton onComposerAction={onSkillIntent} />
                 </div>
                 <Chat.ComposerSend
                   onPrimaryAction={onPrimaryAction}
@@ -700,6 +703,11 @@ function ProjectAssistantChatPane() {
       .openAssistantIntent({ type: "docker" })
       .catch(() => undefined);
   }, [sidePaneController]);
+  const openSkillIntent = useCallback(() => {
+    sidePaneController
+      .openAssistantIntent({ type: "skill" })
+      .catch(() => undefined);
+  }, [sidePaneController]);
 
   if (sessionError) {
     return (
@@ -735,6 +743,7 @@ function ProjectAssistantChatPane() {
       onDockerIntent={openDockerIntent}
       onGithubIntent={openGithubIntent}
       onSelectThread={selectThread}
+      onSkillIntent={openSkillIntent}
       threads={session.threads}
     />
   );

--- a/apps/ui/src/components/skill-library-pane.test.tsx
+++ b/apps/ui/src/components/skill-library-pane.test.tsx
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { SkillLibraryPane } from "./skill-library-pane";
+
+const noop = () => {
+  /* test noop */
+};
+
+const INSTALL_COMMAND_RE = /npx skills add labring\/seakills/;
+const OLD_AVAILABLE_SKILL_RE = /Available skill/;
+const OLD_DETAILS_RE = /Details/;
+const PANE_LABEL_RE = /aria-label="Skill library pane"/;
+const SEVEN_STEPS_RE = /7 steps/;
+const STEP_1_RE = /1\. Install Skills and Docker Locally/;
+const STEP_6_RE = /6\. Push the Docker Image and Apply Runtime Manifests/;
+const STEP_7_RE = /7\. Automatically Deploy and Generate an Accessible Domain/;
+const COPY_INSTALL_COMMAND_RE = /aria-label="Copy install command"/;
+const TITLE_RE = /Sealos Skills Workflow/;
+
+test("skill library pane renders the static Sealos Skills workflow", () => {
+  const html = renderToStaticMarkup(<SkillLibraryPane onClose={noop} />);
+
+  assert.match(html, PANE_LABEL_RE);
+  assert.match(html, TITLE_RE);
+  assert.match(html, SEVEN_STEPS_RE);
+  assert.match(html, INSTALL_COMMAND_RE);
+  assert.match(html, COPY_INSTALL_COMMAND_RE);
+  assert.match(html, STEP_1_RE);
+  assert.match(html, STEP_6_RE);
+  assert.match(html, STEP_7_RE);
+  assert.doesNotMatch(html, OLD_AVAILABLE_SKILL_RE);
+  assert.doesNotMatch(html, OLD_DETAILS_RE);
+});

--- a/apps/ui/src/components/skill-library-pane.tsx
+++ b/apps/ui/src/components/skill-library-pane.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { Button } from "@workspace/ui/components/button";
+import { SidePane } from "@workspace/ui/components/side-pane";
+import { cn } from "@workspace/ui/lib/utils";
+import { Copy, Wrench } from "lucide-react";
+import type { ReactNode } from "react";
+import { useCallback } from "react";
+import { toast } from "sonner";
+
+const INSTALL_COMMAND = "npx skills add labring/seakills";
+
+const WORKFLOW_STEPS = [
+  {
+    description:
+      "Run the installation command to prepare the Sealos Skills runtime environment.",
+    title: "Install Skills and Docker Locally",
+  },
+  {
+    description:
+      "Trigger the automated deployment workflow directly inside the current project.",
+    title: 'Run the "Deploy on Sealos" Skills Command',
+  },
+  {
+    description:
+      "Follow the instructions to bind and authenticate your local machine with your Sealos account.",
+    title: "Complete Device Authentication",
+  },
+  {
+    description:
+      "Automatically detect the tech stack, entry command, and dependencies, then generate a buildable Dockerfile.",
+    title: "Automatically Analyze the Project and Generate a Dockerfile",
+  },
+  {
+    description:
+      "Build the container image based on the generated configuration and prepare it for release.",
+    title: "Automatically Build the Docker Image",
+  },
+  {
+    description:
+      "Publish the image and apply the generated Sealos runtime manifests to the target project.",
+    title: "Push the Docker Image and Apply Runtime Manifests",
+  },
+  {
+    description:
+      "After deployment is complete, an accessible domain will be returned automatically.",
+    title: "Automatically Deploy and Generate an Accessible Domain",
+  },
+];
+
+async function copyInstallCommand() {
+  if (typeof navigator === "undefined" || !navigator.clipboard) {
+    toast.error("Could not copy install command.");
+    return;
+  }
+
+  try {
+    await navigator.clipboard.writeText(INSTALL_COMMAND);
+    toast.success("Install command copied.");
+  } catch {
+    toast.error("Could not copy install command.");
+  }
+}
+
+function WorkflowSection({
+  children,
+  className,
+  title,
+}: {
+  children: ReactNode;
+  className?: string;
+  title: string;
+}) {
+  return (
+    <section className={cn("flex min-w-0 flex-col gap-2.5", className)}>
+      <h3 className="font-medium text-resource-pane-foreground text-sm leading-5">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+export function SkillLibraryPane({ onClose }: { onClose: () => void }) {
+  const copyCommand = useCallback(() => {
+    copyInstallCommand().catch(() => undefined);
+  }, []);
+
+  return (
+    <SidePane
+      closeAriaLabel="Close skill library pane"
+      icon={<Wrench aria-hidden className="size-4 text-theme-blue" />}
+      label="Skill library pane"
+      onClose={onClose}
+      subtitle="From local installation to automatic deployment, the entire process consists of 7 steps."
+      title="Sealos Skills Workflow"
+    >
+      <div className="flex min-w-0 flex-col gap-5" data-slot="skill-library">
+        <WorkflowSection title="INSTALL">
+          <p className="text-resource-pane-muted text-sm leading-5">
+            Install Sealos Skills locally first.
+          </p>
+          <div
+            className="flex min-w-0 items-center gap-3 rounded-md bg-resource-pane-input px-3 py-2.5"
+            data-slot="skill-install-command"
+          >
+            <code className="min-w-0 flex-1 truncate font-mono text-resource-pane-muted text-sm leading-5">
+              {INSTALL_COMMAND}
+            </code>
+            <Button
+              aria-label="Copy install command"
+              className="hoverable size-7 shrink-0 text-resource-pane-muted hover:text-resource-pane-foreground"
+              onClick={copyCommand}
+              size="icon"
+              title="Copy install command"
+              type="button"
+              variant="ghost"
+            >
+              <Copy aria-hidden className="size-4" />
+            </Button>
+          </div>
+        </WorkflowSection>
+
+        <WorkflowSection title="Flow">
+          <p className="text-resource-pane-muted text-sm leading-5">
+            The entire deployment process will be completed automatically in the
+            following order.
+          </p>
+          <ol className="mt-2 flex min-w-0 flex-col gap-5">
+            {WORKFLOW_STEPS.map((step, index) => (
+              <li className="flex min-w-0 flex-col gap-1.5" key={step.title}>
+                <h4 className="font-medium text-resource-pane-foreground text-sm leading-5">
+                  {index + 1}. {step.title}
+                </h4>
+                <p className="text-resource-pane-muted text-sm leading-5">
+                  {step.description}
+                </p>
+              </li>
+            ))}
+          </ol>
+        </WorkflowSection>
+      </div>
+    </SidePane>
+  );
+}

--- a/apps/ui/src/lib/project-canvas/panels/project-canvas-side-pane-slot.test.ts
+++ b/apps/ui/src/lib/project-canvas/panels/project-canvas-side-pane-slot.test.ts
@@ -12,6 +12,7 @@ const GITHUB_DEPLOYMENT_RE = /GitHub deployment/;
 const DATABASE_DEPLOYMENT_RE = /Database deployment/;
 const DOCKER_DEPLOYMENT_RE = /Docker deployment/;
 const RESOURCE_SETTINGS_RE = /Resource settings/;
+const SKILL_LIBRARY_RE = /Skill library/;
 
 test("github deployment stays active while resource selection is being cleared", () => {
   assert.deepEqual(
@@ -45,6 +46,18 @@ test("docker deployment stays active while resource selection is being cleared",
       resourcePaneOpen: true,
     }),
     { kind: "dockerDeployment" }
+  );
+});
+
+test("skill library stays active while resource selection is being cleared", () => {
+  assert.deepEqual(
+    resolveProjectCanvasSidePaneEntry({
+      githubDeploymentPaneOpen: false,
+      preferredEntry: "skillLibrary",
+      resourcePaneOpen: true,
+      skillLibraryPaneOpen: true,
+    }),
+    { kind: "skillLibrary" }
   );
 });
 
@@ -96,6 +109,7 @@ test("canvas side pane slot renders the replacement pane while both candidates e
       dockerDeploymentPane: createElement("aside", null, "Docker deployment"),
       githubDeploymentPane: createElement("aside", null, "GitHub deployment"),
       resourcePane: createElement("aside", null, "Resource settings"),
+      skillLibraryPane: createElement("aside", null, "Skill library"),
     })
   );
 
@@ -103,4 +117,5 @@ test("canvas side pane slot renders the replacement pane while both candidates e
   assert.doesNotMatch(html, DATABASE_DEPLOYMENT_RE);
   assert.doesNotMatch(html, DOCKER_DEPLOYMENT_RE);
   assert.doesNotMatch(html, RESOURCE_SETTINGS_RE);
+  assert.doesNotMatch(html, SKILL_LIBRARY_RE);
 });

--- a/apps/ui/src/lib/project-canvas/panels/project-canvas-side-pane-slot.tsx
+++ b/apps/ui/src/lib/project-canvas/panels/project-canvas-side-pane-slot.tsx
@@ -8,6 +8,7 @@ export type ProjectCanvasSidePaneEntry =
   | { kind: "dockerDeployment" }
   | { kind: "githubDeployment" }
   | { kind: "resource" }
+  | { kind: "skillLibrary" }
   | null;
 
 export type ProjectCanvasSidePanePreferredEntry = Exclude<
@@ -21,12 +22,14 @@ export function resolveProjectCanvasSidePaneEntry({
   githubDeploymentPaneOpen,
   preferredEntry,
   resourcePaneOpen,
+  skillLibraryPaneOpen,
 }: {
   databaseDeploymentPaneOpen?: boolean;
   dockerDeploymentPaneOpen?: boolean;
   githubDeploymentPaneOpen: boolean;
   preferredEntry?: ProjectCanvasSidePanePreferredEntry | null;
   resourcePaneOpen: boolean;
+  skillLibraryPaneOpen?: boolean;
 }): ProjectCanvasSidePaneEntry {
   if (preferredEntry === "databaseDeployment" && databaseDeploymentPaneOpen) {
     return { kind: "databaseDeployment" };
@@ -38,6 +41,10 @@ export function resolveProjectCanvasSidePaneEntry({
 
   if (preferredEntry === "githubDeployment" && githubDeploymentPaneOpen) {
     return { kind: "githubDeployment" };
+  }
+
+  if (preferredEntry === "skillLibrary" && skillLibraryPaneOpen) {
+    return { kind: "skillLibrary" };
   }
 
   if (preferredEntry === "resource" && resourcePaneOpen) {
@@ -56,6 +63,10 @@ export function resolveProjectCanvasSidePaneEntry({
     return { kind: "dockerDeployment" };
   }
 
+  if (skillLibraryPaneOpen) {
+    return { kind: "skillLibrary" };
+  }
+
   if (resourcePaneOpen) {
     return { kind: "resource" };
   }
@@ -69,12 +80,14 @@ export function ProjectCanvasSidePaneSlot({
   entry,
   githubDeploymentPane,
   resourcePane,
+  skillLibraryPane,
 }: {
   databaseDeploymentPane?: ReactNode;
   dockerDeploymentPane?: ReactNode;
   entry: ProjectCanvasSidePaneEntry;
   githubDeploymentPane: ReactNode;
   resourcePane: ReactNode;
+  skillLibraryPane?: ReactNode;
 }) {
   let pane: ReactNode = null;
 
@@ -84,6 +97,8 @@ export function ProjectCanvasSidePaneSlot({
     pane = dockerDeploymentPane;
   } else if (entry?.kind === "githubDeployment") {
     pane = githubDeploymentPane;
+  } else if (entry?.kind === "skillLibrary") {
+    pane = skillLibraryPane;
   } else if (entry?.kind === "resource") {
     pane = resourcePane;
   }

--- a/apps/ui/src/lib/project-side-pane/controller.ts
+++ b/apps/ui/src/lib/project-side-pane/controller.ts
@@ -1,5 +1,5 @@
 export interface ProjectSidePaneAssistantIntent {
-  type: "database" | "docker" | "github";
+  type: "database" | "docker" | "github" | "skill";
 }
 
 export type ProjectSidePaneIntentResult =

--- a/apps/ui/src/lib/project-side-pane/surface-intents.test.ts
+++ b/apps/ui/src/lib/project-side-pane/surface-intents.test.ts
@@ -30,6 +30,13 @@ test("Project List translates assistant Docker intent to Docker direct project c
   });
 });
 
+test("Project List translates assistant Skill intent to the Skill library", () => {
+  assert.deepEqual(projectListEntryForAssistantIntent({ type: "skill" }), {
+    kind: "skillLibrary",
+    placement: "reserved",
+  });
+});
+
 test("Project Canvas translates assistant GitHub intent to deployment in the current Project", () => {
   assert.deepEqual(
     projectCanvasEntryForAssistantIntent(
@@ -66,6 +73,20 @@ test("Project Canvas translates assistant Docker intent to deployment in the cur
     ),
     {
       kind: "dockerDeployment",
+      placement: "overlay",
+      projectUid: "project-1",
+    }
+  );
+});
+
+test("Project Canvas translates assistant Skill intent to the Skill library", () => {
+  assert.deepEqual(
+    projectCanvasEntryForAssistantIntent(
+      { type: "skill" },
+      { projectUid: "project-1" }
+    ),
+    {
+      kind: "skillLibrary",
       placement: "overlay",
       projectUid: "project-1",
     }

--- a/apps/ui/src/lib/project-side-pane/surface-intents.ts
+++ b/apps/ui/src/lib/project-side-pane/surface-intents.ts
@@ -10,6 +10,10 @@ export type ProjectSidePaneEntry =
       placement: "reserved";
     }
   | {
+      kind: "skillLibrary";
+      placement: "reserved";
+    }
+  | {
       kind: "databaseDeployment";
       placement: "overlay";
       projectUid: string;
@@ -23,11 +27,22 @@ export type ProjectSidePaneEntry =
       kind: "githubDeployment";
       placement: "overlay";
       projectUid: string;
+    }
+  | {
+      kind: "skillLibrary";
+      placement: "overlay";
+      projectUid: string;
     };
 
 export function projectListEntryForAssistantIntent(
   intent: ProjectSidePaneAssistantIntent
 ): ProjectSidePaneEntry | null {
+  if (intent.type === "skill") {
+    return {
+      kind: "skillLibrary",
+      placement: "reserved",
+    };
+  }
   if (intent.type === "github") {
     return {
       entryMode: "githubDirect",
@@ -59,6 +74,13 @@ export function projectCanvasEntryForAssistantIntent(
   const uid = projectUid.trim();
   if (uid === "") {
     return null;
+  }
+  if (intent.type === "skill") {
+    return {
+      kind: "skillLibrary",
+      placement: "overlay",
+      projectUid: uid,
+    };
   }
   if (intent.type === "database") {
     return {

--- a/packages/ui/src/components/chat/chat.input.test.tsx
+++ b/packages/ui/src/components/chat/chat.input.test.tsx
@@ -6,28 +6,35 @@ import {
   ChatDatabaseDeployButton,
   ChatDockerDeployButton,
   ChatGithubDeployButton,
+  ChatSkillLibraryButton,
 } from "./chat.input";
 
 const noop = () => undefined;
 const DOCKER_DEPLOY_ARIA_LABEL_RE = /aria-label="Docker deploy"/;
+const SKILL_LIBRARY_ARIA_LABEL_RE = /aria-label="Skill library"/;
 
-test("chat composer deploy actions include GitHub, Docker, and Database controls in order", () => {
+test("chat composer actions include GitHub, Docker, Database, and Skill controls in order", () => {
   const html = renderToStaticMarkup(
     <div>
       <ChatGithubDeployButton onComposerAction={noop} />
       <ChatDockerDeployButton onComposerAction={noop} />
       <ChatDatabaseDeployButton onComposerAction={noop} />
+      <ChatSkillLibraryButton onComposerAction={noop} />
     </div>
   );
 
   const github = html.indexOf('data-slot="chat-github-deploy-button"');
   const docker = html.indexOf('data-slot="chat-docker-deploy-button"');
   const database = html.indexOf('data-slot="chat-database-deploy-button"');
+  const skill = html.indexOf('data-slot="chat-skill-library-button"');
 
   assert.ok(github !== -1, "GitHub action is visible");
   assert.ok(docker !== -1, "Docker action is visible");
   assert.ok(database !== -1, "Database action is visible");
+  assert.ok(skill !== -1, "Skill action is visible");
   assert.ok(github < docker, "GitHub appears before Docker");
   assert.ok(docker < database, "Docker appears before Database");
+  assert.ok(database < skill, "Database appears before Skill");
   assert.match(html, DOCKER_DEPLOY_ARIA_LABEL_RE);
+  assert.match(html, SKILL_LIBRARY_ARIA_LABEL_RE);
 });

--- a/packages/ui/src/components/chat/chat.input.tsx
+++ b/packages/ui/src/components/chat/chat.input.tsx
@@ -11,7 +11,7 @@ import {
 } from "@workspace/ui/components/popover";
 import { Textarea } from "@workspace/ui/components/textarea";
 import { cn } from "@workspace/ui/lib/utils";
-import { Database, Square } from "lucide-react";
+import { Blocks, Database, Square } from "lucide-react";
 import { type ComponentProps, useEffect, useLayoutEffect, useRef } from "react";
 
 import { ProjectSourceDockerIcon } from "../../assets/project-source-icons";
@@ -40,6 +40,13 @@ export type ChatDatabaseDeployButtonProps = Omit<
 };
 
 export type ChatDockerDeployButtonProps = Omit<
+  ComponentProps<typeof Button>,
+  "children" | "onClick" | "size" | "type" | "variant"
+> & {
+  onComposerAction?: () => void;
+};
+
+export type ChatSkillLibraryButtonProps = Omit<
   ComponentProps<typeof Button>,
   "children" | "onClick" | "size" | "type" | "variant"
 > & {
@@ -408,6 +415,34 @@ export function ChatDockerDeployButton({
   );
 }
 
+/** Icon-only control for the static Skill library; omitted `onComposerAction` renders nothing. */
+export function ChatSkillLibraryButton({
+  className,
+  "aria-label": ariaLabel = "Skill library",
+  onComposerAction,
+  ...props
+}: ChatSkillLibraryButtonProps) {
+  if (!onComposerAction) {
+    return null;
+  }
+
+  return (
+    <Button
+      aria-label={ariaLabel}
+      className={cn("hoverable shrink-0 cursor-pointer rounded-xl", className)}
+      data-slot="chat-skill-library-button"
+      onClick={onComposerAction}
+      size="icon-lg"
+      title="Skill library"
+      type="button"
+      variant="ghost"
+      {...props}
+    >
+      <Blocks aria-hidden className="size-4 text-foreground opacity-90" />
+    </Button>
+  );
+}
+
 export interface ChatComposerSendProps {
   className?: string;
   onPrimaryAction: () => void;
@@ -487,6 +522,7 @@ export function ChatComposer({
             <ChatGithubDeployButton onComposerAction={onComposerAction} />
             <ChatDockerDeployButton onComposerAction={onComposerAction} />
             <ChatDatabaseDeployButton onComposerAction={onComposerAction} />
+            <ChatSkillLibraryButton onComposerAction={onComposerAction} />
           </div>
           <ChatComposerSend
             onPrimaryAction={onPrimaryAction}
@@ -510,4 +546,5 @@ ChatGithubDeployPopover.displayName = "Chat.GithubDeployPopover";
 ChatDatabaseDeployButton.displayName = "Chat.DatabaseDeployButton";
 ChatDockerDeployButton.displayName = "Chat.DockerDeployButton";
 ChatGithubDeployButton.displayName = "Chat.GithubDeployButton";
+ChatSkillLibraryButton.displayName = "Chat.SkillLibraryButton";
 ChatComposer.displayName = "Chat.Composer";

--- a/packages/ui/src/components/chat/chat.tsx
+++ b/packages/ui/src/components/chat/chat.tsx
@@ -24,6 +24,7 @@ import {
   ChatGithubDeployButton,
   ChatGithubDeployPopover,
   ChatGithubMark,
+  ChatSkillLibraryButton,
 } from "./chat.input";
 import { ChatTranscript } from "./chat.transcript";
 
@@ -47,6 +48,7 @@ export type {
   ChatDockerDeployButtonProps,
   ChatGithubDeployButtonProps,
   ChatGithubDeployPopoverProps,
+  ChatSkillLibraryButtonProps,
 } from "./chat.input";
 export {
   ChatComposerContextIndicator,
@@ -56,6 +58,7 @@ export {
   ChatGithubDeployButton,
   ChatGithubDeployPopover,
   ChatGithubMark,
+  ChatSkillLibraryButton,
   GITHUB_MARK_PATH,
 } from "./chat.input";
 export type {
@@ -102,6 +105,7 @@ export const Chat = Object.assign(ChatShell, {
   NewThread: ChatHeaderNewThread,
   Root: ChatRoot,
   Setting: ChatHeaderSetting,
+  SkillLibraryButton: ChatSkillLibraryButton,
   ThreadSelect: ChatThreadSelect,
   Transcript: ChatTranscript,
 });


### PR DESCRIPTION
## Summary
- add a Skill action beside the existing GitHub, Docker, and Database chat actions
- wire the Skill intent into the project list and project canvas side pane flow
- replace the static Skill pane content with the Sealos Skills workflow layout from the design

## Test Plan
- bun typecheck
- bun test apps/ui/src/components/skill-library-pane.test.tsx packages/ui/src/components/chat/chat.input.test.tsx apps/ui/src/lib/project-canvas/panels/project-canvas-side-pane-slot.test.ts apps/ui/src/lib/project-side-pane/surface-intents.test.ts
- bunx ultracite check packages/ui/src/components/chat/chat.input.tsx packages/ui/src/components/chat/chat.tsx packages/ui/src/components/chat/chat.input.test.tsx apps/ui/src/components/skill-library-pane.tsx apps/ui/src/components/skill-library-pane.test.tsx apps/ui/src/components/project-workspace-layout.tsx apps/ui/src/app/project/page.tsx 'apps/ui/src/app/project/[uid]/page.tsx' apps/ui/src/lib/project-side-pane/controller.ts apps/ui/src/lib/project-side-pane/surface-intents.ts apps/ui/src/lib/project-side-pane/surface-intents.test.ts apps/ui/src/lib/project-canvas/panels/project-canvas-side-pane-slot.tsx apps/ui/src/lib/project-canvas/panels/project-canvas-side-pane-slot.test.ts