### PR TITLE
[codex] Align canvas minimap chrome with controls

### DIFF
--- a/packages/ui/src/components/canvas/canvas.controls.test.ts
+++ b/packages/ui/src/components/canvas/canvas.controls.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const CANVAS_CONTROLS_SOURCE = readFileSync(
+  new URL("./canvas.controls.tsx", import.meta.url),
+  "utf8"
+);
+const NAVIGATION_CHROME_CONSTANT_RE =
+  /CANVAS_NAVIGATION_CHROME_CLASS =\s+"rounded-lg bg-\[#09090b\]\/10 backdrop-blur-lg"/;
+const NAVIGATION_CHROME_USAGE_RE = /CANVAS_NAVIGATION_CHROME_CLASS/;
+const MINIMAP_FIXED_FRAME_RE = /h-\[130px\] w-\[223px\]/;
+
+function sourceBeforeCanvasMiniMapSlot() {
+  const slotIndex = CANVAS_CONTROLS_SOURCE.indexOf(
+    'data-slot="canvas-minimap"'
+  );
+  assert.notEqual(slotIndex, -1, "canvas minimap slot should be present");
+  return CANVAS_CONTROLS_SOURCE.slice(Math.max(0, slotIndex - 700), slotIndex);
+}
+
+test("canvas minimap uses the same glass chrome material as canvas controls", () => {
+  const minimapSource = sourceBeforeCanvasMiniMapSlot();
+
+  assert.match(CANVAS_CONTROLS_SOURCE, NAVIGATION_CHROME_CONSTANT_RE);
+  assert.match(minimapSource, MINIMAP_FIXED_FRAME_RE);
+  assert.match(minimapSource, NAVIGATION_CHROME_USAGE_RE);
+});

--- a/packages/ui/src/components/canvas/canvas.controls.tsx
+++ b/packages/ui/src/components/canvas/canvas.controls.tsx
@@ -15,6 +15,8 @@ import type { CanvasInteractionMode } from "./canvas.types";
 import { useCanvas } from "./canvas.use";
 
 const VIEWPORT_ACTION_DURATION_MS = 180;
+const CANVAS_NAVIGATION_CHROME_CLASS =
+  "rounded-lg bg-[#09090b]/10 backdrop-blur-lg";
 type CanvasShortcut = "fit-view" | "hand" | "pointer" | "zoom-in" | "zoom-out";
 
 export interface CanvasViewportInsetProps {
@@ -270,7 +272,8 @@ export function CanvasControls({ className, rightInset }: CanvasControlsProps) {
   return (
     <div
       className={cn(
-        "absolute top-[52px] right-2 z-10 flex flex-col items-center rounded-lg bg-[#09090b]/10 backdrop-blur-lg transition-[right,opacity] duration-200 ease-out",
+        "absolute top-[52px] right-2 z-10 flex flex-col items-center transition-[right,opacity] duration-200 ease-out",
+        CANVAS_NAVIGATION_CHROME_CLASS,
         chrome.hidden
           ? "pointer-events-none opacity-0"
           : "pointer-events-auto opacity-100",
@@ -333,7 +336,8 @@ export function CanvasMiniMap({
   return (
     <div
       className={cn(
-        "absolute top-[60px] left-3 z-10 transition-[right,opacity] duration-200 ease-out",
+        "absolute top-[60px] left-3 z-10 h-[130px] w-[223px] overflow-hidden transition-[right,opacity] duration-200 ease-out",
+        CANVAS_NAVIGATION_CHROME_CLASS,
         chrome.hidden
           ? "pointer-events-none opacity-0"
           : "pointer-events-auto opacity-100",
@@ -346,9 +350,9 @@ export function CanvasMiniMap({
     >
       <MiniMap
         ariaLabel="Canvas mini map"
-        bgColor="color-mix(in oklab, var(--input) 30%, transparent)"
-        className="overflow-hidden bg-input/30 shadow-none"
-        maskColor="color-mix(in oklab, var(--input) 30%, transparent)"
+        bgColor="transparent"
+        className="bg-transparent shadow-none"
+        maskColor="transparent"
         maskStrokeColor="var(--color-border)"
         maskStrokeWidth={1}
         nodeBorderRadius={10}


### PR DESCRIPTION
## Summary

- Align the canvas MiniMap overlay with the canvas controls glass chrome.
- Keep the MiniMap frame fixed at 223x130 so blur, rounded corners, and hit area apply to the visible preview.
- Add a focused source-level regression test for the shared MiniMap chrome contract.

## Test Plan

- bun test packages/ui/src/components/canvas/canvas.controls.test.ts
- bun typecheck
- bun check
