### PR TITLE
feat(ui): add Sealos Skills workflow side pane

### DIFF
--- a/apps/ui/src/app/project/page.tsx
+++ b/apps/ui/src/app/project/page.tsx
@@ -5,10 +5,11 @@ import { SidePanePresence } from "@workspace/ui/components/side-pane";
 import { cn } from "@workspace/ui/lib/utils";
 import { useAtomValue } from "jotai";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo } from "react";
 
 import { ProjectCreationPane } from "@/components/project-creation-pane";
 import type { ProjectCreationPaneEntryMode } from "@/components/project-creation-pane-state";
+import { SealosSkillsWorkflowPane } from "@/components/sealos-skills-workflow-pane";
 import { useProjectSideRouteState } from "@/features/project-route-state/use-project-side-route-state";
 import type { ProjectSidePaneAssistantSurface } from "@/features/project-surfaces/assistant-router";
 import { useProjectSidePaneSurface } from "@/features/project-surfaces/react";
@@ -32,7 +33,8 @@ export default function ProjectIndexPage() {
     openSide: openProjectSideRoute,
     side: projectSideRouteEntry,
   } = useProjectSideRouteState({
-    isSideEntrySupported: (entry) => entry.kind === "projectCreation",
+    isSideEntrySupported: (entry) =>
+      entry.kind === "projectCreation" || entry.kind === "skillsWorkflow",
   });
   const creationSideEntry =
     projectSideRouteEntry?.kind === "projectCreation"
