### PR TITLE
[codex] show quota sizes as Gi

### DIFF
--- a/apps/ui/src/components/app-sidebar-upgrade.test.ts
+++ b/apps/ui/src/components/app-sidebar-upgrade.test.ts
@@ -16,8 +16,8 @@ test("formatWorkspaceQuotaRows maps Sealos quota items to sidebar rows", () => {
 
   assert.deepEqual(formatWorkspaceQuotaRows(quota), [
     ["CPU", "0.5/16C"],
-    ["Memory", "1GB/64GB"],
-    ["Storage", "3GB/200GB"],
+    ["Memory", "1Gi/64Gi"],
+    ["Storage", "3Gi/200Gi"],
     ["Ports", "0/10"],
   ]);
 });

--- a/apps/ui/src/components/app-sidebar-upgrade.ts
+++ b/apps/ui/src/components/app-sidebar-upgrade.ts
@@ -14,7 +14,6 @@ const WORKSPACE_QUOTA_ROW_DEFINITIONS = [
   { label: "Storage", type: "storage" },
   { label: "Ports", type: "nodeport" },
 ] as const;
-const GIBI_SUFFIX_RE = /Gi$/;
 
 function formatPortQuotaNumber(value: number) {
   if (!Number.isFinite(value)) {
@@ -46,13 +45,11 @@ function formatBinaryQuotaNumberFromMi(value: number) {
     return "--";
   }
   try {
-    return Quantity.parse(`${value}Mi`)
-      .formatForDisplay({
-        digits: 2,
-        format: "BinarySI",
-        scale: BinaryScale.Gibi,
-      })
-      .replace(GIBI_SUFFIX_RE, "GB");
+    return Quantity.parse(`${value}Mi`).formatForDisplay({
+      digits: 2,
+      format: "BinarySI",
+      scale: BinaryScale.Gibi,
+    });
   } catch {
     return "--";
   }


### PR DESCRIPTION
## Summary

- Show sidebar quota memory and storage values with the `Gi` suffix instead of `GB`.
- Keep CPU and port quota formatting unchanged.

## Root Cause

- The formatter converted binary Gi display output to `GB`, which hid that the values are rendered using Gi-scale quantities.

## Validation

- `bun test apps/ui/src/components/app-sidebar-upgrade.test.ts`
- `bun typecheck`
- `bun check`
