### PR TITLE
[codex] Show delayed database deletion hint

### DIFF
--- a/apps/api/service/orchestration/db_adapter.go
+++ b/apps/api/service/orchestration/db_adapter.go
@@ -2,6 +2,7 @@ package orchestration
 
 import (
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -42,17 +43,21 @@ func DBObjectFromCluster(cluster *unstructured.Unstructured) map[string]interfac
 	}
 	statusRaw, _ := cluster.Object["status"].(map[string]interface{})
 	phase := dbPhase(statusRaw)
+	metadata := map[string]interface{}{
+		"creationTimestamp": cluster.GetCreationTimestamp().String(),
+		"labels":            labels,
+		"name":              cluster.GetName(),
+		"namespace":         cluster.GetNamespace(),
+		"uid":               string(cluster.GetUID()),
+	}
+	if deletionTimestamp := cluster.GetDeletionTimestamp(); deletionTimestamp != nil && !deletionTimestamp.IsZero() {
+		metadata["deletionTimestamp"] = deletionTimestamp.UTC().Format(time.RFC3339)
+	}
 	return map[string]interface{}{
 		"apiVersion": "brain.io/direct",
 		"kind":       "DB",
-		"metadata": map[string]interface{}{
-			"creationTimestamp": cluster.GetCreationTimestamp().String(),
-			"labels":            labels,
-			"name":              cluster.GetName(),
-			"namespace":         cluster.GetNamespace(),
-			"uid":               string(cluster.GetUID()),
-		},
-		"spec": productSpec,
+		"metadata":   metadata,
+		"spec":       productSpec,
 		"status": map[string]interface{}{
 			"observed": statusRaw,
 			"phase":    phase,

--- a/apps/api/service/orchestration/render_test.go
+++ b/apps/api/service/orchestration/render_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -1133,6 +1134,28 @@ func TestDBObjectFromClusterReturnsDBLikeShape(t *testing.T) {
 	status := db["status"].(map[string]interface{})
 	if got := status["phase"]; got != "Running" {
 		t.Fatalf("status.phase = %v, want Running", got)
+	}
+}
+
+func TestDBObjectFromClusterIncludesDeletionTimestamp(t *testing.T) {
+	resources, err := RenderDBResources(DBResourcesInput{
+		ClusterVersion: "postgresql-16",
+		Engine:         "postgresql",
+		Name:           "pg",
+		Namespace:      "ns-a",
+		ProjectID:      "project-a",
+	})
+	if err != nil {
+		t.Fatalf("RenderDBResources returned error: %v", err)
+	}
+	deletionTimestamp := metav1.NewTime(time.Date(2026, 7, 6, 12, 34, 56, 0, time.UTC))
+	resources.Cluster.SetDeletionTimestamp(&deletionTimestamp)
+
+	db := DBObjectFromCluster(resources.Cluster)
+	metadata := db["metadata"].(map[string]interface{})
+
+	if got := metadata["deletionTimestamp"]; got != "2026-07-06T12:34:56Z" {
+		t.Fatalf("metadata.deletionTimestamp = %v, want Kubernetes deletion timestamp", got)
 	}
 }
 

--- a/apps/registry/registry/linear/components/database-node/database-node-preview.canvas.tsx
+++ b/apps/registry/registry/linear/components/database-node/database-node-preview.canvas.tsx
@@ -15,6 +15,7 @@ import { memo, useMemo } from "react";
 interface CanvasDatabaseNodeData extends Record<string, unknown> {
   connections: DatabaseNodeConnection[];
   defaultExpanded: boolean;
+  showDeletionDelayHint?: boolean;
   states: DatabaseNodeStates;
 }
 
@@ -45,7 +46,12 @@ const PreviewCanvasDatabaseNode = memo(function PreviewCanvasDatabaseNode({
       quickActions={PREVIEW_QUICK_ACTIONS}
       states={data.states}
     >
-      <DatabaseNode.Content />
+      <div className="relative">
+        <DatabaseNode.Content />
+        {data.showDeletionDelayHint ? (
+          <DatabaseNode.DeletionDelayHint className="absolute top-full left-1/2 mt-2 -translate-x-1/2" />
+        ) : null}
+      </div>
     </DatabaseNode.Root>
   );
 });
@@ -65,6 +71,12 @@ const states: DatabaseNodeStates = {
   },
   name: "orders-api",
   status: { label: "Running", tone: "running" },
+};
+
+const deletingStates: DatabaseNodeStates = {
+  ...states,
+  deletionTimestamp: "2026-07-06T10:00:00Z",
+  status: { label: "Deleting", tone: "deleting" },
 };
 
 const connections: DatabaseNodeConnection[] = [
@@ -99,6 +111,17 @@ const DATABASE_NODE_CANVAS_NODES: Node<
     data: { connections, defaultExpanded: true, states },
     id: "database-node-expanded",
     position: { x: 560, y: 120 },
+    type: "databaseNode",
+  },
+  {
+    data: {
+      connections,
+      defaultExpanded: false,
+      showDeletionDelayHint: true,
+      states: deletingStates,
+    },
+    id: "database-node-deleting-delay-hint",
+    position: { x: 940, y: 130 },
     type: "databaseNode",
   },
 ];

