### PR TITLE
[codex] fix skills workflow command row states

### DIFF
--- a/apps/ui/src/components/sealos-skills-workflow-content.tsx
+++ b/apps/ui/src/components/sealos-skills-workflow-content.tsx
@@ -37,12 +37,14 @@ export const SEALOS_SKILLS_FLOW_STEPS = [
   {
     description:
       "After deployment is complete, an accessible domain will be returned automatically.",
-    title: "7. Automatically Deploy and Generate an Accessible Domain",
+    title: "6. Automatically Deploy and Generate an Accessible Domain",
   },
 ] as const;
 
 function SealosSkillsInstallCommandRow({ command }: { command: string }) {
   const [copied, setCopied] = useState(false);
+  const [copyButtonFocused, setCopyButtonFocused] = useState(false);
+  const isCommandHighlighted = copied || copyButtonFocused;
 
   const copyCommand = useCallback(async () => {
     if (typeof navigator === "undefined" || !navigator.clipboard) {
@@ -61,26 +63,40 @@ function SealosSkillsInstallCommandRow({ command }: { command: string }) {
 
   return (
     <div
-      className="flex h-10 items-center gap-1 overflow-hidden rounded-md bg-input/30 px-3 py-2"
+      className={cn(
+        "group flex h-10 items-center gap-1 overflow-hidden rounded-md bg-input/30 px-3 py-2 transition-colors hover:bg-input",
+        isCommandHighlighted && "bg-input"
+      )}
       data-slot="sealos-skills-install-command"
     >
-      <p className="min-w-0 flex-1 truncate font-normal text-muted-foreground text-sm leading-5">
+      <p
+        className={cn(
+          "min-w-0 flex-1 truncate font-normal text-muted-foreground text-sm leading-5 transition-colors group-hover:text-foreground",
+          isCommandHighlighted && "text-foreground"
+        )}
+      >
         {command}
       </p>
       <AppIconButton
         aria-label={copied ? "Copied install command" : "Copy install command"}
-        className="shrink-0"
+        className={cn(
+          "shrink-0 text-muted-foreground hover:bg-transparent hover:text-foreground focus-visible:bg-transparent group-hover:text-foreground",
+          isCommandHighlighted && "text-foreground"
+        )}
+        data-copied={copied}
+        onBlur={() => setCopyButtonFocused(false)}
         onClick={() => {
           copyCommand().catch(() => undefined);
         }}
+        onFocus={() => setCopyButtonFocused(true)}
         size="sm"
         type="button"
         variant="quiet"
       >
         {copied ? (
-          <Check aria-hidden className="size-4 text-foreground" />
+          <Check aria-hidden className="size-4" />
         ) : (
-          <Copy aria-hidden className="size-4 text-foreground" />
+          <Copy aria-hidden className="size-4" />
         )}
       </AppIconButton>
     </div>

--- a/apps/ui/src/components/sealos-skills-workflow-pane.test.ts
+++ b/apps/ui/src/components/sealos-skills-workflow-pane.test.ts
@@ -6,9 +6,46 @@ const SKILLS_WORKFLOW_PANE_SOURCE = readFileSync(
   new URL("./sealos-skills-workflow-pane.tsx", import.meta.url),
   "utf8"
 );
+const SKILLS_WORKFLOW_CONTENT_SOURCE = readFileSync(
+  new URL("./sealos-skills-workflow-content.tsx", import.meta.url),
+  "utf8"
+);
 const CONCISE_SUBTITLE_RE =
-  /subtitle="Set up locally and deploy automatically in 7 steps\."/;
+  /subtitle="Set up locally and deploy automatically in 6 steps\."/;
+const INSTALL_COMMAND_ROW_CLICK_RE =
+  /data-slot="sealos-skills-install-command"[\s\S]{0,240}onClick=/;
+const COMMAND_HIGHLIGHT_STATE_RE =
+  /const isCommandHighlighted = copied \|\| copyButtonFocused;/;
+const COMMAND_HIGHLIGHT_BACKGROUND_RE = /isCommandHighlighted && "bg-input"/;
+const COMMAND_HIGHLIGHT_TEXT_RE = /isCommandHighlighted && "text-foreground"/;
+const COMMAND_ROW_HOVER_BACKGROUND_RE = /group[\s\S]*hover:bg-input/;
+const COMMAND_ROW_HOVER_TEXT_RE = /group-hover:text-foreground/;
+const INSTALL_COMMAND_ROW_SOURCE =
+  SKILLS_WORKFLOW_CONTENT_SOURCE.match(
+    /function SealosSkillsInstallCommandRow[\s\S]*?function SealosSkillsSectionHeader/
+  )?.[0] ?? "";
 
 test("skills workflow pane subtitle stays concise enough for the header", () => {
   assert.match(SKILLS_WORKFLOW_PANE_SOURCE, CONCISE_SUBTITLE_RE);
+});
+
+test("skills workflow flow step titles use continuous numbering", () => {
+  const stepNumbers = Array.from(
+    SKILLS_WORKFLOW_CONTENT_SOURCE.matchAll(/title: ["'](\d+)\./g),
+    (match) => Number(match[1])
+  );
+
+  assert.deepEqual(
+    stepNumbers,
+    Array.from({ length: stepNumbers.length }, (_, index) => index + 1)
+  );
+});
+
+test("skills workflow install command row keeps copy scoped to the icon button", () => {
+  assert.doesNotMatch(INSTALL_COMMAND_ROW_SOURCE, INSTALL_COMMAND_ROW_CLICK_RE);
+  assert.match(INSTALL_COMMAND_ROW_SOURCE, COMMAND_HIGHLIGHT_STATE_RE);
+  assert.match(INSTALL_COMMAND_ROW_SOURCE, COMMAND_HIGHLIGHT_BACKGROUND_RE);
+  assert.match(INSTALL_COMMAND_ROW_SOURCE, COMMAND_HIGHLIGHT_TEXT_RE);
+  assert.match(INSTALL_COMMAND_ROW_SOURCE, COMMAND_ROW_HOVER_BACKGROUND_RE);
+  assert.match(INSTALL_COMMAND_ROW_SOURCE, COMMAND_ROW_HOVER_TEXT_RE);
 });

--- a/apps/ui/src/components/sealos-skills-workflow-pane.tsx
+++ b/apps/ui/src/components/sealos-skills-workflow-pane.tsx
@@ -13,7 +13,7 @@ export function SealosSkillsWorkflowPane({ onClose }: { onClose: () => void }) {
       icon={<Wrench aria-hidden className="size-4 text-blue-400" />}
       label="Sealos Skills workflow pane"
       onClose={onClose}
-      subtitle="Set up locally and deploy automatically in 7 steps."
+      subtitle="Set up locally and deploy automatically in 6 steps."
       title="Sealos Skills Workflow"
     >
       <SealosSkillsWorkflowContent />


### PR DESCRIPTION
## Summary

- Fix the Sealos Skills workflow step numbering so the displayed flow is continuous and the subtitle matches the six visible steps.
- Update the install command row states to match the Figma references: default, row hover, and copied/focused feedback.
- Keep copying scoped to the right-side icon button while allowing the full command row to show hover feedback.
- Add regression coverage for continuous step numbering and the command row interaction boundary.

## Validation

- `bun test apps/ui/src/components/sealos-skills-workflow-pane.test.ts`
- `bun typecheck`
- `bun check`
