### PR TITLE
Project Canvas Auto layout, log time-wheel edge fade, and ADR/docs cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ packages/
 - **UI components:** reuse `packages/ui/src/components/` first; app-specific compositions stay local until a second consumer needs them.
 - **Styling:** Tailwind v4 tokens live in `packages/ui/src/styles/globals.css` — no inline color/spacing/radius/type/shadow literals; use tokens or the Tailwind scale.
 - **Registry:** items live in `apps/registry/registry/<style>/<group>/<name>` with metadata in `preview-registry.ts`.
-- **Domain:** before changing AP, DB, EntryPoint, canvas, or settings behavior, check `CONTEXT.md` and the ADRs in `docs/adr/`.
+- **Domain:** before changing AP, DB, public access, canvas, or settings behavior, check `CONTEXT.md` and the ADRs in `docs/adr/`.
 - **Crossplane:** compatibility with Crossplane-era behavior, fields, routes, docs, or naming is out of scope — don't preserve it unless explicitly asked.
 
 ## When making changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,50 +4,43 @@ Guidance for AI coding agents working in this repo. Keep it short.
 
 ## Project
 
-- **Name:** `sealai` — monorepo for an internal platform combining a Next.js UI, a shadcn-style component registry, shared TS packages, and Go backend services.
-- **Shape:** Turbo monorepo with `apps/*` (ui, registry, api, whodb) and `packages/*` (ui, api, eslint-config, typescript-config).
-- **Package manager:** **bun 1.3.5** (NOT npm/pnpm/yarn). Node ≥20. Lockfile: `bun.lock`.
+`sealai` — Turbo monorepo for an internal platform (Next.js UIs + Go services).
+**Package manager: bun 1.3.5** (NOT npm/pnpm/yarn), Node ≥20.
 
 ## Workspace layout
 
 ```
 apps/
-  ui/         Next.js + React — main product UI (default port 3000)
-  registry/   Next.js + React — component preview registry (port 10000)
+  ui/         Next.js — main product UI (default port 3000)
+  registry/   Next.js — component preview registry (port 10000)
   api/        Go service (Huma + chi) — K8s/db/task/logs/metrics endpoints
   whodb/      backend-only Go service; see apps/whodb/AGENTS.md
 packages/
   ui/         @workspace/ui — shared shadcn/ui + Radix + Tailwind 4 components
   api/        @workspace/api — shared API fetchers, hooks, schemas, and constants
-  eslint-config/     shared eslint configs (base, next-js, react-internal)
-  typescript-config/ shared tsconfig bases
+  shared/     @workspace/shared — runtime utils (k8s quantity parsing + zod)
+  eslint-config/, typescript-config/ — shared lint and tsconfig bases
 ```
 
-## Standard commands (run from repo root unless noted)
+## Commands (from repo root)
 