--- a/apps/ui/src/features/project-canvas/nodes/canvas-database-node.tsx
+++ b/apps/ui/src/features/project-canvas/nodes/canvas-database-node.tsx
@@ -15,6 +15,7 @@ import {
 import { useWorkloadTelemetrySnapshot } from "@/features/project-canvas/telemetry/workload-telemetry-react";
 import type { WorkloadTelemetryTarget } from "@/features/project-canvas/telemetry/workload-telemetry-store";
 import { useProjectRuntimeNodeModel } from "@/features/project-runtime/resource-models-react";
+import { shouldShowDatabaseDeletionDelayHint } from "./database-deletion-warning";
 import type { CanvasDatabaseNodeData, CanvasDatabaseRfNode } from "./types";
 import { useCanvasNodeExpansion } from "./use-canvas-node-expansion";
 import { useCanvasDatabaseNodeActions } from "./use-database-node-actions";
@@ -65,6 +66,10 @@ export const CanvasDatabaseNode = memo(function CanvasDatabaseNode({
     positionAbsoluteY,
     type,
   });
+  const showDeletionDelayHint = shouldShowDatabaseDeletionDelayHint({
+    nowMs: Date.now(),
+    states,
+  });
 
   return (
     <DatabaseNode.Root
@@ -81,14 +86,19 @@ export const CanvasDatabaseNode = memo(function CanvasDatabaseNode({
         actions.togglePublicConnectionDisabledReason
       }
     >
-      <DatabaseNode.Content
-        metricsContent={
-          <CanvasDatabaseTelemetryMetrics
-            fallbackMetrics={states.metrics}
-            target={telemetryTarget}
-          />
-        }
-      />
+      <div className="relative">
+        <DatabaseNode.Content
+          metricsContent={
+            <CanvasDatabaseTelemetryMetrics
+              fallbackMetrics={states.metrics}
+              target={telemetryTarget}
+            />
+          }
+        />
+        {showDeletionDelayHint ? (
+          <DatabaseNode.DeletionDelayHint className="absolute top-full left-1/2 mt-2 -translate-x-1/2" />
+        ) : null}
+      </div>
     </DatabaseNode.Root>
   );
 });

--- a/apps/ui/src/features/project-canvas/nodes/database-deletion-warning.test.ts
+++ b/apps/ui/src/features/project-canvas/nodes/database-deletion-warning.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { DatabaseNodeStates } from "@workspace/ui/components/database-node/database-node";
+
+import { shouldShowDatabaseDeletionDelayHint } from "./database-deletion-warning";
+
+const DELETION_TIMESTAMP = "2026-07-06T10:00:00Z";
+const DELETION_STARTED_AT = Date.parse(DELETION_TIMESTAMP);
+
+function states(
+  overrides: Partial<DatabaseNodeStates> = {}
+): DatabaseNodeStates {
+  return {
+    deletionTimestamp: DELETION_TIMESTAMP,
+    displayEngine: "PostgreSQL",
+    name: "postgres",
+    status: { label: "Deleting", tone: "deleting" },
+    ...overrides,
+  };
+}
+
+test("does not show the database deletion delay hint before two minutes", () => {
+  assert.equal(
+    shouldShowDatabaseDeletionDelayHint({
+      nowMs: DELETION_STARTED_AT + 2 * 60 * 1000 - 1,
+      states: states(),
+    }),
+    false
+  );
+});
+
+test("shows the database deletion delay hint after two minutes", () => {
+  assert.equal(
+    shouldShowDatabaseDeletionDelayHint({
+      nowMs: DELETION_STARTED_AT + 2 * 60 * 1000,
+      states: states(),
+    }),
+    true
+  );
+});
+
+test("does not show the database deletion delay hint for non-deleting databases", () => {
+  assert.equal(
+    shouldShowDatabaseDeletionDelayHint({
+      nowMs: DELETION_STARTED_AT + 2 * 60 * 1000,
+      states: states({ status: { label: "Running", tone: "running" } }),
+    }),
+    false
+  );
+});
+
+test("does not show the database deletion delay hint without a trusted deletion timestamp", () => {
+  assert.equal(
+    shouldShowDatabaseDeletionDelayHint({
+      nowMs: DELETION_STARTED_AT + 2 * 60 * 1000,
+      states: states({ deletionTimestamp: undefined }),
+    }),
+    false
+  );
+});
+
+test("does not reuse a generic transient timestamp as the deletion start time", () => {
+  assert.equal(
+    shouldShowDatabaseDeletionDelayHint({
+      nowMs: DELETION_STARTED_AT + 2 * 60 * 1000,
+      states: {
+        ...states({ deletionTimestamp: undefined }),
+        transientSince: "2026-07-06T09:00:00Z",
+      } as DatabaseNodeStates,
+    }),
+    false
+  );
+});

--- a/apps/ui/src/features/project-canvas/nodes/database-deletion-warning.ts
+++ b/apps/ui/src/features/project-canvas/nodes/database-deletion-warning.ts
@@ -1,0 +1,38 @@
+import type { DatabaseNodeStates } from "@workspace/ui/components/database-node/database-node";
+
+function normalizeDatabaseStatus(input: string | undefined) {
+  return input
+    ?.trim()
+    .toLowerCase()
+    .replace(/[\s_]+/g, "-");
+}
+
+export function isDatabaseDeleting(states: DatabaseNodeStates): boolean {
+  return (
+    normalizeDatabaseStatus(states.status?.tone) === "deleting" ||
+    normalizeDatabaseStatus(states.status?.label) === "deleting"
+  );
+}
+
+function databaseDeletionStartedAtMs(states: DatabaseNodeStates) {
+  if (!isDatabaseDeleting(states)) {
+    return undefined;
+  }
+
+  const deletionStartedAt = Date.parse(states.deletionTimestamp ?? "");
+  return Number.isFinite(deletionStartedAt) ? deletionStartedAt : undefined;
+}
+
+export function shouldShowDatabaseDeletionDelayHint({
+  nowMs,
+  states,
+}: {
+  nowMs: number;
+  states: DatabaseNodeStates;
+}): boolean {
+  const deletionStartedAt = databaseDeletionStartedAtMs(states);
+  return (
+    deletionStartedAt !== undefined &&
+    nowMs - deletionStartedAt >= 2 * 60 * 1000
+  );
+}

--- a/apps/ui/src/features/project-runtime/resource-facts.ts
+++ b/apps/ui/src/features/project-runtime/resource-facts.ts
@@ -57,6 +57,7 @@ export interface DbFact {
       value?: string;
     };
   };
+  deletionTimestamp?: string;
   displayName: string;
   engine: {
     displayName: string;
@@ -182,6 +183,10 @@ function metadataUid(resource: unknown): string | undefined {
   return nonEmptyString(metadataRecord(resource).uid);
 }
 
+function metadataDeletionTimestamp(resource: unknown): string | undefined {
+  return nonEmptyString(metadataRecord(resource).deletionTimestamp);
+}
+
 function metadataLabels(
   resource: unknown
 ): Record<string, unknown> | undefined {
@@ -300,6 +305,9 @@ function dbFactFromResource(
           : { value: nonEmptyString(status.connectionStringPublic) }),
       },
     },
+    ...(metadataDeletionTimestamp(db) === undefined
+      ? {}
+      : { deletionTimestamp: metadataDeletionTimestamp(db) }),
     displayName: name,
     engine: {
       displayName: displayEngineFromKey(engineKey),

--- a/apps/ui/src/features/project-runtime/resource-models.ts
+++ b/apps/ui/src/features/project-runtime/resource-models.ts
@@ -117,6 +117,9 @@ function dbModelFromFact(fact: DbFact): CanvasDatabaseNodeData {
       ? {}
       : { metadata: { labels: fact.metadataLabels } }),
     states: {
+      ...(fact.deletionTimestamp === undefined
+        ? {}
+        : { deletionTimestamp: fact.deletionTimestamp }),
       displayEngine: fact.engine.displayName,
       ...(fact.engine.key === undefined ? {} : { engineKey: fact.engine.key }),
       ...(fact.version === undefined ? {} : { formattedVersion: fact.version }),

--- a/apps/ui/src/features/project-runtime/resource-read-model.test.ts
+++ b/apps/ui/src/features/project-runtime/resource-read-model.test.ts
@@ -61,6 +61,7 @@ test("Project Runtime parses AP resources into app-owned read-side facts", () =>
 test("Project Runtime parses DB resources into app-owned read-side facts", () => {
   const rawDb = {
     metadata: {
+      deletionTimestamp: "2026-07-06T10:00:00Z",
       labels: { region: "192.168.12.53.nip.io" },
       name: "postgres",
       namespace: "default",
@@ -98,6 +99,7 @@ test("Project Runtime parses DB resources into app-owned read-side facts", () =>
         private: { value: "postgres://private" },
         public: { enabled: true, value: "postgres://public" },
       },
+      deletionTimestamp: "2026-07-06T10:00:00Z",
       displayName: "postgres",
       engine: { displayName: "PostgreSQL", key: "postgresql" },
       key: "DB:default:postgres",
@@ -449,6 +451,7 @@ test("Project Runtime commits one DB update without notifying unrelated DB model
       items: [
         {
           metadata: {
+            deletionTimestamp: "2026-07-06T10:00:00Z",
             labels: { region: "192.168.12.53.nip.io" },
             name: "postgres",
             namespace: "default",
@@ -597,6 +600,7 @@ test("Project Runtime adapts per-node models to shared UI props outside read-sid
       items: [
         {
           metadata: {
+            deletionTimestamp: "2026-07-06T10:00:00Z",
             labels: { region: "192.168.12.53.nip.io" },
             name: "postgres",
             namespace: "default",
@@ -649,6 +653,7 @@ test("Project Runtime adapts per-node models to shared UI props outside read-sid
     metadata: { labels: { region: "192.168.12.53.nip.io" } },
     states: {
       displayEngine: "PostgreSQL",
+      deletionTimestamp: "2026-07-06T10:00:00Z",
       engineKey: "postgresql",
       iconUrl: databaseModel.states.iconUrl,
       metrics: {},

--- a/apps/ui/src/features/project-settings/db/db-settings-resource.test.ts
+++ b/apps/ui/src/features/project-settings/db/db-settings-resource.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { dbResourceToSettingsData } from "./db-settings-resource";
+
+test("dbResourceToSettingsData reads Kubernetes metadata deletionTimestamp", () => {
+  const data = dbResourceToSettingsData({
+    metadata: {
+      deletionTimestamp: "2026-07-06T10:00:00Z",
+      name: "postgres",
+      namespace: "ns-a",
+    },
+    spec: { engine: "postgresql" },
+    status: { phase: "Deleting" },
+  });
+
+  assert.equal(data.states.deletionTimestamp, "2026-07-06T10:00:00Z");
+});
+
+test("dbResourceToSettingsData does not reuse generic transient timestamps", () => {
+  const data = dbResourceToSettingsData({
+    metadata: {
+      name: "postgres",
+      namespace: "ns-a",
+    },
+    spec: { engine: "postgresql" },
+    status: {
+      phase: "Deleting",
+      transientSince: "2026-07-06T09:00:00Z",
+    },
+  });
+
+  assert.equal(data.states.deletionTimestamp, undefined);
+});

--- a/apps/ui/src/features/project-settings/db/db-settings-resource.ts
+++ b/apps/ui/src/features/project-settings/db/db-settings-resource.ts
@@ -72,6 +72,10 @@ function metadataNamespace(item: unknown): string | undefined {
   return typeof namespace === "string" ? namespace : undefined;
 }
 
+function metadataDeletionTimestamp(item: unknown): string | undefined {
+  return nonEmptyString(asRecord(asRecord(item)?.metadata)?.deletionTimestamp);
+}
+
 function nonEmptyString(input: unknown): string | undefined {
   return typeof input === "string" && input.trim() !== ""
     ? input.trim()
@@ -286,6 +290,7 @@ export function dbResourceToSettingsData(
   const name = metadataName(db) ?? "unknown";
   const namespace = metadataNamespace(db) ?? options?.namespaceFallback ?? "";
   const uid = metadataUid(db);
+  const deletionTimestamp = metadataDeletionTimestamp(db);
   const engineKey = nonEmptyString(spec.engine);
   const telemetry = databaseTelemetryForResource({
     metricsLookup: options?.metricsLookup,
@@ -308,6 +313,7 @@ export function dbResourceToSettingsData(
   const backupPolicy = databaseBackupPolicyFromSpec(spec);
 
   const states: DatabaseNodeStates = {
+    ...(deletionTimestamp === undefined ? {} : { deletionTimestamp }),
     displayEngine: displayEngineFromKey(engineKey),
     ...(engineKey === undefined
       ? {}

--- a/packages/ui/src/components/database-node/database-node.content.test.tsx
+++ b/packages/ui/src/components/database-node/database-node.content.test.tsx
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { DatabaseNodeContent } from "./database-node.content";
+import {
+  DatabaseNodeContent,
+  DatabaseNodeDeletionDelayHint,
+} from "./database-node.content";
 import { DatabaseNodeRoot } from "./database-node.root";
 
 const DATABASE_STATES = {
@@ -21,6 +24,10 @@ const RAW_CONNECTION_TITLE_RE =
   /title="postgresql:\/\/alice:s3cr3t@db-main-postgresql.ns-a.svc:5432\/postgres"/;
 const PARTIAL_CONNECTION_MASK_RE =
   /postgresql:\/\/a\*\*\*\*\*\*\*:\*\*\*\*\*\*\*@db-main-postgresql/;
+const DELETION_DELAY_HINT_RE =
+  /Your database is being deleted\. This may take a few minutes\./;
+const DELETION_DELAY_HINT_SLOT_RE =
+  /data-slot="database-node-deletion-delay-hint"/;
 
 test("DatabaseNodeContent omits lifecycle menu without a family", () => {
   const html = renderToStaticMarkup(
@@ -122,4 +129,11 @@ test("DatabaseNodeContent hides connection strings until the row is hovered", ()
   assert.doesNotMatch(html, FIXED_CONNECTION_MASK_TITLE_RE);
   assert.doesNotMatch(html, RAW_CONNECTION_TITLE_RE);
   assert.doesNotMatch(html, PARTIAL_CONNECTION_MASK_RE);
+});
+
+test("DatabaseNodeDeletionDelayHint renders the Figma-specified message", () => {
+  const html = renderToStaticMarkup(<DatabaseNodeDeletionDelayHint />);
+
+  assert.match(html, DELETION_DELAY_HINT_SLOT_RE);
+  assert.match(html, DELETION_DELAY_HINT_RE);
 });

--- a/packages/ui/src/components/database-node/database-node.content.tsx
+++ b/packages/ui/src/components/database-node/database-node.content.tsx
@@ -25,6 +25,7 @@ import {
   SquareTerminal,
   TableProperties,
   Trash2,
+  TriangleAlert,
 } from "lucide-react";
 import type { ComponentType, ReactNode, SVGProps } from "react";
 
@@ -194,6 +195,35 @@ export function DatabaseNodeContent({
         <DatabaseNodeFooterContent metricsContent={metricsContent} />
       </CanvasNode.Footer>
     </CanvasNode.Card>
+  );
+}
+
+export function DatabaseNodeDeletionDelayHint({
+  className,
+}: {
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "database-node-deletion-delay-hint pointer-events-none flex w-[267px] flex-col items-start justify-center gap-4 overflow-hidden rounded-lg border-[0.5px] border-border bg-white/5 p-2.5 text-muted-foreground backdrop-blur-[20px]",
+        className
+      )}
+      data-slot="database-node-deletion-delay-hint"
+    >
+      <div className="flex w-full items-start gap-2">
+        <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-white/5">
+          <TriangleAlert
+            aria-hidden
+            className="size-3.5 text-yellow-500"
+            strokeWidth={2}
+          />
+        </div>
+        <p className="min-w-0 flex-1 text-xs leading-4">
+          Your database is being deleted. This may take a few minutes.
+        </p>
+      </div>
+    </div>
   );
 }
 

--- a/packages/ui/src/components/database-node/database-node.tsx
+++ b/packages/ui/src/components/database-node/database-node.tsx
@@ -8,6 +8,7 @@ import {
   DatabaseNodeConnectionList,
   DatabaseNodeConnectionRow,
   DatabaseNodeContent,
+  DatabaseNodeDeletionDelayHint,
   DatabaseNodeFooterContent,
   DatabaseNodeHeaderContent,
   DatabaseNodeMetricsContent,
@@ -60,6 +61,7 @@ export const DatabaseNode = {
   ConnectionList: DatabaseNodeConnectionList,
   ConnectionRow: DatabaseNodeConnectionRow,
   Content: DatabaseNodeContent,
+  DeletionDelayHint: DatabaseNodeDeletionDelayHint,
   FooterContent: DatabaseNodeFooterContent,
   HeaderContent: DatabaseNodeHeaderContent,
   MetricsContent: DatabaseNodeMetricsContent,
@@ -72,6 +74,7 @@ const dn = (component: object, name: string) => {
 
 dn(DatabaseNodeRoot, "DatabaseNode.Root");
 dn(DatabaseNodeContent, "DatabaseNode.Content");
+dn(DatabaseNodeDeletionDelayHint, "DatabaseNode.DeletionDelayHint");
 dn(DatabaseNodeHeaderContent, "DatabaseNode.HeaderContent");
 dn(DatabaseNodeBodyContent, "DatabaseNode.BodyContent");
 dn(DatabaseNodeConnectionList, "DatabaseNode.ConnectionList");

--- a/packages/ui/src/components/database-node/database-node.types.ts
+++ b/packages/ui/src/components/database-node/database-node.types.ts
@@ -54,6 +54,7 @@ export interface DatabaseNodeStatus {
 }
 
 export interface DatabaseNodeStates {
+  deletionTimestamp?: string;
   displayEngine: string;
   engineKey?: DatabaseEngineKey;
   formattedVersion?: string;


### PR DESCRIPTION
## Summary

- surface Kubernetes `metadata.deletionTimestamp` on DB product responses
- carry trusted DB deletion timestamps through project runtime models
- show a Figma-matched deletion delay hint below database canvas cards after the DB has been Deleting for about two minutes
- add registry preview coverage for the deletion hint state

## Why

Database deletion can occasionally remain in progress long enough that users need reassurance that the operation is still underway. The hint uses Kubernetes `metadata.deletionTimestamp` as the authoritative deletion start time and intentionally does not reuse generic transient-phase tracking.

## Validation

- `bun typecheck`
- `bun check`
- `bun test apps/ui/src/features/project-canvas/nodes/database-deletion-warning.test.ts apps/ui/src/features/project-settings/db/db-settings-resource.test.ts apps/ui/src/features/project-runtime/resource-read-model.test.ts packages/ui/src/components/database-node/database-node.content.test.tsx`
- `GOCACHE=/private/tmp/brain-go-build-cache go test ./service/orchestration -run 'TestDBObjectFromCluster(IncludesDeletionTimestamp|ReturnsDBLikeShape)'`