@@ -87,7 +89,7 @@ export default function ProjectIndexPage() {
       id: "project-list",
       openAssistantIntent: (intent) => {
         const entry = projectListEntryForAssistantIntent(intent);
-        if (entry?.kind !== "projectCreation") {
+        if (entry == null) {
           return { status: "ignored" as const };
         }
         openProjectSideRoute(entry);
@@ -103,6 +105,36 @@ export default function ProjectIndexPage() {
     [actions, openProjectCreationPane]
   );
   const creationPaneOpen = creationSideEntry != null;
+  const skillsPaneOpen = projectSideRouteEntry?.kind === "skillsWorkflow";
+  const sidePaneOpen = creationPaneOpen || skillsPaneOpen;
+
+  const sidePaneContent = useMemo((): ReactNode => {
+    if (creationPaneOpen) {
+      return (
+        <ProjectCreationPane
+          busy={githubDeployerLoading}
+          creatorRootProps={creatorRootProps}
+          entryMode={creationPaneEntryMode}
+          onClose={() => closeProjectSideRoute()}
+          resetKey={creatorResetKey}
+        />
+      );
+    }
+    if (skillsPaneOpen) {
+      return (
+        <SealosSkillsWorkflowPane onClose={() => closeProjectSideRoute()} />
+      );
+    }
+    return null;
+  }, [
+    closeProjectSideRoute,
+    creationPaneEntryMode,
+    creationPaneOpen,
+    creatorResetKey,
+    creatorRootProps,
+    githubDeployerLoading,
+    skillsPaneOpen,
+  ]);
 
   return (
     <div className="relative flex min-h-0 min-w-0 flex-1 flex-col bg-background">
@@ -152,22 +184,12 @@ export default function ProjectIndexPage() {
             styles.sidePaneReserve,
             "min-h-0 shrink-0 transition-[width,max-width] duration-200 ease-out motion-reduce:transition-none"
           )}
-          data-open={creationPaneOpen}
+          data-open={sidePaneOpen}
           data-slot="project-index-side-pane-reserve"
         />
       </div>
 
-      <SidePanePresence>
-        {creationPaneOpen ? (
-          <ProjectCreationPane
-            busy={githubDeployerLoading}
-            creatorRootProps={creatorRootProps}
-            entryMode={creationPaneEntryMode}
-            onClose={() => closeProjectSideRoute()}
-            resetKey={creatorResetKey}
-          />
-        ) : null}
-      </SidePanePresence>
+      <SidePanePresence>{sidePaneContent}</SidePanePresence>
     </div>
   );
 }

--- a/apps/ui/src/components/project-workspace-layout.tsx
+++ b/apps/ui/src/components/project-workspace-layout.tsx
@@ -259,6 +259,7 @@ function ProjectAssistantChatSession({
   onCreateThread,
   onGithubIntent,
   onSelectThread,
+  onSkillsIntent,
 }: {
   bootstrap: Pick<AssistantSessionPayload, "chatId" | "messages">;
   creatingThread: boolean;
@@ -270,6 +271,7 @@ function ProjectAssistantChatSession({
   onCreateThread: () => Promise<void>;
   onGithubIntent: () => void;
   onSelectThread: (threadId: string) => Promise<void>;
+  onSkillsIntent: () => void;
 }) {
   const router = useRouter();
   const projectSurfaceRouter = useProjectSidePaneAssistantRouter();
@@ -658,6 +660,9 @@ function ProjectAssistantChatSession({
                   <Chat.DatabaseDeployButton
                     onComposerAction={onDatabaseIntent}
                   />
+                  <Chat.SkillsWorkflowButton
+                    onComposerAction={onSkillsIntent}
+                  />
                 </div>
                 <Chat.ComposerSend
                   onPrimaryAction={onPrimaryAction}
@@ -760,6 +765,11 @@ function ProjectAssistantChatPane() {
       .openAssistantIntent({ type: "docker" })
       .catch(() => undefined);
   }, [sidePaneRouter]);
+  const openSkillsIntent = useCallback(() => {
+    sidePaneRouter
+      .openAssistantIntent({ type: "skills" })
+      .catch(() => undefined);
+  }, [sidePaneRouter]);
 
   if (sessionError) {
     return (
@@ -795,6 +805,7 @@ function ProjectAssistantChatPane() {
       onDockerIntent={openDockerIntent}
       onGithubIntent={openGithubIntent}
       onSelectThread={selectThread}
+      onSkillsIntent={openSkillsIntent}
       threads={session.threads}
     />
   );

--- a/apps/ui/src/components/sealos-skills-workflow-content.tsx
+++ b/apps/ui/src/components/sealos-skills-workflow-content.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { AppIconButton } from "@workspace/ui/components/app-icon-button";
+import { cn } from "@workspace/ui/lib/utils";
+import { Check, Copy } from "lucide-react";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+
+export const SEALOS_SKILLS_INSTALL_COMMAND = "npx skills add labring/seakills";
+
+export const SEALOS_SKILLS_FLOW_STEPS = [
+  {
+    description:
+      "Run the installation command to prepare the Sealos Skills runtime environment.",
+    title: "1. Install Skills and Docker Locally",
+  },
+  {
+    description:
+      "Trigger the automated deployment workflow directly inside the current project.",
+    title: '2. Run the "Deploy on Sealos" Skills Command',
+  },
+  {
+    description:
+      "Follow the instructions to bind and authenticate your local machine with your Sealos account.",
+    title: "3. Complete Device Authentication",
+  },
+  {
+    description:
+      "Automatically detect the tech stack, entry command, and dependencies, then generate a buildable Dockerfile.",
+    title: "4. Automatically Analyze the Project and Generate a Dockerfile",
+  },
+  {
+    description:
+      "Build the container image based on the generated configuration and prepare it for release.",
+    title: "5. Automatically Build the Docker Image",
+  },
+  {
+    description:
+      "After deployment is complete, an accessible domain will be returned automatically.",
+    title: "7. Automatically Deploy and Generate an Accessible Domain",
+  },
+] as const;
+
+function SealosSkillsInstallCommandRow({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copyCommand = useCallback(async () => {
+    if (typeof navigator === "undefined" || !navigator.clipboard) {
+      toast.error("Clipboard is not available.");
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      toast.success("Copied install command.");
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      toast.error("Could not copy install command.");
+    }
+  }, [command]);
+
+  return (
+    <div
+      className="flex h-10 items-center gap-1 overflow-hidden rounded-md bg-input/30 px-3 py-2"
+      data-slot="sealos-skills-install-command"
+    >
+      <p className="min-w-0 flex-1 truncate font-normal text-muted-foreground text-sm leading-5">
+        {command}
+      </p>
+      <AppIconButton
+        aria-label={copied ? "Copied install command" : "Copy install command"}
+        className="shrink-0"
+        onClick={() => {
+          copyCommand().catch(() => undefined);
+        }}
+        size="sm"
+        type="button"
+        variant="quiet"
+      >
+        {copied ? (
+          <Check aria-hidden className="size-4 text-foreground" />
+        ) : (
+          <Copy aria-hidden className="size-4 text-foreground" />
+        )}
+      </AppIconButton>
+    </div>
+  );
+}
+
+function SealosSkillsSectionHeader({
+  className,
+  description,
+  title,
+  titleClassName,
+}: {
+  className?: string;
+  description: string;
+  title: string;
+  titleClassName?: string;
+}) {
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      <p
+        className={cn(
+          "font-medium text-primary text-sm leading-5",
+          titleClassName
+        )}
+      >
+        {title}
+      </p>
+      <p className="font-normal text-muted-foreground text-sm leading-5">
+        {description}
+      </p>
+    </div>
+  );
+}
+
+function SealosSkillsFlowStepCard({
+  description,
+  title,
+}: {
+  description: string;
+  title: string;
+}) {
+  return (
+    <div className="flex flex-col gap-2.5 rounded-md p-2.5 shadow-sm">
+      <SealosSkillsSectionHeader description={description} title={title} />
+    </div>
+  );
+}
+
+export function SealosSkillsWorkflowContent({
+  className,
+  installCommand = SEALOS_SKILLS_INSTALL_COMMAND,
+}: {
+  className?: string;
+  installCommand?: string;
+}) {
+  return (
+    <div
+      className={cn("flex min-w-0 flex-col gap-5", className)}
+      data-slot="sealos-skills-workflow-content"
+    >
+      <section className="flex flex-col gap-2">
+        <SealosSkillsSectionHeader
+          description="Install Sealos Skills locally first."
+          title="INSTALL"
+          titleClassName="uppercase tracking-normal"
+        />
+        <SealosSkillsInstallCommandRow command={installCommand} />
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <SealosSkillsSectionHeader
+          description="The entire deployment process will be completed automatically in the following order."
+          title="Flow"
+        />
+        <div className="flex flex-col gap-2">
+          {SEALOS_SKILLS_FLOW_STEPS.map((step) => (
+            <SealosSkillsFlowStepCard
+              description={step.description}
+              key={step.title}
+              title={step.title}
+            />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/ui/src/components/sealos-skills-workflow-pane.tsx
+++ b/apps/ui/src/components/sealos-skills-workflow-pane.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { SidePane } from "@workspace/ui/components/side-pane";
+import { Wrench } from "lucide-react";
+
+import { SealosSkillsWorkflowContent } from "./sealos-skills-workflow-content";
+
+export function SealosSkillsWorkflowPane({ onClose }: { onClose: () => void }) {
+  return (
+    <SidePane
+      bodyClassName="gap-5 pt-0"
+      closeAriaLabel="Close Sealos Skills workflow pane"
+      icon={<Wrench aria-hidden className="size-4 text-blue-400" />}
+      label="Sealos Skills workflow pane"
+      onClose={onClose}
+      subtitle="From local installation to automatic deployment, the entire process consists of 7 steps."
+      title="Sealos Skills Workflow"
+    >
+      <SealosSkillsWorkflowContent />
+    </SidePane>
+  );
+}

--- a/apps/ui/src/features/project-canvas/panels/project-canvas-side-pane-slot.test.ts
+++ b/apps/ui/src/features/project-canvas/panels/project-canvas-side-pane-slot.test.ts
@@ -10,6 +10,7 @@ const DATABASE_DEPLOYMENT_RE = /Database deployment/;
 const DOCKER_DEPLOYMENT_RE = /Docker deployment/;
 const PROJECT_CREATION_RE = /Project creation/;
 const RESOURCE_SETTINGS_RE = /Resource settings/;
+const SKILLS_WORKFLOW_RE = /Skills workflow/;
 
 function renderSlot(
   entry: Parameters<typeof ProjectCanvasSidePaneSlot>[0]["entry"]
@@ -26,6 +27,7 @@ function renderSlot(
       githubDeploymentPane: createElement("aside", null, "GitHub deployment"),
       projectCreationPane: createElement("aside", null, "Project creation"),
       resourcePane: createElement("aside", null, "Resource settings"),
+      skillsWorkflowPane: createElement("aside", null, "Skills workflow"),
     })
   );
 }
@@ -51,6 +53,13 @@ test("canvas side pane slot can render Project creation entries", () => {
 
   assert.match(html, PROJECT_CREATION_RE);
   assert.doesNotMatch(html, RESOURCE_SETTINGS_RE);
+});
+
+test("canvas side pane slot can render skills workflow entries", () => {
+  const html = renderSlot({ kind: "skillsWorkflow" });
+
+  assert.match(html, SKILLS_WORKFLOW_RE);
+  assert.doesNotMatch(html, GITHUB_DEPLOYMENT_RE);
 });
 
 test("canvas side pane slot is absent without an active side entry", () => {

--- a/apps/ui/src/features/project-canvas/panels/project-canvas-side-pane-slot.tsx
+++ b/apps/ui/src/features/project-canvas/panels/project-canvas-side-pane-slot.tsx
@@ -9,6 +9,7 @@ export type ProjectCanvasSidePaneEntry =
   | { kind: "githubDeployment" }
   | { kind: "projectCreation" }
   | { kind: "resource" }
+  | { kind: "skillsWorkflow" }
   | null;
 
 export function ProjectCanvasSidePaneSlot({
@@ -18,6 +19,7 @@ export function ProjectCanvasSidePaneSlot({
   githubDeploymentPane,
   projectCreationPane,
   resourcePane,
+  skillsWorkflowPane,
 }: {
   databaseDeploymentPane?: ReactNode;
   dockerDeploymentPane?: ReactNode;
@@ -25,6 +27,7 @@ export function ProjectCanvasSidePaneSlot({
   githubDeploymentPane: ReactNode;
   projectCreationPane?: ReactNode;
   resourcePane: ReactNode;
+  skillsWorkflowPane?: ReactNode;
 }) {
   let pane: ReactNode = null;
 
@@ -36,6 +39,8 @@ export function ProjectCanvasSidePaneSlot({
     pane = githubDeploymentPane;
   } else if (entry?.kind === "projectCreation") {
     pane = projectCreationPane;
+  } else if (entry?.kind === "skillsWorkflow") {
+    pane = skillsWorkflowPane;
   } else if (entry?.kind === "resource") {
     pane = resourcePane;
   }

--- a/apps/ui/src/features/project-canvas/surface/rendering-adapter.ts
+++ b/apps/ui/src/features/project-canvas/surface/rendering-adapter.ts
@@ -207,6 +207,7 @@ function sideRenderModel({
     case "dockerDeployment":
     case "githubDeployment":
     case "projectCreation":
+    case "skillsWorkflow":
       return { entry, kind: "global" };
     default:
       return entry satisfies never;

--- a/apps/ui/src/features/project-canvas/workbench/project-canvas-workbench-surfaces.tsx
+++ b/apps/ui/src/features/project-canvas/workbench/project-canvas-workbench-surfaces.tsx
@@ -3,6 +3,7 @@
 import { DatabaseDeploymentPane } from "@/components/database-deployment-pane";
 import { DockerDeploymentPane } from "@/components/docker-deployment-pane";
 import { GitHubDeploymentPane } from "@/components/github-deployment-pane";
+import { SealosSkillsWorkflowPane } from "@/components/sealos-skills-workflow-pane";
 import { MainActionSurface } from "@/features/project-canvas/actions/canvas-action-surface";
 import { DatabaseLogsPane } from "@/features/project-canvas/panels/database-logs-pane";
 import { DatabaseTerminalPane } from "@/features/project-canvas/panels/database-terminal-pane";
@@ -78,6 +79,9 @@ export function ProjectCanvasWorkbenchSurfaces({
             onUpdated={refreshWorkloadLists}
           />
         }
+        skillsWorkflowPane={
+          <SealosSkillsWorkflowPane onClose={workbench.closeResourcePane} />
+        }
       />
       <MainActionSurface
         kubeconfig={kubeconfig}
@@ -136,6 +140,8 @@ function canvasSidePaneEntryFromRenderModel(
       return { kind: "githubDeployment" };
     case "projectCreation":
       return { kind: "projectCreation" };
+    case "skillsWorkflow":
+      return { kind: "skillsWorkflow" };
     default:
       return side.entry satisfies never;
   }

--- a/apps/ui/src/features/project-surfaces/assistant-router.ts
+++ b/apps/ui/src/features/project-surfaces/assistant-router.ts
@@ -6,7 +6,7 @@ import type {
 } from "./target-identity";
 
 export type ProjectSidePaneAssistantIntent =
-  | { type: "database" | "docker" | "github" }
+  | { type: "database" | "docker" | "github" | "skills" }
   | { target: ProjectApTarget; type: "apEvents" | "apHistory" | "apMetrics" }
   | { target: ProjectApTarget; type: "apSettings" | "apTerminal" }
   | { target: ProjectDbTarget; type: "dbAccess" | "dbMetrics" | "dbSettings" }

--- a/apps/ui/src/features/project-surfaces/surface-intents.test.ts
+++ b/apps/ui/src/features/project-surfaces/surface-intents.test.ts
@@ -27,6 +27,12 @@ test("Project List translates assistant Docker intent to Docker direct project c
   });
 });
 
+test("Project List translates assistant skills intent to skills workflow side pane", () => {
+  assert.deepEqual(projectListEntryForAssistantIntent({ type: "skills" }), {
+    kind: "skillsWorkflow",
+  });
+});
+
 test("Project Canvas translates assistant GitHub intent to deployment in the current Project", () => {
   assert.deepEqual(
     projectCanvasEntryForAssistantIntent(
@@ -69,6 +75,21 @@ test("Project Canvas translates assistant Docker intent to deployment in the cur
       entry: {
         kind: "dockerDeployment",
         projectId: "project-1",
+      },
+      slot: "side",
+    }
+  );
+});
+
+test("Project Canvas translates assistant skills intent to skills workflow side pane", () => {
+  assert.deepEqual(
+    projectCanvasEntryForAssistantIntent(
+      { type: "skills" },
+      { projectId: "project-1" }
+    ),
+    {
+      entry: {
+        kind: "skillsWorkflow",
       },
       slot: "side",
     }

--- a/apps/ui/src/features/project-surfaces/surface-intents.ts
+++ b/apps/ui/src/features/project-surfaces/surface-intents.ts
@@ -10,6 +10,7 @@ export type ProjectSidePaneEntry = Extract<
   | { kind: "dockerDeployment" }
   | { kind: "githubDeployment" }
   | { kind: "projectCreation" }
+  | { kind: "skillsWorkflow" }
 >;
 
 export function projectListEntryForAssistantIntent(
@@ -32,6 +33,9 @@ export function projectListEntryForAssistantIntent(
       entryMode: "dockerDirect",
       kind: "projectCreation",
     };
+  }
+  if (intent.type === "skills") {
+    return { kind: "skillsWorkflow" };
   }
   return null;
 }
@@ -123,6 +127,12 @@ export function projectCanvasEntryForAssistantIntent(
   const uid = options?.projectId?.trim() ?? "";
   if (uid === "") {
     return null;
+  }
+  if (intent.type === "skills") {
+    return {
+      entry: { kind: "skillsWorkflow" },
+      slot: "side",
+    };
   }
   if (intent.type === "database") {
     return {

--- a/apps/ui/src/features/project-surfaces/surface-state.ts
+++ b/apps/ui/src/features/project-surfaces/surface-state.ts
@@ -23,7 +23,8 @@ export type ProjectGlobalSidePaneEntry =
   | { kind: "databaseDeployment"; projectId: string }
   | { kind: "dockerDeployment"; projectId: string }
   | { kind: "githubDeployment"; projectId: string }
-  | { kind: "projectCreation"; entryMode: ProjectCreationPaneEntryMode };
+  | { kind: "projectCreation"; entryMode: ProjectCreationPaneEntryMode }
+  | { kind: "skillsWorkflow" };
 
 export type ProjectSideSurfaceEntry =
   | ProjectGlobalSidePaneEntry

--- a/apps/ui/src/features/project-surfaces/url-codec.ts
+++ b/apps/ui/src/features/project-surfaces/url-codec.ts
@@ -121,6 +121,8 @@ export function serializeProjectSideSurfaceEntry(
       return `github-deployment:${encodePart(entry.projectId)}`;
     case "projectCreation":
       return `project-creation:${encodePart(entry.entryMode)}`;
+    case "skillsWorkflow":
+      return "skills-workflow";
     case "publicAddresses":
       return `public-addresses:${serializeProjectTarget(entry.target)}`;
     default:
@@ -205,6 +207,8 @@ export function parseProjectSideSurfaceEntry(
       return projectIdEntry("githubDeployment", parts);
     case "project-creation":
       return parseProjectCreationSideEntry(parts);
+    case "skills-workflow":
+      return parts.length === 1 ? { kind: "skillsWorkflow" } : null;
     default:
       return null;
   }

--- a/packages/ui/src/components/chat/chat.input.test.tsx
+++ b/packages/ui/src/components/chat/chat.input.test.tsx
@@ -6,28 +6,33 @@ import {
   ChatDatabaseDeployButton,
   ChatDockerDeployButton,
   ChatGithubDeployButton,
+  ChatSkillsWorkflowButton,
 } from "./chat.input";
 
 const noop = () => undefined;
 const DOCKER_DEPLOY_ARIA_LABEL_RE = /aria-label="Docker deploy"/;
 
-test("chat composer deploy actions include GitHub, Docker, and Database controls in order", () => {
+test("chat composer deploy actions include GitHub, Docker, Database, and Skills controls in order", () => {
   const html = renderToStaticMarkup(
     <div>
       <ChatGithubDeployButton onComposerAction={noop} />
       <ChatDockerDeployButton onComposerAction={noop} />
       <ChatDatabaseDeployButton onComposerAction={noop} />
+      <ChatSkillsWorkflowButton onComposerAction={noop} />
     </div>
   );
 
   const github = html.indexOf('data-slot="chat-github-deploy-button"');
   const docker = html.indexOf('data-slot="chat-docker-deploy-button"');
   const database = html.indexOf('data-slot="chat-database-deploy-button"');
+  const skills = html.indexOf('data-slot="chat-skills-workflow-button"');
 
   assert.ok(github !== -1, "GitHub action is visible");
   assert.ok(docker !== -1, "Docker action is visible");
   assert.ok(database !== -1, "Database action is visible");
+  assert.ok(skills !== -1, "Skills action is visible");
   assert.ok(github < docker, "GitHub appears before Docker");
   assert.ok(docker < database, "Docker appears before Database");
+  assert.ok(database < skills, "Database appears before Skills");
   assert.match(html, DOCKER_DEPLOY_ARIA_LABEL_RE);
 });

--- a/packages/ui/src/components/chat/chat.input.tsx
+++ b/packages/ui/src/components/chat/chat.input.tsx
@@ -15,7 +15,7 @@ import {
 } from "@workspace/ui/components/popover";
 import { Textarea } from "@workspace/ui/components/textarea";
 import { cn } from "@workspace/ui/lib/utils";
-import { Database, Square } from "lucide-react";
+import { Database, Square, Wrench } from "lucide-react";
 import { type ComponentProps, useEffect, useLayoutEffect, useRef } from "react";
 
 import { ProjectSourceDockerIcon } from "../../assets/project-source-icons";
@@ -46,6 +46,14 @@ export type ChatDatabaseDeployButtonProps = Omit<
 };
 
 export type ChatDockerDeployButtonProps = Omit<
+  AppIconButtonProps,
+  "aria-label" | "children" | "onClick" | "size" | "type" | "variant"
+> & {
+  "aria-label"?: string;
+  onComposerAction?: () => void;
+};
+
+export type ChatSkillsWorkflowButtonProps = Omit<
   AppIconButtonProps,
   "aria-label" | "children" | "onClick" | "size" | "type" | "variant"
 > & {
@@ -415,6 +423,34 @@ export function ChatDockerDeployButton({
   );
 }
 
+/** Icon-only control for Sealos Skills workflow; omitted `onComposerAction` renders nothing. */
+export function ChatSkillsWorkflowButton({
+  className,
+  "aria-label": ariaLabel = "Sealos Skills workflow",
+  onComposerAction,
+  ...props
+}: ChatSkillsWorkflowButtonProps) {
+  if (!onComposerAction) {
+    return null;
+  }
+
+  return (
+    <AppIconButton
+      aria-label={ariaLabel}
+      className={cn("shrink-0 cursor-pointer", className)}
+      data-slot="chat-skills-workflow-button"
+      onClick={onComposerAction}
+      size="lg"
+      title="Sealos Skills workflow"
+      type="button"
+      variant="quiet"
+      {...props}
+    >
+      <Wrench aria-hidden className="size-4 text-foreground opacity-90" />
+    </AppIconButton>
+  );
+}
+
 export interface ChatComposerSendProps {
   className?: string;
   onPrimaryAction: () => void;
@@ -494,6 +530,7 @@ export function ChatComposer({
             <ChatGithubDeployButton onComposerAction={onComposerAction} />
             <ChatDockerDeployButton onComposerAction={onComposerAction} />
             <ChatDatabaseDeployButton onComposerAction={onComposerAction} />
+            <ChatSkillsWorkflowButton onComposerAction={onComposerAction} />
           </div>
           <ChatComposerSend
             onPrimaryAction={onPrimaryAction}
@@ -517,4 +554,5 @@ ChatGithubDeployPopover.displayName = "Chat.GithubDeployPopover";
 ChatDatabaseDeployButton.displayName = "Chat.DatabaseDeployButton";
 ChatDockerDeployButton.displayName = "Chat.DockerDeployButton";
 ChatGithubDeployButton.displayName = "Chat.GithubDeployButton";
+ChatSkillsWorkflowButton.displayName = "Chat.SkillsWorkflowButton";
 ChatComposer.displayName = "Chat.Composer";

--- a/packages/ui/src/components/chat/chat.tsx
+++ b/packages/ui/src/components/chat/chat.tsx
@@ -24,6 +24,7 @@ import {
   ChatGithubDeployButton,
   ChatGithubDeployPopover,
   ChatGithubMark,
+  ChatSkillsWorkflowButton,
 } from "./chat.input";
 import { ChatTranscript } from "./chat.transcript";
 
@@ -47,6 +48,7 @@ export type {
   ChatDockerDeployButtonProps,
   ChatGithubDeployButtonProps,
   ChatGithubDeployPopoverProps,
+  ChatSkillsWorkflowButtonProps,
 } from "./chat.input";
 export {
   ChatComposerContextIndicator,
@@ -56,6 +58,7 @@ export {
   ChatGithubDeployButton,
   ChatGithubDeployPopover,
   ChatGithubMark,
+  ChatSkillsWorkflowButton,
   GITHUB_MARK_PATH,
 } from "./chat.input";
 export type {
@@ -98,6 +101,7 @@ export const Chat = Object.assign(ChatShell, {
   GithubDeployButton: ChatGithubDeployButton,
   GithubDeployPopover: ChatGithubDeployPopover,
   GithubMark: ChatGithubMark,
+  SkillsWorkflowButton: ChatSkillsWorkflowButton,
   Header: ChatHeader,
   NewThread: ChatHeaderNewThread,
   Root: ChatRoot,


### PR DESCRIPTION
## Summary
- Add a wrench button in the assistant composer footer alongside GitHub, Docker, and Database deploy shortcuts.
- Open a static Sealos Skills Workflow side pane that reuses the existing `SidePane` layout on both the project list and project canvas routes.
- Wire routing via `skills` assistant intent and `?side=skills-workflow`, with install command copy support and Figma-aligned step content.

## Test plan
- [x] Open `/project`, expand assistant pane, click wrench icon — Skills workflow side pane opens with install command and flow steps.
- [x] Open a project canvas, click wrench icon — same pane opens from canvas side surface routing.
- [x] Close pane via X; confirm URL `side` query clears.
- [x] Copy install command button copies `npx skills add labring/seakills`.
- [x] Confirm wrench icon matches other composer icons (foreground/white style).


Made with [Cursor](https://cursor.com)