### PR TITLE
[codex] Set default Docker image placeholder

### DIFF
--- a/apps/ui/src/features/deployment/docker-deployer.test.tsx
+++ b/apps/ui/src/features/deployment/docker-deployer.test.tsx
@@ -22,7 +22,7 @@ const ARIA_BUSY_RE = /aria-busy="true"/;
 const VALUE_8080_RE = /value="8080"/;
 const FEATURE_FLAG_RE = /value="FEATURE_FLAG"/;
 const VALUE_TRUE_RE = /value="true"/;
-const DEFAULT_DOCKER_IMAGE_RE = /value="nginx:stable"/;
+const DEFAULT_DOCKER_IMAGE_RE = /value="nginx"/;
 const IMAGE_PLACEHOLDER_RE = /placeholder="image:tag"/;
 const DOCKER_IMAGE_REQUIRED_RE = /Docker image is required\./;
 

--- a/apps/ui/src/features/deployment/docker-deployer.test.tsx
+++ b/apps/ui/src/features/deployment/docker-deployer.test.tsx
@@ -22,6 +22,8 @@ const ARIA_BUSY_RE = /aria-busy="true"/;
 const VALUE_8080_RE = /value="8080"/;
 const FEATURE_FLAG_RE = /value="FEATURE_FLAG"/;
 const VALUE_TRUE_RE = /value="true"/;
+const DEFAULT_DOCKER_IMAGE_RE = /value="nginx:stable"/;
+const IMAGE_PLACEHOLDER_RE = /placeholder="image:tag"/;
 const DOCKER_IMAGE_REQUIRED_RE = /Docker image is required\./;
 
 test("DockerDeployer renders Docker Deployment Settings with default network choices", () => {
@@ -30,6 +32,8 @@ test("DockerDeployer renders Docker Deployment Settings with default network cho
   assert.match(html, DOCKER_DEPLOYER_SLOT_RE);
   assert.match(html, IMAGE_RE);
   assert.match(html, DOCKER_IMAGE_RE);
+  assert.match(html, DEFAULT_DOCKER_IMAGE_RE);
+  assert.match(html, IMAGE_PLACEHOLDER_RE);
   assert.match(html, RUNTIME_RE);
   assert.doesNotMatch(html, ENVIRONMENT_VARIABLES_RE);
   assert.match(html, ADD_ENVIRONMENT_VARIABLE_RE);

--- a/apps/ui/src/features/deployment/docker-deployer.tsx
+++ b/apps/ui/src/features/deployment/docker-deployer.tsx
@@ -23,6 +23,7 @@ import { useEffect, useMemo, useState } from "react";
 import { DeploymentSettings } from "./deployment-settings";
 import {
   DEFAULT_DOCKER_APP_LISTENING_PORT,
+  DEFAULT_DOCKER_IMAGE,
   type DockerDeploymentConfigMap,
   type DockerDeploymentEnvVar,
   type DockerDeploymentSettings,
@@ -136,7 +137,9 @@ export function DockerDeployer({
   onDeploy?: (settings: DockerDeploymentSettings) => void | Promise<void>;
   onSettingsChange?: (settings: DockerDeploymentSettings) => void;
 }) {
-  const [image, setImage] = useState(initialSettings?.image ?? "");
+  const [image, setImage] = useState(
+    initialSettings?.image ?? DEFAULT_DOCKER_IMAGE
+  );
   const [commandText, setCommandText] = useState(
     initialSettings?.command?.join("\n") ?? ""
   );
@@ -239,7 +242,7 @@ export function DockerDeployer({
                 setImageTouched(true);
                 setImage(event.currentTarget.value);
               }}
-              placeholder="ghcr.io/org/image:tag"
+              placeholder="image:tag"
               value={image}
             />
             {visibleImageError ? (

--- a/apps/ui/src/features/deployment/docker-deployment-settings.ts
+++ b/apps/ui/src/features/deployment/docker-deployment-settings.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_DOCKER_APP_LISTENING_PORT = 80;
-export const DEFAULT_DOCKER_IMAGE = "nginx:stable";
+export const DEFAULT_DOCKER_IMAGE = "nginx";
 
 export interface DockerDeploymentEnvVar {
   name: string;

--- a/apps/ui/src/features/deployment/docker-deployment-settings.ts
+++ b/apps/ui/src/features/deployment/docker-deployment-settings.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_DOCKER_APP_LISTENING_PORT = 80;
+export const DEFAULT_DOCKER_IMAGE = "nginx:stable";
 
 export interface DockerDeploymentEnvVar {
   name: string;


### PR DESCRIPTION
## Summary

- Default the Docker image deployer to nginx:stable.
- Replace the GHCR-specific image placeholder with the generic image:tag format hint.
- Add DockerDeployer coverage for the default image and placeholder contract.

## Test Plan

- bun test apps/ui/src/features/deployment/docker-deployer.test.tsx
- bun typecheck
- bun check
