### PR TITLE
[codex] Cache template catalog fetches

### DIFF
--- a/apps/ui/src/app/api/templates/route.test.ts
+++ b/apps/ui/src/app/api/templates/route.test.ts
@@ -1,0 +1,8 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+test("template catalog route does not force dynamic fetch caching", async () => {
+  const templatesRoute = await import("./route");
+
+  assert.equal(Object.hasOwn(templatesRoute, "dynamic"), false);
+});

--- a/apps/ui/src/app/api/templates/route.ts
+++ b/apps/ui/src/app/api/templates/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 
 import { listTemplateCatalog } from "@/lib/template-provider-core";
 
-export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 function jsonError(message: string, status: number) {

--- a/apps/ui/src/lib/template-provider-core.ts
+++ b/apps/ui/src/lib/template-provider-core.ts
@@ -302,7 +302,7 @@ export async function listTemplateCatalog(input?: {
     providerUrl("/api/listTemplate", {
       language,
     }),
-    { cache: "no-store" }
+    { next: { revalidate: 300 } }
   );
   const body = await readJsonResponse(response);
   if (!response.ok) {

--- a/apps/ui/src/lib/template-provider.test.ts
+++ b/apps/ui/src/lib/template-provider.test.ts
@@ -33,8 +33,10 @@ function jsonResponse(body: unknown, init?: ResponseInit) {
 test("listTemplateCatalog maps Sealos provider templates to Brain choices", async () => {
   process.env.TEMPLATE_PROVIDER_URL = "https://template.example.com";
   let requestedUrl = "";
-  globalThis.fetch = ((url) => {
+  let requestedInit: RequestInit | undefined;
+  globalThis.fetch = ((url, init) => {
     requestedUrl = String(url);
+    requestedInit = init;
     return Promise.resolve(
       jsonResponse({
         code: 200,
@@ -74,6 +76,9 @@ test("listTemplateCatalog maps Sealos provider templates to Brain choices", asyn
     requestedUrl,
     "https://template.example.com/api/listTemplate?language=zh"
   );
+  assert.deepEqual(requestedInit, {
+    next: { revalidate: 300 },
+  });
   assert.deepEqual(catalog, [
     {
       args: [


### PR DESCRIPTION
## Summary

- Cache template catalog provider fetches with Next.js `next.revalidate: 300`
- Keep template source loading and deployment mutations uncached
- Add test coverage for the provider fetch cache options

## Why

Template catalog data is low-frequency-change and high-frequency-read. Previously every `/api/templates` server request called `TEMPLATE_PROVIDER_URL/api/listTemplate` because the provider fetch used `cache: "no-store"`.

## Validation

- `bun test apps/ui/src/lib/template-provider.test.ts`
- `bun typecheck`
- `bun check`