-- `bun dev` — Turbo runs the usual dev servers, excluding `@sealai/whodb`
-- `bun dev:all` — runs all workspace dev servers, including `@sealai/whodb`
-- `bun build` — build all workspaces
-- `bun lint` — turbo lint (per-package eslint)
-- `bun format` — turbo format (prettier)
-- `bun typecheck` — turbo typecheck (tsc --noEmit)
-- `bun check` / `bun fix` — ultracite/biome code checks & autofix
-- Registry build: `cd apps/registry && bun run registry:build` (runs `shadcn build`)
-- Go API: `cd apps/api && <go run|go build|go test>` (see app's package.json scripts)
-- WhoDB: use root `bun whodb:*` scripts or follow `apps/whodb/AGENTS.md`
+- `bun dev` — dev servers excluding `@sealai/whodb`; `bun dev:all` — all of them
+- `bun build` / `bun lint` / `bun format` / `bun typecheck` — turbo, per-package
+- `bun check` / `bun fix` — ultracite/biome, the source of truth for code quality
+- Registry build: `cd apps/registry && bun run registry:build`
+- Go API: standard `go` toolchain in `apps/api`; WhoDB: root `bun whodb:*` scripts
 
 ## Conventions
 
 - **Boundaries:** import through package exports (`@workspace/ui/*`, `@workspace/api/*`) or app-local `@/*`; never across apps or into another package's private `src`.
-- **UI components:** reuse `packages/ui/src/components/` first. Shared primitives live in `packages/ui`; app-specific compositions stay local until a second consumer needs them.
-- **Styling:** Tailwind v4 theme tokens live in `packages/ui/src/styles/globals.css`. Avoid inline color/spacing/radius/type/shadow literals; use tokens or Tailwind scale.
-- **Quality:** Biome/ultracite is source of truth (`bun check` / `bun fix`).
+- **UI components:** reuse `packages/ui/src/components/` first; app-specific compositions stay local until a second consumer needs them.
+- **Styling:** Tailwind v4 tokens live in `packages/ui/src/styles/globals.css` — no inline color/spacing/radius/type/shadow literals; use tokens or the Tailwind scale.
 - **Registry:** items live in `apps/registry/registry/<style>/<group>/<name>` with metadata in `preview-registry.ts`.
-- **Domain:** before AP, DB, EntryPoint, canvas, or settings behavior changes, check `CONTEXT.md` and relevant ADRs in `docs/adr/`.
-- **Crossplane:** do not preserve Crossplane-era behavior, fields, routes, docs, or naming for compatibility. Treat Crossplane compatibility as explicitly out of scope unless the user asks for it in the current task.
+- **Domain:** before changing AP, DB, EntryPoint, canvas, or settings behavior, check `CONTEXT.md` and the ADRs in `docs/adr/`.
+- **Crossplane:** compatibility with Crossplane-era behavior, fields, routes, docs, or naming is out of scope — don't preserve it unless explicitly asked.
 
 ## When making changes
 
 - Default to editing existing files; don't introduce parallel patterns.
-- Before claiming code work is done, run `bun typecheck` and `bun check`; also run focused TS/Go tests for touched behavior when available.
+- Before claiming code work is done, run `bun typecheck` and `bun check`; run focused TS/Go tests for touched behavior when available.
 - `output: "standalone"` is set on Next.js apps — be mindful when touching build config (Docker depends on it).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,16 +1,8 @@
 # Domain Context
 
-## Ubiquitous Language
+The ubiquitous language for the Brain product domain, grouped by area.
 
-### Component Registry
-
-An internal catalog for reusable UI components in the product design system. It is not a catalog for complete product surfaces, panes, or workflows.
-
-### Registry Component
-
-A reusable UI component eligible for the Component Registry. A Registry Component may carry product vocabulary, but it must be driven by a host surface and must not own a complete product workflow or settings lifecycle.
-
-_Avoid_: Product Surface Registry, Pane Registry, Flow Registry.
+## Project & Navigation
 
 ### Project Description
 
@@ -18,13 +10,71 @@ A user-maintained optional Project summary that explains the Project's purpose o
 
 _Avoid_: Deployment description, source description, generated summary.
 
-### AP Public Access Node
+### Project Display Name
 
-An AP Public Access Node is a presentation-only Project Canvas node derived from an AP's Public Addresses. It is not a Brain product resource, backend API view, Kubernetes resource, or Settings Owner.
+The human-facing Project name shown in navigation, project chrome, project creation forms, and human confirmation prompts. It is stored on the Brain Project product record and is unique within a namespace after trimming surrounding whitespace and comparing case-insensitively. Avoid using Project name as a selector; stable identity uses Project ID.
 
-The node represents AP-owned public access, including pending Platform Addresses and Custom Domains; its user-visible label is Public access.
+### Project Aggregate Status
 
-_Avoid_: EntryPoint, EntryPoint resource, EntryPoint API view, AP endpoints, Ingress.
+A derived health tone for one Project row in the project list, computed from the phases of the Project's APs and DBs. It is not a persisted field on the Project product record; it is computed from sibling workload lists. It expresses "are the workloads inside this project healthy", which is what users look at on the list, and is distinct from whether the Project record itself exists.
+
+### Pinned Project
+
+A current-user navigation preference that marks one Project for prominent access from product navigation. Pinned Projects are a small user-curated shortcut set, not a complete Project list; each entry points to Project ID and is not a shared Project property, Project Aggregate Status, recent Project, or workload lifecycle state.
+
+_Avoid_: Favorite Project, starred Project, recent Project, sidebar Project.
+
+### Last Viewed Unpinned Project Shortcut
+
+A current-user navigation memory for the most recently opened unpinned Project in a namespace. It can remain visible while the user navigates to Pinned Projects or non-Project sidebar destinations, but it is not a Pinned Project, complete recent-project list, shared Project property, Project Aggregate Status, or workload lifecycle state.
+
+When the Last Viewed Unpinned Project becomes a Pinned Project, it leaves this shortcut slot rather than falling back to an older Project.
+
+_Avoid_: Current Project Shortcut, auto-pinned Project, recent Project, temporary Pinned Project, last viewed Pinned Project.
+
+### Project Shortcut Icon
+
+A presentation-only icon shown on a Project navigation shortcut. It may use a representative workload inside the Project as its visual source, but it is not Project identity, Project Aggregate Status, a persisted Project field, or a workload lifecycle state.
+
+_Avoid_: Project identity icon, Project status icon, workload status icon.
+
+## AP & Application Workloads
+
+### AP (Application)
+
+A Brain product resource that represents an application workload. AP owns the application's desired compute, environment, App Listening Ports, Private Addresses, and Platform Address allocation requests.
+
+### AP Workload Readiness
+
+The condition where an AP's application workload has enough running replicas to satisfy its AP Replica Strategy. AP Workload Readiness is distinct from AP Public Access Health; public routing may still be progressing after the workload is ready.
+
+_Avoid_: AP Public Access Health, Public Address readiness, route readiness.
+
+### AP Replica Strategy
+
+The AP configuration choice for how many workload replicas should run: either a fixed user-selected count or Elastic Scaling within user-selected bounds.
+
+### Fixed Replicas
+
+An AP Replica Strategy where the user selects one desired replica count and the platform keeps the AP at that count.
+
+### Elastic Scaling
+
+An AP Replica Strategy where the platform automatically adjusts AP replicas between a user-selected minimum and maximum based on one selected resource utilization target.
+
+### AP Configuration File
+
+An AP-owned configuration file mounted into the application runtime through AP Settings. AP Configuration Files are user-authored file content and mount paths, not a standalone Settings Owner.
+
+_Avoid_: ConfigMap, Config Files, configuration map.
+
+### AP Storage Mount
+
+A persistent volume an AP owns at one absolute container path, where the application's own data is kept across restarts and redeploys. An AP has zero or more AP Storage Mounts; each mount path is unique and fixed once created, and a mount's capacity can grow but never shrink. Distinct from an AP Configuration File, which mounts user-authored file content rather than application-written data.
+
+_Avoid_: Volume, PVC, disk, persistent storage, storage size.
+
+## AP Networking & Public Access
 
 ### App Listening Port
 
@@ -44,6 +94,28 @@ A system-assigned Public Address that the platform can create without user DNS o
 
 Platform Address health is based on whether the AP's platform routing support matches the AP's Public Address intent and target App Listening Port. It does not require a separately reported load balancer address before the Platform Address can be considered accessible.
 
+### Custom Domain
+
+A user-owned Public Address for an AP. A Custom Domain reaches an App Listening Port through a Custom Domain Binding.
+
+Custom Domain health uses `verifying` while DNS ownership, certificate readiness, or routing readiness is still being established. It becomes `blocked` only when the binding is known not to be able to proceed without a changed user or platform action.
+
+### Custom Domain Binding
+
+The relationship that attaches a Custom Domain to an AP by promoting one Platform Address as the CNAME target. The AP owns the user's binding intent and public access health; the AP Public Access Node only presents that AP-owned public access state on the canvas.
+
+A Custom Domain Binding targets the App Listening Port selected on the promoted Platform Address. Binding a Custom Domain may also retarget that promoted Platform Address to a different App Listening Port.
+
+Unbinding a Custom Domain removes that relationship and returns the promoted Platform Address to ordinary display; it does not delete the Platform Address or close public access.
+
+### CNAME Verification Evidence
+
+The remembered fact that a Custom Domain pointed to the promoted Platform Address when the Custom Domain Binding was submitted. It belongs to the Custom Domain Binding intent lifecycle and is not ongoing DNS monitoring.
+
+### Routing Scope
+
+The public routing boundary within which one Custom Domain can belong to only one AP. In v1, the enforceable Routing Scope is the current Kubernetes namespace; broader cluster-wide uniqueness requires platform-level admission or indexing.
+
 ### AP Public Access Health
 
 An AP-owned read-side assessment of each Public Address's public routing readiness and reachability, using routing states such as `progressing`, `verifying`, `accessible`, and `blocked`. It is routing health rather than application response monitoring: workload HTTP 404 or 500 responses do not make a Public Address unhealthy.
@@ -54,41 +126,13 @@ An AP with no Public Address intent has no AP Public Access Health entries; this
 
 _Avoid_: EntryPoint health, AP Public Access Node health, standalone public access monitor.
 
-### Custom Domain
+### AP Public Access Node
 
-A user-owned Public Address for an AP. A Custom Domain reaches an App Listening Port through a Custom Domain Binding.
+An AP Public Access Node is a presentation-only Project Canvas node derived from an AP's Public Addresses. It is not a Brain product resource, backend API view, Kubernetes resource, or Settings Owner.
 
-Custom Domain health uses `verifying` while DNS ownership, certificate readiness, or routing readiness is still being established. It becomes `blocked` only when the binding is known not to be able to proceed without a changed user or platform action.
+The node represents AP-owned public access, including pending Platform Addresses and Custom Domains; its user-visible label is Public access.
 
-### Routing Scope
-
-The public routing boundary within which one Custom Domain can belong to only one AP. In v1, the enforceable Routing Scope is the current Kubernetes namespace; broader cluster-wide uniqueness requires platform-level admission or indexing.
-
-### AP (Application)
-
-A Brain product resource that represents an application workload. AP owns the application's desired compute, environment, App Listening Ports, Private Addresses, and Platform Address allocation requests.
-
-### AP Workload Readiness
-
-The condition where an AP's application workload has enough running replicas to satisfy its AP Replica Strategy. AP Workload Readiness is distinct from AP Public Access Health; public routing may still be progressing after the workload is ready.
-
-_Avoid_: AP Public Access Health, Public Address readiness, route readiness.
-
-### AP Settings
-
-The primary UI surface for viewing and editing AP desired configuration, including image, resource capacity, Replica Strategy, environment, and network settings.
-
-### AP Configuration File
-
-An AP-owned configuration file mounted into the application runtime through AP Settings. AP Configuration Files are user-authored file content and mount paths, not a standalone Settings Owner.
-
-_Avoid_: ConfigMap, Config Files, configuration map.
-
-### AP Storage Mount
-
-A persistent volume an AP owns at one absolute container path, where the application's own data is kept across restarts and redeploys. An AP has zero or more AP Storage Mounts; each mount path is unique and fixed once created, and a mount's capacity can grow but never shrink. Distinct from an AP Configuration File, which mounts user-authored file content rather than application-written data.
-
-_Avoid_: Volume, PVC, disk, persistent storage, storage size.
+_Avoid_: EntryPoint, EntryPoint resource, EntryPoint API view, AP endpoints, Ingress.
 
 ### AP Network Settings
 
@@ -96,223 +140,13 @@ The AP-owned settings area for App Listening Ports, Private Addresses, Public Ad
 
 AP Network Settings may appear inside the full AP Settings surface or a narrower Settings View, but they remain one AP Settings Draft domain rather than settings owned by an AP Public Access Node.
 
-### Settings View
+### Domain List
 
-A settings entry point that presents one named subset of a resource's settings surface, containing one or more settings sections rather than necessarily showing the full settings surface. It remains part of that resource's settings surface and uses the same Settings Draft confirmation model as the full surface.
+The AP Network Settings section that lists an AP's Public Addresses — Platform Addresses and Custom Domain Bindings — with their public routing state. Domain List is a public-routing view inside the AP settings surface: it may add App Listening Ports as part of Public Address edits, but it does not display Private Addresses and is not a standalone Settings Owner.
 
-_Avoid_: Standalone Settings Section Pane, Section Pane, arbitrary section bundle.
+_Avoid_: EntryPoint list, Ingress list, domain manager.
 
-### Settings Section
-
-A coherent subset of a Settings Owner's configuration shown inside a Settings View. Settings Sections belong to their Settings Owner's settings surface and are not standalone panes, Component Registry items, or caller-selected arbitrary bundles.
-
-_Avoid_: Registry Component, product workflow, standalone settings pane.
-
-### Settings Owner
-
-The resource whose desired configuration is edited by a settings surface. AP and DB resources can be Settings Owners; selecting an AP Public Access Node may open an AP-owned Settings View, but the AP Public Access Node is not the Settings Owner.
-
-_Avoid_: EntryPoint Settings Owner, Public Access Node Settings Owner.
-
-### Settings Domain
-
-A Settings Owner configuration partition that can be independently checked for conflicts, submitted as a Pending Settings Update, reconciled against observed resource state, and cleared when applied. A Settings Domain is not a Settings Section, Settings View, or API field group.
-
-_Avoid_: Settings Section, Settings View, form tab, API field group.
-
-### Docker Deployment Settings
-
-The creation-time choices for a new AP before the AP exists, including Docker image, container launch command and arguments override, runtime environment variables, AP Configuration Files, AP Storage Mounts, App Listening Port, and whether to request a Platform Address. Docker Deployment Settings create an AP workload from an existing image, are independent of entry path, and should use Public Address or Network language rather than Ingress language in user-facing surfaces.
-
-### Deployment Task
-
-A deploy workflow work unit for creating or changing Project resources from a Deployment Source into a Deployment Target. A Deployment Task has one Deployment Runner and may produce Deployment Artifacts.
-
-_Avoid_: GitHub task, deploy job, deployment request.
-
-A Deployment Task is owned by the deployment domain, not by the Project Assistant Pane or any Chat thread. Chat may create, inspect, or explain a Deployment Task through tools, but the task's lifecycle, events, artifacts, and runner transcript remain deployment records.
-
-### Deployment Projection Slot
-
-A task-local Project Canvas slot within one Deployment Task Projection. An unknown Deployment Projection Slot represents deployment progress before structured result evidence exists; a concrete slot may carry the anticipated result identity used for Deployment Handoff, but it is not a Canvas Resource Identity.
-
-An unknown Deployment Projection Slot uses a stable unknown slot identity within its Deployment Task. A concrete Deployment Projection Slot uses an identity derived from its anticipated result reference, while the Canvas Placement Owner combines that slot identity with the Deployment Task identity.
-
-Deployment Projection Slots are only for anticipated results that can become Project Canvas resource nodes. Template support objects may inform deployment progress, but they are not Deployment Projection Slots.
-
-_Avoid_: generic placeholder identity, result-only slot, pending resource identity, fake Canvas Resource Identity, one slot per applied Kubernetes object.
-
-### Deployment Projection Footprint
-
-The visual group of currently visible Deployment Projection Slots for one Deployment Task Projection. A Deployment Projection Footprint may include AP, DB, AP Public Access Node, and template-visible workload slots from the same task; it is not limited to an AP-and-Public-access pair.
-
-An unknown Deployment Projection Slot may represent the Deployment Projection Footprint's visual origin before concrete slots are known. When concrete Deployment Projection Slots become known, the unknown slot's placement is consumed into concrete slot placements rather than remaining as a separate placement.
-
-Within a Deployment Projection Footprint, each AP Public Access Node slot remains visually paired with its owning AP slot; this pairing is independent of which slot anchors the whole footprint.
-
-An AP Public Access Node Deployment Projection Slot has its own Deployment Projection Placement. When it has no placement yet, its initial generated placement may be derived from its owning AP's resource or projection placement.
-
-AP-to-Public-access pairing guides generated placement; it does not override separately user-arranged placements.
-
-_Avoid_: AP PublicAccess group, result pair, placeholder cluster.
-
-### Deployment Placeholder Node
-
-A temporary Project Canvas skeleton node rendered for a Deployment Projection Slot that does not have a live resource node. It is a task projection, not an AP, DB, AP Public Access Node, template workload, Settings Owner, resource action target, or Canvas Connection endpoint.
-
-_Avoid_: ghost node, pending node, pending AP, pending DB, fake resource node.
-
-### Deployment Projection Placement
-
-The project-scoped temporary visual position owned by a Deployment Projection Slot before Deployment Handoff. Deployment Projection Placement is a Canvas Layout placement owned by the deployment projection, and it may be rekeyed to a resulting resource when handoff occurs.
-
-A user-arranged Deployment Projection Placement represents the user's intended visual position for that Deployment Task Projection until Deployment Handoff; it should not be displaced by automatic footprint avoidance.
-
-A generated Deployment Projection Placement is system-proposed and may be refined by later projection evidence until a user arranges it.
-
-After concrete Deployment Projection Slots are known, arranging one concrete slot expresses intent for that slot only, not for the whole Deployment Projection Footprint.
-
-_Avoid_: pending node layout, fake resource layout, viewport placement.
-
-### Deployment Preview Edge
-
-A temporary visual relationship between Deployment Projection Slots in one Deployment Task Projection. It is not a Canvas Connection and does not represent an established runtime dependency.
-
-Deployment Preview Edges require explicit preview facts, such as generated AP-to-DB reference intent, template-declared dependency, or AP-to-Public-Access presentation relationship. Sharing one Deployment Task is not enough to create a Deployment Preview Edge.
-
-_Avoid_: pending connection, fake edge, draft Canvas Connection.
-
-### Deployment Task Projection
-
-A Project-scoped read-side view of one Deployment Task containing only the facts needed by project surfaces to present deployment progress and resource handoff. It contains one or more Deployment Projection Slots and Deployment Preview Edges, but it does not own Canvas Layout positions.
-
-Project Canvas consumes Deployment Task Projections rather than full Deployment Task records when rendering Deployment Placeholder Nodes and Deployment Handoff.
-
-_Avoid_: task list row, canvas task, placeholder source data.
-
-### Deployment Handoff
-
-The transition where a concrete Deployment Projection Slot stops being represented by a Deployment Placeholder Node and its matching result appears as a normal Project Canvas resource node. Deployment Handoff may rekey the slot's Deployment Projection Placement to the resulting resource when that resource has no existing Canvas Layout position.
-
-Deployment Handoff may complete per slot while unresolved slots remain visible as Deployment Placeholder Nodes.
-
-After Deployment Handoff, the resulting resource's placement is no longer arranged by the remaining Deployment Projection Footprint.
-
-When a user-arranged Deployment Projection Placement is handed off, the resulting resource inherits that user placement intent.
-
-_Avoid_: completed placeholder, ghost replacement, result takeover.
-
-### Deployment Result Readiness
-
-The condition where the user-visible result resources of a Deployment Task have become healthy enough for the task to be considered complete. Deployment Result Readiness is distinct from applying Deployment Artifacts; support objects may explain progress, but they do not by themselves define task completion.
-
-_Avoid_: apply complete, resource created, manifest applied.
-
-### Deployment Result Resource
-
-A user-visible Project result that a Deployment Task creates or changes, such as an AP, DB, AP-owned Public Address, or template-visible workload. Support objects may explain a Deployment Result Resource's progress, but they are not Deployment Result Resources.
-
-_Avoid_: applied object, Kubernetes object, support resource, raw manifest resource.
-
-### Deployment Timeline Step
-
-A runner-defined user-facing step in a Deployment Task Timeline. A Deployment Timeline Step may summarize multiple runner or backend execution phases; it does not need to match Deployment Task phase one-to-one.
-
-A Deployment Runner should keep Deployment Timeline Step identity stable during a task run, even when the step status, events, or result details change.
-
-_Avoid_: backend phase, runner phase, task status, fixed global timeline phase.
-
-### Deployment Task Timeline
-
-The user-facing progress view for one Deployment Task. A Deployment Task Timeline is made of runner-defined Deployment Timeline Steps and may include Deployment Result Resource Cards once the task has known result resources.
-
-A Deployment Task Timeline belongs to the Deployment Task rather than to a browser session or Assistant Chat transcript.
-
-_Avoid_: assistant chat transcript, backend event log, fixed deploy progress bar.
-
-### Deployment Task Dock
-
-A Project Canvas affordance that presents the current Project's visible Deployment Task Projections so users can notice active or attention-needed deployment work and re-enter each task's Deployment Task Timeline. It is not deployment history, a task list row, a Project Canvas node, or an Assistant Chat transcript.
-
-A failed Deployment Task may remain attention-needed after its run ends until its current dock reminder is dismissed.
-
-A successfully completed Deployment Task is not attention-needed merely because its projection remains available for Project Canvas handoff.
-
-A successfully completed Deployment Task may briefly remain in the Deployment Task Dock as a current-session completion notice when the user observes it finish. This completion notice is not restored from Project bootstrap and is not deployment history.
-
-_Avoid_: canvas task list, deployment history list, task center, chat task status.
-
-### Deployment Task Dock Dismissal
-
-A personal user acknowledgement of one Deployment Task Projection version in the Deployment Task Dock. It suppresses that task's dock reminder for that user until the projection changes; it is not shared Project state, task cancellation, task completion, task deletion, deployment history archival, or timeline deletion.
-
-_Avoid_: close task, archive deployment, delete task, mark complete.
-
-### Deployment Task Display Summary
-
-A compact user-facing description of a Deployment Task used on project surfaces where full task detail would be too heavy. It summarizes the Deployment Source and known or anticipated result resources; it is not the full source record, the Deployment Task Timeline, or the Deployment Task identity.
-
-_Avoid_: task id label, source blob, timeline summary, generated title.
-
-### Deployment Result Resource Card
-
-A Deployment Task Timeline section for one Deployment Result Resource, presenting that resource's status and events within the task's progress. It is not a separate Deployment Task or a card for every applied Kubernetes object.
-
-A Deployment Result Resource Card is based on known Deployment Result Resource evidence, not on speculative canvas projection alone.
-
-Deployment Result Resource Cards use a shared task-facing status vocabulary, while their events may retain resource-specific detail.
-
-On a Deployment Result Resource Card, blocked means the task can still proceed after an external action or changed condition; failed means the current task run has ended for that resource.
-
-Deployment Result Resource Card events are grouped by the resource they explain, not primarily by the system that observed or emitted them.
-
-Required Deployment Result Resource Cards determine whether Deployment Result Readiness has been reached; optional cards may continue to show progress or warnings without blocking task completion.
-
-A Deployment Result Resource Card is not a Project Canvas node, Deployment Projection Slot, or Deployment Placeholder Node.
-
-_Avoid_: Kubernetes object card, manifest card, task row, deployment placeholder card, canvas node.
-
-### Deployment Source
-
-The user-provided origin or intent for a Deployment Task, such as a GitHub repository, Docker image, database choice, application template, or natural-language deployment prompt. A Deployment Source describes what should be deployed, not where it should land.
-
-_Avoid_: deploy input, entry path, creation method.
-
-### GitHub Connection
-
-A namespace-scoped authorization relationship that lets a workspace use a GitHub App installation to list and deploy repositories. A GitHub Connection belongs to the workspace namespace rather than one user's browser session or personal GitHub identity.
-
-_Avoid_: personal GitHub token, user GitHub binding, browser GitHub connection.
-
-### Deployment Target
-
-The Project relationship selected before a Deployment Task starts. A Deployment Target is either a new Project being created in the same flow or an existing Project that will receive the deployed resources.
-
-_Avoid_: GitHub Deployment Target, Docker Deployment Target, project selector.
-
-### Deployment Runner
-
-The execution strategy for one Deployment Task. Direct and template runners use already-structured Deployment Sources, while an AI Runner interprets less-structured sources such as repositories or natural-language prompts.
-
-_Avoid_: deterministic runner, task type, deploy engine.
-
-### Deployment Artifact
-
-A product resource description produced or selected by a Deployment Task for application into the Deployment Target. Deployment Artifacts are distinct from Deployment Source details and task progress messages.
-
-_Avoid_: task output, generated file.
-
-### AP Replica Strategy
-
-The AP configuration choice for how many workload replicas should run: either a fixed user-selected count or Elastic Scaling within user-selected bounds.
-
-### Fixed Replicas
-
-An AP Replica Strategy where the user selects one desired replica count and the platform keeps the AP at that count.
-
-### Elastic Scaling
-
-An AP Replica Strategy where the platform automatically adjusts AP replicas between a user-selected minimum and maximum based on one selected resource utilization target.
+## Database
 
 ### DB (Database)
 
@@ -321,6 +155,14 @@ A Brain product resource that represents a managed database workload available t
 ### DB Service
 
 The user-facing database service represented by one DB resource and one database node on the Project Canvas. A DB Service may expose multiple engine-level Logical Databases through DB Access.
+
+### Logical Database
+
+An engine-level database namespace exposed inside one DB Service, such as a PostgreSQL database, MySQL database, MongoDB database, or Redis database index. A Logical Database is an object browsed inside DB Access, not a Project Canvas DB resource.
+
+### DB Instance Preset
+
+A user-facing resource-size choice for DB Deployment Settings. Each DB Instance Preset maps to one DB quota value; avoid exposing internal SKU-like labels such as `db.mysql.small` as the primary UI language.
 
 ### DB Service Backup
 
@@ -334,17 +176,73 @@ The automatic backup rule for one DB Service. A DB Service has at most one curre
 
 A non-destructive workflow that creates a new DB Service from a completed DB Service Backup. A DB Service Restore does not overwrite or roll back the source DB Service; the restored DB Service appears in the same Project, must have a DB Service name that is unique within that Project and namespace, and becomes the user's next Project Canvas focus.
 
-### Logical Database
+### DB Access
 
-An engine-level database namespace exposed inside one DB Service, such as a PostgreSQL database, MySQL database, MongoDB database, or Redis database index. A Logical Database is an object browsed inside DB Access, not a Project Canvas DB resource.
+A resource workflow for inspecting, and when the product enables it editing, one DB Service's objects and data without exposing its connection credentials. DB Access is distinct from DB Settings: DB Settings changes a DB's desired configuration, while DB Access works with the Logical Databases and objects exposed by that DB Service.
 
-### DB Deployment Settings
+_Avoid_: Data Browser, database browser.
 
-The creation-time choices for a new DB before the DB exists, including database engine, instance preset, and replica count. DB Deployment Settings are independent of entry path: they may create a DB together with a new Project or add a DB to an existing Project.
+## Database Binding & AP Environment
 
-### DB Instance Preset
+### Database Binding
 
-A user-facing resource-size choice for DB Deployment Settings. Each DB Instance Preset maps to one DB quota value; avoid exposing internal SKU-like labels such as `db.mysql.small` as the primary UI language.
+A runtime dependency where an AP is configured to consume one DB's connection credentials.
+
+### Pending Database Binding Intent
+
+An unsaved AP Environment draft intent to create or update a Database Binding by adding one or more AP Environment References to a DB Service. A Pending Database Binding Intent may be visualized on the Project Canvas as a pending AP-to-DB edge, but it is not a Canvas Connection until saved AP and DB resource state contains binding evidence.
+
+A Pending Database Binding Intent is derived from explicit AP Environment References, not from ordinary user-authored DSN strings. Multiple AP Environment References from one AP Environment draft to the same DB Service collapse into one Pending Database Binding Intent, and an AP-to-DB Connecting Edge is only a shortcut for creating the same intent in AP Environment Settings.
+
+_Avoid_: Pending edge, hidden binding record, inferred string binding.
+
+### AP Environment Raw Source
+
+The canonical AP environment editing model: the complete set of AP environment entries as the user can author them in `.env` form, including direct values, AP Environment References, and runtime environment expansions. Structured AP Environment controls are views or insertion aids over the AP Environment Raw Source, not separate saved state.
+
+_Avoid_: Hidden binding metadata, editor-only environment language.
+
+### AP Environment Reference
+
+A product-level expression in the AP Environment Raw Source that points at a DB Service-provided environment value. An AP Environment Reference is resolved before runtime into ordinary AP environment entries, while the user-facing raw source may retain the reference expression.
+
+_Avoid_: UI-only token, hidden binding metadata.
+
+### DB Connection DSN
+
+A complete connection string for one DB Service, including the credentials needed by an application to connect when the DB engine requires credentials.
+
+_Avoid_: Address-only DSN, credential-free DATABASE_URL.
+
+## Settings
+
+### Settings Owner
+
+The resource whose desired configuration is edited by a settings surface. AP and DB resources can be Settings Owners; selecting an AP Public Access Node may open an AP-owned Settings View, but the AP Public Access Node is not the Settings Owner.
+
+_Avoid_: EntryPoint Settings Owner, Public Access Node Settings Owner.
+
+### Settings Domain
+
+A Settings Owner configuration partition that can be independently checked for conflicts, submitted as a Pending Settings Update, reconciled against observed resource state, and cleared when applied. A Settings Domain is not a Settings Section, Settings View, or API field group.
+
+_Avoid_: Settings Section, Settings View, form tab, API field group.
+
+### Settings View
+
+A settings entry point that presents one named subset of a resource's settings surface, containing one or more settings sections rather than necessarily showing the full settings surface. It remains part of that resource's settings surface and uses the same Settings Draft confirmation model as the full surface.
+
+_Avoid_: Standalone Settings Section Pane, Section Pane, arbitrary section bundle.
+
+### Settings Section
+
+A coherent subset of a Settings Owner's configuration shown inside a Settings View. Settings Sections belong to their Settings Owner's settings surface and are not standalone panes, Component Registry items, or caller-selected arbitrary bundles.
+
+_Avoid_: Registry Component, product workflow, standalone settings pane.
+
+### AP Settings
+
+The primary UI surface for viewing and editing AP desired configuration, including image, resource capacity, Replica Strategy, environment, and network settings.
 
 ### DB Settings
 
@@ -378,61 +276,205 @@ The condition where a Settings Owner's observed desired configuration for a Sett
 
 _Avoid_: Pending failure, automatic overwrite, silent reload.
 
-### Database Binding
+## Deployment
 
-A runtime dependency where an AP is configured to consume one DB's connection credentials.
+### Deployment Task
 
-### Pending Database Binding Intent
+A deploy workflow work unit for creating or changing Project resources from a Deployment Source into a Deployment Target. A Deployment Task has one Deployment Runner and may produce Deployment Artifacts.
 
-An unsaved AP Environment draft intent to create or update a Database Binding by adding one or more AP Environment References to a DB Service. A Pending Database Binding Intent may be visualized on the Project Canvas as a pending AP-to-DB edge, but it is not a Canvas Connection until saved AP and DB resource state contains binding evidence.
+_Avoid_: GitHub task, deploy job, deployment request.
 
-A Pending Database Binding Intent is derived from explicit AP Environment References, not from ordinary user-authored DSN strings. Multiple AP Environment References from one AP Environment draft to the same DB Service collapse into one Pending Database Binding Intent, and an AP-to-DB Connecting Edge is only a shortcut for creating the same intent in AP Environment Settings.
+A Deployment Task is owned by the deployment domain, not by the Project Assistant Pane or any Chat thread. Chat may create, inspect, or explain a Deployment Task through tools, but the task's lifecycle, events, artifacts, and runner transcript remain deployment records.
 
-_Avoid_: Pending edge, hidden binding record, inferred string binding.
+### Deployment Source
 
-### AP Environment Raw Source
+The user-provided origin or intent for a Deployment Task, such as a GitHub repository, Docker image, database choice, application template, or natural-language deployment prompt. A Deployment Source describes what should be deployed, not where it should land.
 
-The canonical AP environment editing model: the complete set of AP environment entries as the user can author them in `.env` form, including direct values, AP Environment References, and runtime environment expansions. Structured AP Environment controls are views or insertion aids over the AP Environment Raw Source, not separate saved state.
+_Avoid_: deploy input, entry path, creation method.
 
-_Avoid_: Hidden binding metadata, editor-only environment language.
+### Deployment Target
 
-### AP Environment Reference
+The Project relationship selected before a Deployment Task starts. A Deployment Target is either a new Project being created in the same flow or an existing Project that will receive the deployed resources.
 
-A product-level expression in the AP Environment Raw Source that points at a DB Service-provided environment value. An AP Environment Reference is resolved before runtime into ordinary AP environment entries, while the user-facing raw source may retain the reference expression.
+_Avoid_: GitHub Deployment Target, Docker Deployment Target, project selector.
 
-_Avoid_: UI-only token, hidden binding metadata.
+### Deployment Runner
 
-### DB Connection DSN
+The execution strategy for one Deployment Task. Direct and template runners use already-structured Deployment Sources, while an AI Runner interprets less-structured sources such as repositories or natural-language prompts.
 
-A complete connection string for one DB Service, including the credentials needed by an application to connect when the DB engine requires credentials.
+_Avoid_: deterministic runner, task type, deploy engine.
 
-_Avoid_: Address-only DSN, credential-free DATABASE_URL.
+### Deployment Artifact
 
-### DB Access
+A product resource description produced or selected by a Deployment Task for application into the Deployment Target. Deployment Artifacts are distinct from Deployment Source details and task progress messages.
 
-A resource workflow for inspecting, and when the product enables it editing, one DB Service's objects and data without exposing its connection credentials. DB Access is distinct from DB Settings: DB Settings changes a DB's desired configuration, while DB Access works with the Logical Databases and objects exposed by that DB Service.
+_Avoid_: task output, generated file.
 
-_Avoid_: Data Browser, database browser.
+### GitHub Connection
 
-### DB Terminal
+A namespace-scoped authorization relationship that lets a workspace use a GitHub App installation to list and deploy repositories. A GitHub Connection belongs to the workspace namespace rather than one user's browser session or personal GitHub identity.
 
-An interactive terminal session that runs a DB Service's native engine client — such as `psql`, `mysql`, `mongosh`, or `redis-cli` — for ad-hoc, read-write commands against that DB Service. A DB Terminal is distinct from DB Access: DB Access is a structured object and data workflow, while a DB Terminal is a full interactive engine-client session. It is usable only for engines that ship a supported client and only while the DB Service is running; on engines without a supported client it is presented as an Unavailable Resource Affordance rather than omitted.
+_Avoid_: personal GitHub token, user GitHub binding, browser GitHub connection.
 
-_Avoid_: DB Console, console.
+### Docker Deployment Settings
 
-### AP Terminal
+The creation-time choices for a new AP before the AP exists, including Docker image, container launch command and arguments override, runtime environment variables, AP Configuration Files, AP Storage Mounts, App Listening Port, and whether to request a Platform Address. Docker Deployment Settings create an AP workload from an existing image, are independent of entry path, and should use Public Address or Network language rather than Ingress language in user-facing surfaces.
 
-An interactive terminal session that opens a generic pod shell on an AP workload. An AP Terminal is distinct from a DB Terminal: both are terminals in the UI, but an AP Terminal is a workload shell while a DB Terminal is a database engine-client session.
+### DB Deployment Settings
 
-_Avoid_: AP Console, console.
+The creation-time choices for a new DB before the DB exists, including database engine, instance preset, and replica count. DB Deployment Settings are independent of entry path: they may create a DB together with a new Project or add a DB to an existing Project.
 
-### Session Drawer
+### Deployment Task Projection
 
-A bottom temporary project surface for one interactive resource session, such as an AP Terminal or DB Terminal. A Session Drawer is distinct from a Side Pane and may remain open while the user inspects resource details in a Side Pane.
+A Project-scoped read-side view of one Deployment Task containing only the facts needed by project surfaces to present deployment progress and resource handoff. It contains one or more Deployment Projection Slots and Deployment Preview Edges, but it does not own Canvas Layout positions.
+
+Project Canvas consumes Deployment Task Projections rather than full Deployment Task records when rendering Deployment Placeholder Nodes and Deployment Handoff.
+
+_Avoid_: task list row, canvas task, placeholder source data.
+
+### Deployment Projection Slot
+
+A task-local Project Canvas slot within one Deployment Task Projection. An unknown Deployment Projection Slot represents deployment progress before structured result evidence exists; a concrete slot may carry the anticipated result identity used for Deployment Handoff, but it is not a Canvas Resource Identity.
+
+An unknown Deployment Projection Slot uses a stable unknown slot identity within its Deployment Task. A concrete Deployment Projection Slot uses an identity derived from its anticipated result reference, while the Canvas Placement Owner combines that slot identity with the Deployment Task identity.
+
+Deployment Projection Slots are only for anticipated results that can become Project Canvas resource nodes. Template support objects may inform deployment progress, but they are not Deployment Projection Slots.
+
+_Avoid_: generic placeholder identity, result-only slot, pending resource identity, fake Canvas Resource Identity, one slot per applied Kubernetes object.
+
+### Deployment Projection Footprint
+
+The visual group of currently visible Deployment Projection Slots for one Deployment Task Projection. A Deployment Projection Footprint may include AP, DB, AP Public Access Node, and template-visible workload slots from the same task; it is not limited to an AP-and-Public-access pair.
+
+An unknown Deployment Projection Slot may represent the Deployment Projection Footprint's visual origin before concrete slots are known. When concrete Deployment Projection Slots become known, the unknown slot's placement is consumed into concrete slot placements rather than remaining as a separate placement.
+
+Within a Deployment Projection Footprint, each AP Public Access Node slot remains visually paired with its owning AP slot; this pairing is independent of which slot anchors the whole footprint.
+
+An AP Public Access Node Deployment Projection Slot has its own Deployment Projection Placement. When it has no placement yet, its initial generated placement may be derived from its owning AP's resource or projection placement.
+
+AP-to-Public-access pairing guides generated placement; it does not override separately user-arranged placements.
+
+_Avoid_: AP PublicAccess group, result pair, placeholder cluster.
+
+### Deployment Projection Placement
+
+The project-scoped temporary visual position owned by a Deployment Projection Slot before Deployment Handoff. Deployment Projection Placement is a Canvas Layout placement owned by the deployment projection, and it may be rekeyed to a resulting resource when handoff occurs.
+
+A user-arranged Deployment Projection Placement represents the user's intended visual position for that Deployment Task Projection until Deployment Handoff; it should not be displaced by automatic footprint avoidance.
+
+A generated Deployment Projection Placement is system-proposed and may be refined by later projection evidence until a user arranges it.
+
+After concrete Deployment Projection Slots are known, arranging one concrete slot expresses intent for that slot only, not for the whole Deployment Projection Footprint.
+
+_Avoid_: pending node layout, fake resource layout, viewport placement.
+
+### Deployment Placeholder Node
+
+A temporary Project Canvas skeleton node rendered for a Deployment Projection Slot that does not have a live resource node. It is a task projection, not an AP, DB, AP Public Access Node, template workload, Settings Owner, resource action target, or Canvas Connection endpoint.
+
+_Avoid_: ghost node, pending node, pending AP, pending DB, fake resource node.
+
+### Deployment Preview Edge
+
+A temporary visual relationship between Deployment Projection Slots in one Deployment Task Projection. It is not a Canvas Connection and does not represent an established runtime dependency.
+
+Deployment Preview Edges require explicit preview facts, such as generated AP-to-DB reference intent, template-declared dependency, or AP-to-Public-Access presentation relationship. Sharing one Deployment Task is not enough to create a Deployment Preview Edge.
+
+_Avoid_: pending connection, fake edge, draft Canvas Connection.
+
+### Deployment Handoff
+
+The transition where a concrete Deployment Projection Slot stops being represented by a Deployment Placeholder Node and its matching result appears as a normal Project Canvas resource node. Deployment Handoff may rekey the slot's Deployment Projection Placement to the resulting resource when that resource has no existing Canvas Layout position.
+
+Deployment Handoff may complete per slot while unresolved slots remain visible as Deployment Placeholder Nodes.
+
+After Deployment Handoff, the resulting resource's placement is no longer arranged by the remaining Deployment Projection Footprint.
+
+When a user-arranged Deployment Projection Placement is handed off, the resulting resource inherits that user placement intent.
+
+_Avoid_: completed placeholder, ghost replacement, result takeover.
+
+### Deployment Result Resource
+
+A user-visible Project result that a Deployment Task creates or changes, such as an AP, DB, AP-owned Public Address, or template-visible workload. Support objects may explain a Deployment Result Resource's progress, but they are not Deployment Result Resources.
+
+_Avoid_: applied object, Kubernetes object, support resource, raw manifest resource.
+
+### Deployment Result Readiness
+
+The condition where the user-visible result resources of a Deployment Task have become healthy enough for the task to be considered complete. Deployment Result Readiness is distinct from applying Deployment Artifacts; support objects may explain progress, but they do not by themselves define task completion.
+
+_Avoid_: apply complete, resource created, manifest applied.
+
+### Deployment Timeline Step
+
+A runner-defined user-facing step in a Deployment Task Timeline. A Deployment Timeline Step may summarize multiple runner or backend execution phases; it does not need to match Deployment Task phase one-to-one.
+
+A Deployment Runner should keep Deployment Timeline Step identity stable during a task run, even when the step status, events, or result details change.
+
+_Avoid_: backend phase, runner phase, task status, fixed global timeline phase.
+
+### Deployment Task Timeline
+
+The user-facing progress view for one Deployment Task. A Deployment Task Timeline is made of runner-defined Deployment Timeline Steps and may include Deployment Result Resource Cards once the task has known result resources.
+
+A Deployment Task Timeline belongs to the Deployment Task rather than to a browser session or Assistant Chat transcript.
+
+_Avoid_: assistant chat transcript, backend event log, fixed deploy progress bar.
+
+### Deployment Result Resource Card
+
+A Deployment Task Timeline section for one Deployment Result Resource, presenting that resource's status and events within the task's progress. It is not a separate Deployment Task or a card for every applied Kubernetes object.
+
+A Deployment Result Resource Card is based on known Deployment Result Resource evidence, not on speculative canvas projection alone.
+
+Deployment Result Resource Cards use a shared task-facing status vocabulary, while their events may retain resource-specific detail.
+
+On a Deployment Result Resource Card, blocked means the task can still proceed after an external action or changed condition; failed means the current task run has ended for that resource.
+
+Deployment Result Resource Card events are grouped by the resource they explain, not primarily by the system that observed or emitted them.
+
+Required Deployment Result Resource Cards determine whether Deployment Result Readiness has been reached; optional cards may continue to show progress or warnings without blocking task completion.
+
+A Deployment Result Resource Card is not a Project Canvas node, Deployment Projection Slot, or Deployment Placeholder Node.
+
+_Avoid_: Kubernetes object card, manifest card, task row, deployment placeholder card, canvas node.
+
+### Deployment Task Display Summary
+
+A compact user-facing description of a Deployment Task used on project surfaces where full task detail would be too heavy. It summarizes the Deployment Source and known or anticipated result resources; it is not the full source record, the Deployment Task Timeline, or the Deployment Task identity.
+
+_Avoid_: task id label, source blob, timeline summary, generated title.
+
+### Deployment Task Dock
+
+A Project Canvas affordance that presents the current Project's visible Deployment Task Projections so users can notice active or attention-needed deployment work and re-enter each task's Deployment Task Timeline. It is not deployment history, a task list row, a Project Canvas node, or an Assistant Chat transcript.
+
+A failed Deployment Task may remain attention-needed after its run ends until its current dock reminder is dismissed.
+
+A successfully completed Deployment Task is not attention-needed merely because its projection remains available for Project Canvas handoff.
+
+A successfully completed Deployment Task may briefly remain in the Deployment Task Dock as a current-session completion notice when the user observes it finish. This completion notice is not restored from Project bootstrap and is not deployment history.
+
+_Avoid_: canvas task list, deployment history list, task center, chat task status.
+
+### Deployment Task Dock Dismissal
+
+A personal user acknowledgement of one Deployment Task Projection version in the Deployment Task Dock. It suppresses that task's dock reminder for that user until the projection changes; it is not shared Project state, task cancellation, task completion, task deletion, deployment history archival, or timeline deletion.
+
+_Avoid_: close task, archive deployment, delete task, mark complete.
+
+## Project Runtime & Read Model
 
 ### Project Runtime
 
 The Project-scoped read-side boundary that Project surfaces use to interpret current resource presentation facts and session-local launch context. Project Runtime is not the Project Canvas, a Settings Owner, or the source of editable AP or DB desired configuration.
+
+### Project Resource Read Model
+
+The app-owned Project Runtime view of current AP, DB, and AP Public Access Node presentation facts. The Project Resource Read Model is read-side presentation knowledge, not raw resource truth, Canvas Layout, Settings Draft state, or a resource action command bus.
+
+It may provide Settings display hints and relationship indexes, but those read-side hints do not identify the Settings Owner and are not editable Settings backing or Settings Launch Context.
 
 ### Settings Launch Context
 
@@ -444,15 +486,19 @@ A Settings Launch Context belongs to one active Project surface slot and one ful
 
 Route restoration may create a current-session launch source for the restored entry, but it does not restore transient bridge intent.
 
-### Project Resource Read Model
-
-The app-owned Project Runtime view of current AP, DB, AP Public Access Node, and template-native workload presentation facts. The Project Resource Read Model is read-side presentation knowledge, not raw resource truth, Canvas Layout, Settings Draft state, or a resource action command bus.
-
-It may provide Settings display hints and relationship indexes, but those read-side hints do not identify the Settings Owner and are not editable Settings backing or Settings Launch Context.
+## Project Canvas
 
 ### Container Node
 
 A canvas node that represents an AP workload. The name is retained as a product/UI term, but it does not mean an individual Kubernetes container.
+
+### Canvas Resource Identity
+
+The product identity of a canvas node's backing AP, DB, or AP Public Access Node surface. Canvas Resource Identity is keyed by `kind`, `namespace`, and `name`, which keeps Canvas Layout stable across short reconciliation gaps.
+
+For AP and DB nodes, `name` is the product resource name and also the primary underlying workload or Cluster name used by the Brain renderer. For AP Public Access Nodes, `name` is the associated AP name: the node represents that AP's Public Addresses surface, including pending allocation state.
+
+Underlying Kubernetes UID is retained separately as the last-seen entity identity where available so the UI can detect when a same-named AP workload or DB Cluster is meaningfully new. AP Public Access Nodes use AP-bound identity and observed public access facts rather than their own Kubernetes UID.
 
 ### Canvas Layout
 
@@ -536,13 +582,15 @@ The Project Canvas interaction mode for browsing the canvas by moving the viewpo
 
 Canvas Hand Mode preserves the current canvas selection and active project surfaces, and does not change Canvas Layout. Canvas interaction mode is session-local and is not part of URL state or Canvas Layout.
 
-### Canvas Resource Identity
+### Canvas Connection
 
-The product identity of a canvas node's backing AP, DB, or AP Public Access Node surface. Canvas Resource Identity is keyed by `kind`, `namespace`, and `name`, which keeps Canvas Layout stable across short reconciliation gaps.
+A canvas edge that represents an established runtime dependency between resources.
 
-For AP and DB nodes, `name` is the product resource name and also the primary underlying workload or Cluster name used by the Brain renderer. For AP Public Access Nodes, `name` is the associated AP name: the node represents that AP's Public Addresses surface, including pending allocation state.
+Canvas Connections are derived from saved resource state. Removing Database Binding evidence in an unsaved AP Environment draft does not remove or hide the established AP-to-DB Canvas Connection before the AP environment update succeeds.
 
-Underlying Kubernetes UID is retained separately as the last-seen entity identity where available so the UI can detect when a same-named AP workload or DB Cluster is meaningfully new. AP Public Access Nodes use AP-bound identity and observed public access facts rather than their own Kubernetes UID.
+### Connecting Edge
+
+A temporary canvas interaction created when a user drags a line between canvas nodes. A Connecting Edge may become a domain command only when its endpoints match a supported resource relationship, regardless of drag direction.
 
 ### Canvas Node Expansion State
 
@@ -552,11 +600,7 @@ The per-node expanded or collapsed presentation state of a canvas node card.
 
 The per-node visual layering order used when canvas node cards overlap.
 
-### Canvas Connection
-
-A canvas edge that represents an established runtime dependency between resources.
-
-Canvas Connections are derived from saved resource state. Removing Database Binding evidence in an unsaved AP Environment draft does not remove or hide the established AP-to-DB Canvas Connection before the AP environment update succeeds.
+## Resource Actions & Affordances
 
 ### Resource Action
 
@@ -594,15 +638,21 @@ The reason an Unavailable Resource Affordance cannot currently be used, expresse
 
 _Avoid_: generic unavailable state, silent disabled state.
 
-### Main Action Surface
-
-A temporary project surface opened for focused resource work, occupying the project main area rather than the Project Assistant Pane. A Main Action Surface is distinct from a Side Pane because it is not a right-side inspection surface and may host different action-specific experiences over time.
+## Project Surfaces
 
 ### Side Pane
 
 A non-modal, temporary project surface used for focused project work such as resource inspection, settings, or deployment flows.
 
 A Side Pane is distinct from the Project Assistant Pane: the Project Assistant Pane is a persistent layout region for chat, while a Side Pane is a temporary surface triggered by a user action or assistant action.
+
+### Main Action Surface
+
+A temporary project surface opened for focused resource work, occupying the project main area rather than the Project Assistant Pane. A Main Action Surface is distinct from a Side Pane because it is not a right-side inspection surface and may host different action-specific experiences over time.
+
+### Session Drawer
+
+A bottom temporary project surface for one interactive resource session, such as an AP Terminal or DB Terminal. A Session Drawer is distinct from a Side Pane and may remain open while the user inspects resource details in a Side Pane.
 
 ### Project Assistant Pane
 
@@ -615,6 +665,48 @@ A per-device personal presentation preference for how wide the docked Project As
 While the user is resizing the Project Assistant Pane, Canvas Viewport Focus keeps following its target within the shrinking or growing canvas area; resizing does not count as the user taking manual control of the viewport.
 
 _Avoid_: chat pane size, pane layout, shared pane width, Canvas Layout width.
+
+## Sessions & Observability
+
+### AP Terminal
+
+An interactive terminal session that opens a generic pod shell on an AP workload. An AP Terminal is distinct from a DB Terminal: both are terminals in the UI, but an AP Terminal is a workload shell while a DB Terminal is a database engine-client session.
+
+_Avoid_: AP Console, console.
+
+### DB Terminal
+
+An interactive terminal session that runs a DB Service's native engine client — such as `psql`, `mysql`, `mongosh`, or `redis-cli` — for ad-hoc, read-write commands against that DB Service. A DB Terminal is distinct from DB Access: DB Access is a structured object and data workflow, while a DB Terminal is a full interactive engine-client session. It is usable only for engines that ship a supported client and only while the DB Service is running; on engines without a supported client it is presented as an Unavailable Resource Affordance rather than omitted.
+
+_Avoid_: DB Console, console.
+
+### Resource Logs
+
+A read-only Main Action Surface for inspecting timestamped runtime output emitted by one AP or DB Service. Resource Logs are for recent or historical observation, not for interactive commands like AP Terminal or DB Terminal.
+
+### Live Log Window
+
+The Resource Logs viewing state whose window is anchored to the present: it always covers the trailing relative span and keeps following newly emitted output. Choosing a relative span means entering or staying in this state; Resource Logs are always in exactly one of Live Log Window or Frozen Log Window.
+
+_Avoid_: realtime toggle, auto-refresh interval, live mode flag, refresh switch.
+
+### Frozen Log Window
+
+The Resource Logs viewing state whose window is anchored to fixed wall-clock bounds and never moves on its own. Pausing a Live Log Window enters it by materializing the window bounds at that instant; applying an absolute range enters it directly. A Frozen Log Window is always described by its actual start and end, never as a relative span.
+
+_Avoid_: custom range, paused relative range, snapshot mode, static last-hour view.
+
+### Workload Telemetry Series
+
+A normalized time-series representation of workload resource usage for AP and DB workloads. It is consumed by both compact canvas node summaries and detailed metrics panels.
+
+### Workload Telemetry Snapshot
+
+A latest-point summary of workload resource usage for one AP or DB workload. It is observational read-side data for compact resource presentation, not Canvas topology, Canvas Layout, Canvas Resource Identity, or resource lifecycle state.
+
+_Avoid_: metric refresh, node state, resource status.
+
+## Assistant & Billing
 
 ### Chat Billing Mode
 
@@ -642,72 +734,14 @@ A user-scoped API key minted from the caller's kubeconfig through the `aiproxy-w
 
 _Avoid_: system token, platform key, service account token.
 
-### Connecting Edge
+## Design System
 
-A temporary canvas interaction created when a user drags a line between canvas nodes. A Connecting Edge may become a domain command only when its endpoints match a supported resource relationship, regardless of drag direction.
+### Component Registry
 
-### Workload Telemetry Series
+An internal catalog for reusable UI components in the product design system. It is not a catalog for complete product surfaces, panes, or workflows.
 
-A normalized time-series representation of workload resource usage for AP and DB workloads. It is consumed by both compact canvas node summaries and detailed metrics panels.
+### Registry Component
 
-### Workload Telemetry Snapshot
+A reusable UI component eligible for the Component Registry. A Registry Component may carry product vocabulary, but it must be driven by a host surface and must not own a complete product workflow or settings lifecycle.
 
-A latest-point summary of workload resource usage for one AP or DB workload. It is observational read-side data for compact resource presentation, not Canvas topology, Canvas Layout, Canvas Resource Identity, or resource lifecycle state.
-
-_Avoid_: metric refresh, node state, resource status.
-
-### Resource Logs
-
-A read-only Main Action Surface for inspecting timestamped runtime output emitted by one AP or DB Service. Resource Logs are for recent or historical observation, not for interactive commands like AP Terminal or DB Terminal.
-
-### Live Log Window
-
-The Resource Logs viewing state whose window is anchored to the present: it always covers the trailing relative span and keeps following newly emitted output. Choosing a relative span means entering or staying in this state; Resource Logs are always in exactly one of Live Log Window or Frozen Log Window.
-
-_Avoid_: realtime toggle, auto-refresh interval, live mode flag, refresh switch.
-
-### Frozen Log Window
-
-The Resource Logs viewing state whose window is anchored to fixed wall-clock bounds and never moves on its own. Pausing a Live Log Window enters it by materializing the window bounds at that instant; applying an absolute range enters it directly. A Frozen Log Window is always described by its actual start and end, never as a relative span.
-
-_Avoid_: custom range, paused relative range, snapshot mode, static last-hour view.
-
-### Project Aggregate Status
-
-A derived health tone for one Project row in the project list, computed from the phases of the Project's APs and DBs. It is not a persisted field on the Project product record; it is computed from sibling workload lists. It expresses "are the workloads inside this project healthy", which is what users look at on the list, and is distinct from whether the Project record itself exists.
-
-### Project Display Name
-
-The human-facing Project name shown in navigation, project chrome, project creation forms, and human confirmation prompts. It is stored on the Brain Project product record and is unique within a namespace after trimming surrounding whitespace and comparing case-insensitively. Avoid using Project name as a selector; stable identity uses Project ID.
-
-### Pinned Project
-
-A current-user navigation preference that marks one Project for prominent access from product navigation. Pinned Projects are a small user-curated shortcut set, not a complete Project list; each entry points to Project ID and is not a shared Project property, Project Aggregate Status, recent Project, or workload lifecycle state.
-
-_Avoid_: Favorite Project, starred Project, recent Project, sidebar Project.
-
-### Last Viewed Unpinned Project Shortcut
-
-A current-user navigation memory for the most recently opened unpinned Project in a namespace. It can remain visible while the user navigates to Pinned Projects or non-Project sidebar destinations, but it is not a Pinned Project, complete recent-project list, shared Project property, Project Aggregate Status, or workload lifecycle state.
-
-When the Last Viewed Unpinned Project becomes a Pinned Project, it leaves this shortcut slot rather than falling back to an older Project.
-
-_Avoid_: Current Project Shortcut, auto-pinned Project, recent Project, temporary Pinned Project, last viewed Pinned Project.
-
-### Project Shortcut Icon
-
-A presentation-only icon shown on a Project navigation shortcut. It may use a representative workload inside the Project as its visual source, but it is not Project identity, Project Aggregate Status, a persisted Project field, or a workload lifecycle state.
-
-_Avoid_: Project identity icon, Project status icon, workload status icon.
-
-### Custom Domain Binding
-
-The relationship that attaches a Custom Domain to an AP by promoting one Platform Address as the CNAME target. The AP owns the user's binding intent and public access health; the AP Public Access Node only presents that AP-owned public access state on the canvas.
-
-A Custom Domain Binding targets the App Listening Port selected on the promoted Platform Address. Binding a Custom Domain may also retarget that promoted Platform Address to a different App Listening Port.
-
-Unbinding a Custom Domain removes that relationship and returns the promoted Platform Address to ordinary display; it does not delete the Platform Address or close public access.
-
-### CNAME Verification Evidence
-
-The remembered fact that a Custom Domain pointed to the promoted Platform Address when the Custom Domain Binding was submitted. It belongs to the Custom Domain Binding intent lifecycle and is not ongoing DNS monitoring.
+_Avoid_: Product Surface Registry, Pane Registry, Flow Registry.

--- a/apps/ui/src/features/project-canvas/layout/auto-layout.test.ts
+++ b/apps/ui/src/features/project-canvas/layout/auto-layout.test.ts
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { Node } from "@xyflow/react";
+
+import type { CanvasDetectedConnection } from "../flow/detected-connections";
+import {
+  CANVAS_CONTAINER_NODE_TYPE,
+  CANVAS_DATABASE_NODE_TYPE,
+  CANVAS_DEPLOYMENT_PLACEHOLDER_NODE_TYPE,
+} from "../nodes/constants";
+import {
+  autoLayoutCanvasNodes,
+  type CanvasAutoLayoutResult,
+} from "./auto-layout";
+import { DEPLOYMENT_UNKNOWN_SLOT_ID } from "./placement-owner";
+import type { CanvasLayoutPosition } from "./types";
+
+function apNode(
+  name: string,
+  position: Node["position"],
+  layout?: Record<string, unknown>
+): Node {
+  return {
+    data: {
+      ...(layout === undefined ? {} : { layout }),
+      states: {
+        name,
+        namespace: "default",
+      },
+    },
+    id: `ap-${name}`,
+    position,
+    type: CANVAS_CONTAINER_NODE_TYPE,
+  };
+}
+
+function dbNode(name: string, position: Node["position"]): Node {
+  return {
+    data: {
+      connections: [],
+      states: { name },
+      workload: {
+        name,
+        namespace: "default",
+      },
+    },
+    id: `db-${name}`,
+    position,
+    type: CANVAS_DATABASE_NODE_TYPE,
+  };
+}
+
+function placedDeploymentPlaceholderNode(
+  name: string,
+  position: Node["position"]
+): Node {
+  return {
+    data: {
+      hasProjectionPlacement: true,
+      slotId: DEPLOYMENT_UNKNOWN_SLOT_ID,
+      taskId: name,
+    },
+    id: `deployment-placeholder-${name}`,
+    position,
+    type: CANVAS_DEPLOYMENT_PLACEHOLDER_NODE_TYPE,
+  };
+}
+
+const apToDbConnection: CanvasDetectedConnection = {
+  kind: "APToDB",
+  source: { kind: "AP", name: "api", namespace: "default" },
+  target: { kind: "DB", name: "postgres", namespace: "default" },
+};
+
+function resourceLayoutPositionByName(
+  result: CanvasAutoLayoutResult
+): Map<string, CanvasLayoutPosition> {
+  return new Map(
+    result.layoutNodes.flatMap((node) =>
+      node.owner.kind === "resource"
+        ? [[node.owner.ref.name, node.position] as const]
+        : []
+    )
+  );
+}
+
+function movedPosition(
+  result: CanvasAutoLayoutResult,
+  nodeId: string
+): CanvasLayoutPosition | undefined {
+  for (const change of result.positionChanges) {
+    if (
+      change.type === "position" &&
+      change.id === nodeId &&
+      change.position !== undefined
+    ) {
+      return change.position;
+    }
+  }
+  return undefined;
+}
+
+test("regenerates every position and anchors connected DBs beside their APs", () => {
+  const result = autoLayoutCanvasNodes({
+    connections: [apToDbConnection],
+    nodes: [
+      apNode("api", { x: 500, y: 700 }),
+      dbNode("postgres", { x: -50, y: 120 }),
+    ],
+  });
+
+  const positions = resourceLayoutPositionByName(result);
+  const apPosition = positions.get("api");
+  const dbPosition = positions.get("postgres");
+  assert.notEqual(apPosition, undefined);
+  assert.deepEqual(dbPosition, {
+    x: (apPosition?.x ?? 0) + 340,
+    y: apPosition?.y ?? 0,
+  });
+  assert.equal(result.positionChanges.length, 2);
+  assert.deepEqual(movedPosition(result, "ap-api"), apPosition);
+  assert.deepEqual(movedPosition(result, "db-postgres"), dbPosition);
+  assert.equal(
+    result.layoutNodes.every((node) => node.source === "generated"),
+    true
+  );
+});
+
+test("is idempotent once nodes sit at their generated positions", () => {
+  const nodes = [
+    apNode("api", { x: 500, y: 700 }),
+    dbNode("postgres", { x: -50, y: 120 }),
+  ];
+  const first = autoLayoutCanvasNodes({
+    connections: [apToDbConnection],
+    nodes,
+  });
+  const settled = nodes.map((node) => {
+    const position = movedPosition(first, node.id);
+    return position === undefined ? node : { ...node, position };
+  });
+
+  const second = autoLayoutCanvasNodes({
+    connections: [apToDbConnection],
+    nodes: settled,
+  });
+
+  assert.equal(second.positionChanges.length, 0);
+  assert.deepEqual(
+    resourceLayoutPositionByName(second),
+    resourceLayoutPositionByName(first)
+  );
+});
+
+test("carries expansion and stack order into the persisted layout nodes", () => {
+  const result = autoLayoutCanvasNodes({
+    nodes: [
+      apNode("api", { x: 500, y: 700 }, { expanded: false, stackOrder: 3 }),
+    ],
+  });
+
+  const [entry] = result.layoutNodes;
+  assert.equal(entry?.expanded, false);
+  assert.equal(entry?.stackOrder, 3);
+  assert.equal(entry?.source, "generated");
+});
+
+test("keeps placed deployment placeholders in place and out of the persisted layout", () => {
+  const placeholderPosition = { x: 40, y: 60 };
+  const result = autoLayoutCanvasNodes({
+    nodes: [
+      placedDeploymentPlaceholderNode("task-1", placeholderPosition),
+      apNode("api", { x: 40, y: 60 }),
+    ],
+  });
+
+  assert.equal(
+    movedPosition(result, "deployment-placeholder-task-1"),
+    undefined
+  );
+  assert.equal(
+    result.layoutNodes.some(
+      (node) => node.owner.kind === "deploymentProjection"
+    ),
+    false
+  );
+  const apPosition = resourceLayoutPositionByName(result).get("api");
+  assert.notDeepEqual(apPosition, placeholderPosition);
+});

--- a/apps/ui/src/features/project-canvas/layout/auto-layout.ts
+++ b/apps/ui/src/features/project-canvas/layout/auto-layout.ts
@@ -1,0 +1,60 @@
+import type { Node, NodeChange } from "@xyflow/react";
+
+import type { CanvasDetectedConnection } from "../flow/detected-connections";
+import { canvasLayoutNodeFromNode } from "./merge";
+import { placeCanvasNodesWithLayout } from "./placement";
+import { canvasLayoutNodeKey } from "./placement-owner";
+import type { CanvasLayoutNode } from "./types";
+
+export interface CanvasAutoLayoutResult {
+  /** Regenerated Canvas Layout entries to persist, one per placement owner. */
+  layoutNodes: CanvasLayoutNode[];
+  /** React Flow position changes that move rendered nodes to the new layout. */
+  positionChanges: NodeChange[];
+}
+
+/**
+ * Whole-canvas auto-layout: regenerates a Generated Canvas Position for every
+ * rendered node, ignoring existing Canvas Layout positions. Unlike
+ * Incremental Canvas Placement this intentionally reinterprets user-arranged
+ * structure, so it must only run from an explicit user gesture. Expansion,
+ * stack order, and resource identity carry over; only positions change.
+ */
+export function autoLayoutCanvasNodes(input: {
+  connections?: readonly CanvasDetectedConnection[];
+  nodes: readonly Node[];
+}): CanvasAutoLayoutResult {
+  const { nodes: placedNodes, placedLayoutNodes } = placeCanvasNodesWithLayout({
+    connections: input.connections,
+    layout: undefined,
+    nodes: [...input.nodes],
+  });
+
+  const positionChanges: NodeChange[] = [];
+  placedNodes.forEach((node, index) => {
+    const current = input.nodes[index];
+    if (
+      current === undefined ||
+      (node.position.x === current.position.x &&
+        node.position.y === current.position.y)
+    ) {
+      return;
+    }
+    positionChanges.push({
+      id: node.id,
+      position: { x: node.position.x, y: node.position.y },
+      type: "position",
+    });
+  });
+
+  const placedOwnerKeys = new Set(placedLayoutNodes.map(canvasLayoutNodeKey));
+  const layoutNodes = placedNodes.flatMap((node) => {
+    const layoutNode = canvasLayoutNodeFromNode(node, { source: "generated" });
+    return layoutNode !== undefined &&
+      placedOwnerKeys.has(canvasLayoutNodeKey(layoutNode))
+      ? [layoutNode]
+      : [];
+  });
+
+  return { layoutNodes, positionChanges };
+}

--- a/apps/ui/src/features/project-canvas/workbench/project-canvas-page-shell.tsx
+++ b/apps/ui/src/features/project-canvas/workbench/project-canvas-page-shell.tsx
@@ -47,6 +47,7 @@ interface ProjectCanvasViewportProps {
   kubeconfig: string;
   lifecycleActivity?: CanvasLifecycleActivityStore;
   meta?: CanvasMeta;
+  onAutoLayout?: () => void;
   runtimeStore: ProjectRuntimeStore;
 }
 
@@ -57,6 +58,7 @@ export const ProjectCanvasViewport = memo(function ProjectCanvasViewport({
   kubeconfig,
   lifecycleActivity,
   meta,
+  onAutoLayout,
   runtimeStore,
 }: ProjectCanvasViewportProps) {
   return (
@@ -76,7 +78,7 @@ export const ProjectCanvasViewport = memo(function ProjectCanvasViewport({
             >
               <Canvas.Flow>
                 <Canvas.MiniMap />
-                <Canvas.Controls />
+                <Canvas.Controls onAutoLayout={onAutoLayout} />
               </Canvas.Flow>
             </Canvas.Root>
           </ProjectCanvasInteractionStoreProvider>

--- a/apps/ui/src/features/project-canvas/workbench/project-canvas-workbench.tsx
+++ b/apps/ui/src/features/project-canvas/workbench/project-canvas-workbench.tsx
@@ -83,6 +83,7 @@ export function ProjectCanvasWorkbench({
               kubeconfig={kubeconfig}
               lifecycleActivity={projectCanvas.canvas.lifecycleActivityStore}
               meta={projectCanvas.canvas.meta}
+              onAutoLayout={projectCanvas.canvas.autoLayout}
               runtimeStore={projectCanvas.canvas.runtimeStore}
             />
           </Activity>

--- a/apps/ui/src/features/project-canvas/workbench/use-project-canvas-module.ts
+++ b/apps/ui/src/features/project-canvas/workbench/use-project-canvas-module.ts
@@ -18,7 +18,10 @@ import {
 } from "@/features/project-canvas/flow/pending-connections";
 import { isCanvasNodeGeneratedPosition } from "@/features/project-canvas/layout/placement";
 import { resourcePlacementOwner } from "@/features/project-canvas/layout/placement-owner";
-import type { CanvasLayoutResourceRef } from "@/features/project-canvas/layout/types";
+import type {
+  CanvasLayoutNode,
+  CanvasLayoutResourceRef,
+} from "@/features/project-canvas/layout/types";
 import { useProjectCanvasLayout } from "@/features/project-canvas/layout/use-project-canvas-layout";
 import { isDeploymentPlaceholderNode } from "@/features/project-canvas/snapshot/deployment-placeholder-nodes";
 import { deploymentProjectionPlacementNodesFromPlaceholderNode } from "@/features/project-canvas/snapshot/deployment-placement-commands";
@@ -295,6 +298,13 @@ export function useProjectCanvasModule({
     [projectCanvasLayout.savePlacementCommands]
   );
 
+  const saveAutoLayoutNodes = useCallback(
+    (nodes: CanvasLayoutNode[]) => {
+      projectCanvasLayout.saveLayoutNodes(nodes).catch(() => undefined);
+    },
+    [projectCanvasLayout.saveLayoutNodes]
+  );
+
   const onNodePositionChange = useStableCallback(
     (
       node: Parameters<typeof projectCanvasLayout.scheduleNodeLayoutSave>[0]
@@ -343,6 +353,7 @@ export function useProjectCanvasModule({
     edges: canvasEdges,
     kubeconfig,
     namespace,
+    onCanvasAutoLayout: saveAutoLayoutNodes,
     onNodeExpansionChange: projectCanvasLayout.scheduleNodeLayoutSave,
     onNodePositionChange,
     onNodeStackOrderChange: projectCanvasLayout.scheduleNodeLayoutSave,
@@ -528,6 +539,7 @@ export function useProjectCanvasModule({
       openDeploymentTaskDockTask,
     },
     canvas: {
+      autoLayout: workbench.autoLayoutCanvas,
       covered: canvasCovered,
       deploymentTaskDock,
       frameState,

--- a/apps/ui/src/features/project-canvas/workbench/use-project-canvas.ts
+++ b/apps/ui/src/features/project-canvas/workbench/use-project-canvas.ts
@@ -11,7 +11,11 @@ import {
   useState,
 } from "react";
 import type { PendingApDbCanvasReference } from "@/features/project-canvas/flow/pending-connections";
-import type { CanvasLayoutResourceRef } from "@/features/project-canvas/layout/types";
+import { autoLayoutCanvasNodes } from "@/features/project-canvas/layout/auto-layout";
+import type {
+  CanvasLayoutNode,
+  CanvasLayoutResourceRef,
+} from "@/features/project-canvas/layout/types";
 import { interactionSnapshotFromCanvasState } from "@/features/project-canvas/surface/interaction-react";
 import { createProjectCanvasInteractionStore } from "@/features/project-canvas/surface/interaction-store";
 import {
@@ -80,6 +84,8 @@ export interface UseProjectCanvasOptions {
   edges?: Edge[];
   kubeconfig?: string;
   namespace?: string;
+  /** Persist regenerated Canvas Layout entries after an Auto layout gesture. */
+  onCanvasAutoLayout?: (nodes: CanvasLayoutNode[]) => void;
   onNodeExpansionChange?: (node: Node) => void;
   onNodePositionChange?: (node: Node) => void;
   onNodeStackOrderChange?: (node: Node) => void;
@@ -341,6 +347,31 @@ export function useProjectCanvas(
   useLayoutEffect(() => {
     flowStore.reconcile({ edges: optionEdges ?? [], nodes });
   }, [flowStore, nodes, optionEdges]);
+
+  const autoLayoutCanvas = useStableCallback(() => {
+    if (readOnly) {
+      return;
+    }
+    const snapshot = flowStore.getSnapshot();
+    if (snapshot.nodes.length === 0) {
+      return;
+    }
+    const relationships = options?.runtimeStore?.selectRelationshipIndexes();
+    const { layoutNodes, positionChanges } = autoLayoutCanvasNodes({
+      connections:
+        relationships === undefined
+          ? []
+          : [...relationships.publicAccessToAp, ...relationships.apToDb],
+      nodes: snapshot.nodes,
+    });
+    if (positionChanges.length > 0) {
+      flowStore.applyNodeChanges(positionChanges);
+    }
+    if (layoutNodes.length > 0) {
+      options?.onCanvasAutoLayout?.(layoutNodes);
+    }
+  });
+
   const { apSettingsSessionEventsForAp } = useApSettingsSessionEvents({
     onPendingApDbReferencesStart: options?.onPendingApDbReferencesStart,
   });
@@ -766,6 +797,7 @@ export function useProjectCanvas(
   );
 
   return {
+    autoLayoutCanvas,
     clearSelection,
     closeDrawerSurface,
     closeMainSurface,

--- a/docs/CODE_MENTAL_MODEL.md
+++ b/docs/CODE_MENTAL_MODEL.md
@@ -85,7 +85,7 @@ flowchart LR
 - `CONTEXT.md`: ubiquitous language, 定义 Project, AP, DB, Deployment Task, timeline, projection, canvas 等产品语义。
 - `docs/adr/0023-model-all-deployments-as-deployment-tasks.md`: 所有部署入口都应该创建 Deployment Task。
 - `docs/adr/0025-stream-project-deployment-task-projections.md`: Project Canvas 读 deployment projections 的方式是 bootstrap + project-scoped stream。
-- `docs/adr/0027-use-deployment-scope-brain-labels.md`: Brain ownership label contract。
+- `docs/adr/0027-use-sealos-native-product-labels-for-template-instances.md`: AP/DB 产品身份用 Sealos native labels, brain.io/* 只作 bookkeeping。
 - `docs/adr/0028-model-deployment-progress-as-task-owned-timelines.md`: 进度属于 task-owned timeline。
 - `docs/adr/0020-keep-shared-ui-free-of-product-workflows.md`: `packages/ui` 不能变成第二个产品 app 层。
 - `docs/deployment/brain-system.md`: Helm 部署 runbook。
@@ -688,7 +688,7 @@ brain.io/template-name=<templateName>
 
 - TS: `apps/ui/src/lib/brain-labels.ts`
 - Go: `apps/api/service/orchestration/labels.go`
-- ADR: `docs/adr/0027-use-deployment-scope-brain-labels.md`
+- ADR: `docs/adr/0027-use-sealos-native-product-labels-for-template-instances.md`
 
 读资源:
 
@@ -1222,7 +1222,7 @@ Agent-friendly lifecycle docs:
 9. `apps/api/main.go`
 10. `apps/api/service/orchestration/ap.go`
 11. `apps/api/service/orchestration/db.go`
-12. `docs/adr/0027-use-deployment-scope-brain-labels.md`
+12. `docs/adr/0027-use-sealos-native-product-labels-for-template-instances.md`
 
 做部署任务改动:
 

--- a/docs/adr/0002-model-project-db-references-as-ap-environment-variables.md
+++ b/docs/adr/0002-model-project-db-references-as-ap-environment-variables.md
@@ -17,10 +17,6 @@ Project DB references are authored through the AP Environment editor and persist
 
 ## Consequences
 
-The Environment editor must be structured enough to represent direct values and Project DB references. DSN references write selected private or public connection strings as ordinary env values; primitive fields write `valueFrom.secretKeyRef`. Environment variable names are the user's final API and must be unique within the AP.
+Environment variable names are the user's final API and must be unique within the AP. Canvas AP-DB connections continue to derive from exact env evidence — `valueFrom.secretKeyRef` entries that point at DB credential Secrets, or values equal to the DB's current DSN — and environment editing does not introduce a separate connection model.
 
-The editor may offer editor-only value tokens, such as `${{PGPASSWORD}}`, to help users compose environment values from other environment variables. These tokens are not a new AP runtime template language and are not persisted verbatim. Before saving, the editor resolves them into standard AP environment entries: composed values use Kubernetes env expansion syntax such as `$(PGPASSWORD)`, and any DB-backed helper variables required by those tokens are materialized as normal AP env rows.
-
-Token-driven helper variables remain part of the AP environment list because they are real runtime environment variables. They should use DB-provided variable names when possible, such as `PGUSER`, `PGPASSWORD`, `PGHOST`, and `PGPORT`, with conflict handling when those names are already owned by other user-authored rows. Helper variables must not be hidden metadata or a separate binding record.
-
-The editor may keep transient per-row DB context to resolve tokens while the user is editing, but that context is not persisted unless it produces standard AP env values. Canvas AP-DB connections continue to derive from exact env evidence, especially `valueFrom.secretKeyRef` entries that point at DB credential Secrets; token editing does not introduce a separate connection model.
+The editor and persistence model is defined by ADR-0018: a `.env`-style AP Environment Raw Source with AP Environment References such as `${{postgres.DATABASE_URL}}`, compiled on update into runtime env entries backed by DB credential Secret refs. The editor-only value tokens and visible DB-backed helper variable rows this ADR originally described are superseded by that model.

--- a/docs/adr/0013-db-terminal-pod-exec-native-client-server-side-credentials.md
+++ b/docs/adr/0013-db-terminal-pod-exec-native-client-server-side-credentials.md
@@ -9,7 +9,7 @@ The DB node's terminal must give users an interactive database session. We consi
 
 ## Consequences
 
-- Offered only for engines that ship a client in their KubeBlocks container and only while the DB Service is Running; engines without a client (kafka, qdrant, milvus, nebula, weaviate, pulsar) hide the terminal action.
+- Offered only for engines that ship a client in their KubeBlocks container and only while the DB Service is Running; on engines without a client (kafka, qdrant, milvus, nebula, weaviate, pulsar) the terminal is presented as an Unavailable Resource Affordance with an unsupported-engine reason rather than omitted.
 - Primary-pod resolution depends on KubeBlocks `InstanceSet` member roles (`status.membersStatus[].role.isLeader`); a DB Terminal always targets the writable primary.
 - The constructed command's password is visible in the target pod's own process args (`ps`); acceptable because that pod already mounts the DB secret, and can be hardened later via env (`PGPASSWORD`/`MYSQL_PWD`) or stdin.
 - No command-level audit in v1. A DB Terminal grants no privilege the user lacks: the DB node already exposes the connection string and a public-access toggle, so the user can connect directly. That makes auditing only terminal sessions both incomplete and redundant. v1 emits a lightweight session-open event (actor, DB Service, timestamp) for telemetry only; statement-level audit, if ever required, belongs at the engine (`pgaudit` / MySQL audit log), where it covers all connections rather than just the terminal.

--- a/docs/adr/0015-remove-public-project-preview-sharing.md
+++ b/docs/adr/0015-remove-public-project-preview-sharing.md
@@ -15,5 +15,4 @@ The product keeps the UI `readOnly` concept because future internal read-only su
 ## Consequences
 
 - Public share-token APIs and `X-Share-Token` clients are gone from active code.
-- Historical ADR references to Public Project Preview should be read as superseded by this decision.
 - Reintroducing public sharing later should be treated as a new feature: define the access model first, then rebuild the route, token service, and read-only API paths intentionally.

--- a/docs/adr/0027-use-sealos-native-product-labels-for-template-instances.md
+++ b/docs/adr/0027-use-sealos-native-product-labels-for-template-instances.md
@@ -202,25 +202,13 @@ KubeBlocks Cluster => DB
 TemplateNative => user-visible resource type
 ```
 
-`TemplateNative` may exist only as an internal transient implementation detail
-during removal work. It must not be part of the product model, API contract,
-label contract, or user-visible canvas model.
+`TemplateNative` is removed and must not return to the product model, API
+contract, label contract, or user-visible canvas model.
 
-## Removed Contract
-
-The following labels are not product identity labels and must not be used for
-AP/DB discovery:
-
-```text
-brain.io/deployment-kind
-brain.io/resource-kind
-brain.io/app-name
-brain.io/db-name
-brain.io/resource-name
-```
-
-They may be removed or retained only as Brain bookkeeping labels. They do not
-define product type.
+The legacy labels `brain.io/deployment-kind`, `brain.io/resource-kind`,
+`brain.io/app-name`, `brain.io/db-name`, and `brain.io/resource-name` do not
+define product type and must not be used for AP/DB discovery. They may be
+removed or retained only as Brain bookkeeping labels.
 
 ## Compatibility
 
@@ -244,20 +232,3 @@ not a query-layer fallback case.
 Canvas should render template-produced APs and DBs through the normal AP and DB
 resource paths. It should not render template workloads through a separate
 TemplateNative product path.
-
-## Verification Requirements
-
-Before this ADR is considered implemented:
-
-- A template that produces an AP must make that AP visible through the normal AP
-  list API.
-- A template that produces a DB must make that DB visible through the normal DB
-  list API.
-- A template AP must support AP lifecycle operations through the normal AP
-  lifecycle API.
-- A template DB must support DB lifecycle operations through the normal DB
-  lifecycle API.
-- Canvas must show template APs and DBs as normal AP and DB nodes.
-- Canvas must not show a user-visible TemplateNative node.
-- Tests must reject `brain.io/deployment-kind=template` as an AP/DB discovery
-  mechanism.

--- a/docs/adr/0036-model-github-integrations-as-namespace-scoped-app-installations.md
+++ b/docs/adr/0036-model-github-integrations-as-namespace-scoped-app-installations.md
@@ -115,11 +115,13 @@ GITHUB_APP_ID
 GITHUB_APP_PRIVATE_KEY
 ```
 
-The app-owned Postgres schema is currently synchronized through
-`cd apps/ui && bun run db:push`; there is no checked-in migration directory for
-`sealai_assistant.github_connections`. Deployments that already have an old
-personal-token `github_connections` table must run the schema push or an
-equivalent SQL migration before enabling the GitHub App flow.
+The app-owned Postgres schema is synchronized through checked-in Drizzle
+migrations under `apps/ui/drizzle/` (generated with `bun run db:generate`,
+applied automatically at app startup; in production a migration failure aborts
+the boot). `sealai_assistant.github_connections` is part of those migrations.
+Deployments that already have an old personal-token `github_connections` table
+must apply the migrations or an equivalent SQL migration before enabling the
+GitHub App flow.
 
 The personal OAuth implementation is removed rather than kept as a compatibility
 path. Useful product pieces remain: namespace authentication, Desktop SDK actor

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,39 @@
+# ADR Index
+
+One line per decision; the linked record is authoritative. When adding an ADR, take the next unused number and append it here.
+
+- [0001 — Persist Project Canvas Layouts in App Postgres](0001-persist-project-canvas-layouts-in-app-postgres.md)
+- [0002 — Model Project DB References as AP Environment Variables](0002-model-project-db-references-as-ap-environment-variables.md) *(editor model revised by ADR-0018)*
+- [0003 — Derive Canvas Connections from Resource State](0003-derive-canvas-connections-from-resource-state.md)
+- [0008 — Model AP Elastic Scaling as a replica strategy](0008-model-ap-elastic-scaling-as-replica-strategy.md)
+- [0009 — Promote Platform Addresses as Custom Domain CNAME targets](0009-promote-platform-addresses-as-custom-domain-cname-targets.md)
+- [0013 — DB Terminal runs the native engine client via pod-exec with server-side credential injection](0013-db-terminal-pod-exec-native-client-server-side-credentials.md)
+- [0014 — Orchestrate Project Surfaces Separately from Canvas Selection](0014-orchestrate-project-surfaces-separately-from-canvas-selection.md)
+- [0015 — Remove Public Project Preview Sharing](0015-remove-public-project-preview-sharing.md)
+- [0016 — Model App Listening Ports as Private Addresses](0016-model-app-listening-ports-as-private-addresses.md)
+- [0017 — DB Service restore creates a new DB Service](0017-db-service-restore-creates-new-db-service.md)
+- [0018 — Model AP Environment as Raw Source and Compiled Runtime Env](0018-model-ap-environment-as-raw-source-and-compiled-runtime-env.md)
+- [0019 — Model Project Settings as Provider-Defined Side Pane Views](0019-model-project-settings-as-provider-defined-side-pane-views.md)
+- [0020 — Keep Shared UI Free of Product Workflows](0020-keep-shared-ui-free-of-product-workflows.md)
+- [0021 — Persist First Incremental Canvas Placements](0021-persist-first-incremental-canvas-placements.md)
+- [0022 — Use Row-Major Global Canvas Placement](0022-use-row-major-global-canvas-placement.md)
+- [0023 — Model All Deployments as Deployment Tasks](0023-model-all-deployments-as-deployment-tasks.md)
+- [0024 — Model Canvas Placement Owners for Deployment Projections](0024-model-canvas-placement-owners-for-deployment-projections.md)
+- [0025 — Stream Project Deployment Task Projections](0025-stream-project-deployment-task-projections.md)
+- [0026 — Detect Settings Draft Conflicts at Submit Time](0026-detect-settings-draft-conflicts-at-submit-time.md)
+- [0027 — Use Sealos Native Product Labels for Template Instances](0027-use-sealos-native-product-labels-for-template-instances.md) *(replaces the earlier deployment-scoped Brain label model)*
+- [0028 — Model Deployment Progress as Task-Owned Timelines](0028-model-deployment-progress-as-task-owned-timelines.md)
+- [0029 — Let Project Runtime Own Resource Read-Side Facts](0029-let-project-runtime-own-resource-read-side-facts.md)
+- [0030 — Store Pending Settings Updates Browser-Locally](0030-store-pending-settings-updates-browser-locally.md)
+- [0031 — Own Settings Submissions at the Settings Layer](0031-own-settings-submissions-at-the-settings-layer.md)
+- [0032 — Vendor a Kubernetes quantity port for client-side storage sizing](0032-vendor-kubernetes-quantity-for-client-storage-sizing.md)
+- [0033 — Surface assistant billing as a free-allowance counter plus a one-time crossing notice](0033-surface-assistant-billing-as-free-allowance-only.md)
+- [0034 — Anchor Log Windows as Live or Frozen](0034-anchor-log-windows-as-live-or-frozen.md)
+- [0035 — Render Project Canvas from Canvas Runtime Stores and Stable Commands](0035-render-project-canvas-from-canvas-runtime-stores.md)
+- [0036 — Model GitHub Integrations as Namespace-Scoped App Installations](0036-model-github-integrations-as-namespace-scoped-app-installations.md)
+
+## Conventions
+
+- An ADR without a `Status` section is accepted as written.
+- When a later ADR revises or replaces part of an earlier one, give the earlier ADR a `Status` section naming the reviser (see ADR 0002), and trim the superseded text instead of leaving it to mislead.
+- Gaps in the sequence (0004–0007, 0010–0012) are deleted ADRs whose decisions were superseded.

--- a/packages/ui/src/components/canvas/canvas.controls.tsx
+++ b/packages/ui/src/components/canvas/canvas.controls.tsx
@@ -8,7 +8,14 @@ import {
 } from "@workspace/ui/components/tooltip";
 import { cn } from "@workspace/ui/lib/utils";
 import { MiniMap, useReactFlow } from "@xyflow/react";
-import { Fullscreen, Hand, Minus, MousePointer2, Plus } from "lucide-react";
+import {
+  Fullscreen,
+  Hand,
+  LayoutGrid,
+  Minus,
+  MousePointer2,
+  Plus,
+} from "lucide-react";
 import type { FocusEvent, ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { CanvasInteractionMode } from "./canvas.types";
@@ -26,6 +33,11 @@ export interface CanvasViewportInsetProps {
 
 export interface CanvasControlsProps extends CanvasViewportInsetProps {
   className?: string;
+  /**
+   * Host-provided node auto-layout action. The Auto layout button renders
+   * only when set; the canvas fits the view after the host rearranges nodes.
+   */
+  onAutoLayout?: () => void;
 }
 
 export interface CanvasMiniMapProps extends CanvasViewportInsetProps {
@@ -204,7 +216,11 @@ function CanvasControlButton({
   );
 }
 
-export function CanvasControls({ className, rightInset }: CanvasControlsProps) {
+export function CanvasControls({
+  className,
+  onAutoLayout,
+  rightInset,
+}: CanvasControlsProps) {
   const { fitView, zoomIn, zoomOut } = useReactFlow();
   const { interactionMode, meta, rootRef, setInteractionMode } = useCanvas();
   const chrome = useCanvasNavigationChromePresence();
@@ -291,6 +307,22 @@ export function CanvasControls({ className, rightInset }: CanvasControlsProps) {
       <CanvasControlButton {...modeButton("pointer", "Pointer tool")}>
         <MousePointer2 aria-hidden className="size-4" />
       </CanvasControlButton>
+      {onAutoLayout === undefined ? null : (
+        <CanvasControlButton
+          label="Auto layout"
+          onClick={() => {
+            chrome.reveal();
+            onAutoLayout();
+            window.requestAnimationFrame(() => {
+              runViewportAction(() =>
+                fitView({ duration: VIEWPORT_ACTION_DURATION_MS })
+              );
+            });
+          }}
+        >
+          <LayoutGrid aria-hidden className="size-4" />
+        </CanvasControlButton>
+      )}
       <CanvasControlButton
         label="Fit view"
         onClick={() => {

--- a/packages/ui/src/components/time-wheel-field.tsx
+++ b/packages/ui/src/components/time-wheel-field.tsx
@@ -14,7 +14,7 @@ import {
 } from "@workspace/ui/components/popover";
 import { cn } from "@workspace/ui/lib/utils";
 import { Clock } from "lucide-react";
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo } from "react";
 
 function buildOptions(count: number): WheelPickerOption<number>[] {
   return Array.from({ length: count }, (_, index) => ({
@@ -54,13 +54,6 @@ const SHARED_WHEEL_CLASS_NAMES = {
   optionItem: "font-normal text-foreground text-sm",
 };
 
-// The library ships an *unlayered* CSS mask that only fades the outer ~20% of
-// each column, and unlayered CSS beats Tailwind's layered utilities — so a
-// utility override silently loses. We apply a stronger mask via inline styles
-// (which always win) once the portalled columns have mounted.
-const WHEEL_EDGE_MASK =
-  "linear-gradient(to bottom, transparent 0%, black 26%, black 74%, transparent 100%)";
-
 interface TimeWheelFieldProps {
   className?: string;
   label: string;
@@ -85,35 +78,7 @@ export function TimeWheelField({
   open,
   value,
 }: TimeWheelFieldProps) {
-  const wheelsRef = useRef<HTMLDivElement>(null);
   const [hours, minutes, seconds] = useMemo(() => parseTime(value), [value]);
-
-  // Replace the library's built-in edge mask with a stronger fade that dims the
-  // neighbouring rows, not just the outermost sliver. Inline styles beat the
-  // library's unlayered CSS rule; retry across frames until the portalled
-  // columns mount.
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-    let frame = 0;
-    let tries = 0;
-    const applyMask = () => {
-      const columns =
-        wheelsRef.current?.querySelectorAll<HTMLElement>("[data-rwp]");
-      if ((!columns || columns.length === 0) && tries < 30) {
-        tries += 1;
-        frame = requestAnimationFrame(applyMask);
-        return;
-      }
-      for (const column of columns ?? []) {
-        column.style.setProperty("mask-image", WHEEL_EDGE_MASK);
-        column.style.setProperty("-webkit-mask-image", WHEEL_EDGE_MASK);
-      }
-    };
-    applyMask();
-    return () => cancelAnimationFrame(frame);
-  }, [open]);
 
   return (
     <div className={cn("flex flex-col gap-2", className)}>
@@ -140,7 +105,7 @@ export function TimeWheelField({
           className="w-[150px] overflow-hidden rounded-lg border border-border bg-input/30 p-1 ring-0 backdrop-blur-xl"
           sideOffset={4}
         >
-          <div ref={wheelsRef}>
+          <div className="time-wheel-picker">
             <WheelPickerWrapper>
               <WheelPicker
                 classNames={{

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -395,6 +395,30 @@
     max-width: min(34rem, calc(100vw - 2rem));
   }
 
+  /*
+   * @ncdai/react-wheel-picker ships an *unlayered* mask on [data-rwp] that only
+   * fades the outer ~20% of each column; unlayered rules beat our layered ones,
+   * so !important is required to win. The wheel is a 3D cylinder, so its outer
+   * two rows bunch close together near each edge — a plain linear ramp can't dim
+   * the outermost row without also dimming its still-crisp neighbour. The extra
+   * transparent shoulder holds full transparency across the outermost row, then
+   * ramps steeply so the ±1 neighbour stays ~opaque: the outer row melts to a
+   * faint ghost while the value and its immediate neighbours stay crisp.
+   */
+  .time-wheel-picker [data-rwp] {
+    --time-wheel-edge-mask: linear-gradient(
+      to bottom,
+      transparent 0%,
+      transparent 7%,
+      #000 27%,
+      #000 73%,
+      transparent 93%,
+      transparent 100%
+    );
+    -webkit-mask-image: var(--time-wheel-edge-mask) !important;
+    mask-image: var(--time-wheel-edge-mask) !important;
+  }
+
   .monaco-editor.ap-env-raw-source-monaco .suggest-widget,
   .monaco-editor.ap-env-raw-source-monaco .suggest-details {
     overflow: hidden;


### PR DESCRIPTION
## Summary

This branch bundles two UI changes and a documentation pass. The commits are independent — grouped below so a reviewer can read them separately.

**UI**
- `1cbcaef1` **feat(ui): add Auto layout control to the Project Canvas** — adds an Auto layout control to the Project Canvas.
- `27d3662d` **fix(ui): strengthen and reliably apply the time-wheel edge fade** — the log time picker's wheel now fades its outer rows to a faint ghost and applies that fade reliably (details below).

**Docs**
- `b7c51d33` **docs: fix ADR drift, regroup CONTEXT.md, add ADR index** — reconciles ADRs with current behavior, regroups `CONTEXT.md`, adds an ADR index.
- `de088862` **docs: trim AGENTS.md and document packages/shared** — trims `AGENTS.md` and documents `packages/shared`.

---

## Details — time-wheel edge fade (this session)

**Problem.** In the log window picker, the hour/minute/second wheel faded its outer rows only marginally (a `~26%` inline mask pushed onto the library's `[data-rwp]` columns via a `requestAnimationFrame` retry loop). Two issues:

1. The fade was too weak to read as "melting away" — the outermost rows sat at ~37% opacity, clearly legible.
2. The rAF-driven inline-style hack **silently fell back** to the library's default `20/80` mask whenever rAF was throttled (background tab, slow mount), so users could intermittently see an even weaker fade.

**Fix.** Replace the inline-style hack with a static, higher-priority CSS rule in `packages/ui/src/styles/globals.css`, scoped `.time-wheel-picker [data-rwp]` and using `!important` to beat the library's *unlayered* mask (same pattern as the existing sonner/monaco library overrides in that file). Because the wheel is a 3D cylinder its outer two rows bunch close together, so a plain linear ramp can't dim the outermost row without also dimming its neighbour — the curve therefore holds full transparency across the outermost row, then ramps steeply:

```
linear-gradient(to bottom, transparent 0%, transparent 7%, #000 27%, #000 73%, transparent 93%, transparent 100%)
```

Measured result (real DOM, from the registry preview):

| Row | Opacity | Effect |
|-----|---------|--------|
| ±3 (outermost) | 0% | gone |
| ±2 | ~14% | faint ghost |
| ±1 | ~99% | crisp |
| selected | 100% | crisp |

The `useEffect`/`ref`/constant are removed — the mask now comes from the stylesheet with no timing dependency. Verified that in a backgrounded preview tab (where rAF is paused and the old hack applied *nothing*), the CSS rule still applies the intended mask.

**Diff:** `time-wheel-field.tsx` −37/+2, `globals.css` +24.

---

## Reviewer notes

- This PR spans 4 independent commits (3 predate this session). They can be reviewed commit-by-commit.
- Local `apps/*/next-env.d.ts` auto-generated churn was intentionally left out of the branch.
- Gates for the time-wheel change: `ultracite/biome` ✓, `tsc --noEmit` (@workspace/ui) ✓. Visually verified in the registry `log-viewer` preview.
