### PR TITLE
[codex] stabilize GitHub install completion

### DIFF
--- a/apps/ui/src/app/github/install-complete/page.tsx
+++ b/apps/ui/src/app/github/install-complete/page.tsx
@@ -3,7 +3,9 @@
 import { useEffect } from "react";
 
 import {
+  GITHUB_APP_INSTALL_COMPLETE_CHANNEL,
   GITHUB_APP_INSTALL_COMPLETE_MESSAGE,
+  GITHUB_APP_INSTALL_COMPLETE_STORAGE_KEY,
   parseInstallReturnPathParam,
 } from "@/lib/github-app/types";
 
@@ -15,15 +17,57 @@ function installReturnPath(): string {
   return parseInstallReturnPathParam(url.searchParams.get("next")) ?? "/";
 }
 
+function installState(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  const state = new URL(window.location.href).searchParams.get("state")?.trim();
+  return state ? state : null;
+}
+
+function publishInstallComplete(
+  returnPath: string,
+  state: string | null
+): void {
+  if (state == null) {
+    return;
+  }
+  const payload = {
+    completedAt: Date.now(),
+    returnPath,
+    state,
+    type: GITHUB_APP_INSTALL_COMPLETE_MESSAGE,
+  };
+  try {
+    if ("BroadcastChannel" in window) {
+      const channel = new BroadcastChannel(GITHUB_APP_INSTALL_COMPLETE_CHANNEL);
+      channel.postMessage(payload);
+      channel.close();
+    }
+  } catch {
+    // BroadcastChannel can be unavailable in restricted browser contexts.
+  }
+  try {
+    window.localStorage.setItem(
+      GITHUB_APP_INSTALL_COMPLETE_STORAGE_KEY,
+      JSON.stringify(payload)
+    );
+  } catch {
+    // Local storage can be unavailable in restricted browser contexts.
+  }
+}
+
 export default function GithubInstallCompletePage() {
   useEffect(() => {
     const returnPath = installReturnPath();
+    const state = installState();
+    publishInstallComplete(returnPath, state);
     if (!window.opener) {
       window.location.replace(returnPath);
       return;
     }
     window.opener.postMessage(
-      { returnPath, type: GITHUB_APP_INSTALL_COMPLETE_MESSAGE },
+      { returnPath, state, type: GITHUB_APP_INSTALL_COMPLETE_MESSAGE },
       window.location.origin
     );
     window.close();

--- a/apps/ui/src/components/project-workspace-layout.tsx
+++ b/apps/ui/src/components/project-workspace-layout.tsx
@@ -190,6 +190,85 @@ function buildAssistantContextPayload(
   };
 }
 
+function ProjectAssistantComposer({
+  busy,
+  contextToggles,
+  onDatabaseIntent,
+  onDockerIntent,
+  onGithubIntent,
+  onSkillsIntent,
+  onStop,
+  onSubmit,
+}: {
+  busy: boolean;
+  contextToggles: readonly string[];
+  onDatabaseIntent: () => void;
+  onDockerIntent: () => void;
+  onGithubIntent: () => void;
+  onSkillsIntent: () => void;
+  onStop: () => void;
+  onSubmit: (text: string) => void;
+}) {
+  const [input, setInput] = useState("");
+  const { isAuthorized, isLoading: authLoading } = useGithubAuth();
+
+  const onPrimaryAction = useCallback(() => {
+    if (busy) {
+      onStop();
+      return;
+    }
+    const text = input.trim();
+    if (!text) {
+      return;
+    }
+    onSubmit(text);
+    setInput("");
+  }, [busy, input, onStop, onSubmit]);
+
+  return (
+    <div className="group flex w-full shrink-0 flex-col p-[10px]">
+      {contextToggles.length > 0 ? (
+        <div className="relative h-0 w-full overflow-visible transition-[height] duration-300 ease-out group-focus-within:h-6 motion-reduce:transition-none">
+          <div className="pointer-events-none absolute inset-x-0 top-full w-full -translate-y-full">
+            <Chat.ContextIndicator
+              className="w-full"
+              contextToggles={contextToggles}
+            />
+          </div>
+        </div>
+      ) : null}
+      <Chat.ComposerShell>
+        <Chat.ComposerTextarea
+          onPrimaryAction={onPrimaryAction}
+          onValueChange={setInput}
+          placeholder="Ask SealAI to inspect, deploy, or explain this project..."
+          responding={busy}
+          value={input}
+        />
+        <Chat.ComposerFooter>
+          <div className="flex min-w-0 flex-1 items-center gap-1">
+            <Chat.GithubDeployButton
+              authLoading={authLoading}
+              isAuthorized={isAuthorized}
+              onComposerAction={onGithubIntent}
+            />
+            <Chat.SkillsWorkflowButton onComposerAction={onSkillsIntent} />
+            <Chat.DockerDeployButton onComposerAction={onDockerIntent} />
+            <Chat.DatabaseDeployButton onComposerAction={onDatabaseIntent} />
+          </div>
+          <Chat.ComposerSend
+            onPrimaryAction={onPrimaryAction}
+            responding={busy}
+            value={input}
+          />
+        </Chat.ComposerFooter>
+      </Chat.ComposerShell>
+    </div>
+  );
+}
+
+const ProjectAssistantComposerMemo = memo(ProjectAssistantComposer);
+
 function ProjectAssistantChatSession({
   bootstrap,
   freeTier,
@@ -420,9 +499,6 @@ function ProjectAssistantChatSession({
       }
     }
   }, [messages, projectId]);
-  const [input, setInput] = useState("");
-  const { isAuthorized, isLoading: authLoading } = useGithubAuth();
-
   const createThreadClicked = useCallback(() => {
     onCreateThread().catch(() => undefined);
   }, [onCreateThread]);
@@ -466,18 +542,16 @@ function ProjectAssistantChatSession({
     return toggles;
   }, [projectId, selected]);
 
-  const onPrimaryAction = useCallback(() => {
-    if (busy) {
-      stop();
-      return;
-    }
-    const text = input.trim();
-    if (!text) {
-      return;
-    }
-    sendMessage({ text }).catch(() => undefined);
-    setInput("");
-  }, [busy, input, sendMessage, stop]);
+  const submitComposerText = useCallback(
+    (text: string) => {
+      sendMessage({ text }).catch(() => undefined);
+    },
+    [sendMessage]
+  );
+
+  const stopComposerResponse = useCallback(() => {
+    stop();
+  }, [stop]);
 
   return (
     <Chat.Root>
@@ -508,46 +582,16 @@ function ProjectAssistantChatSession({
             />
           </div>
         ) : null}
-        <div className="group flex w-full shrink-0 flex-col p-[10px]">
-          {composerContextToggles.length > 0 ? (
-            <div className="relative h-0 w-full overflow-visible transition-[height] duration-300 ease-out group-focus-within:h-6 motion-reduce:transition-none">
-              <div className="pointer-events-none absolute inset-x-0 top-full w-full -translate-y-full">
-                <Chat.ContextIndicator
-                  className="w-full"
-                  contextToggles={composerContextToggles}
-                />
-              </div>
-            </div>
-          ) : null}
-          <Chat.ComposerShell>
-            <Chat.ComposerTextarea
-              onPrimaryAction={onPrimaryAction}
-              onValueChange={setInput}
-              placeholder="Ask SealAI to inspect, deploy, or explain this project..."
-              responding={busy}
-              value={input}
-            />
-            <Chat.ComposerFooter>
-              <div className="flex min-w-0 flex-1 items-center gap-1">
-                <Chat.GithubDeployButton
-                  authLoading={authLoading}
-                  isAuthorized={isAuthorized}
-                  onComposerAction={onGithubIntent}
-                />
-                <Chat.SkillsWorkflowButton onComposerAction={onSkillsIntent} />
-                <Chat.DockerDeployButton onComposerAction={onDockerIntent} />
-                <Chat.DatabaseDeployButton
-                  onComposerAction={onDatabaseIntent}
-                />
-              </div>
-              <Chat.ComposerSend
-                onPrimaryAction={onPrimaryAction}
-                responding={busy}
-                value={input}
-              />
-            </Chat.ComposerFooter>
-          </Chat.ComposerShell>
-        </div>
+        <ProjectAssistantComposerMemo
+          busy={busy}
+          contextToggles={composerContextToggles}
+          onDatabaseIntent={onDatabaseIntent}
+          onDockerIntent={onDockerIntent}
+          onGithubIntent={onGithubIntent}
+          onSkillsIntent={onSkillsIntent}
+          onStop={stopComposerResponse}
+          onSubmit={submitComposerText}
+        />
       </Chat>
     </Chat.Root>
   );

--- a/apps/ui/src/hooks/use-github-auth.test.ts
+++ b/apps/ui/src/hooks/use-github-auth.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GITHUB_APP_INSTALL_COMPLETE_MESSAGE } from "../lib/github-app/types";
+import { githubInstallReturnPathForNavigation } from "./use-github-auth";
+
+test("githubInstallReturnPathForNavigation only applies targeted return paths", () => {
+  const message = {
+    returnPath: "/projects?source=github",
+    state: "install-state",
+    type: GITHUB_APP_INSTALL_COMPLETE_MESSAGE,
+  };
+
+  assert.equal(
+    githubInstallReturnPathForNavigation(message, { applyReturnPath: true }),
+    "/projects?source=github"
+  );
+  assert.equal(githubInstallReturnPathForNavigation(message), null);
+  assert.equal(
+    githubInstallReturnPathForNavigation(message, { applyReturnPath: false }),
+    null
+  );
+});
+
+test("githubInstallReturnPathForNavigation rejects malformed completion messages", () => {
+  assert.equal(
+    githubInstallReturnPathForNavigation(
+      {
+        returnPath: "https://example.com/projects",
+        state: "install-state",
+        type: GITHUB_APP_INSTALL_COMPLETE_MESSAGE,
+      },
+      { applyReturnPath: true }
+    ),
+    null
+  );
+  assert.equal(
+    githubInstallReturnPathForNavigation(
+      {
+        returnPath: "/projects",
+        state: "install-state",
+        type: "other-message",
+      },
+      { applyReturnPath: true }
+    ),
+    null
+  );
+  assert.equal(
+    githubInstallReturnPathForNavigation(
+      {
+        returnPath: "/projects",
+        type: GITHUB_APP_INSTALL_COMPLETE_MESSAGE,
+      },
+      { applyReturnPath: true }
+    ),
+    null
+  );
+});

--- a/apps/ui/src/hooks/use-github-auth.ts
+++ b/apps/ui/src/hooks/use-github-auth.ts
@@ -1,12 +1,14 @@
 "use client";
 
 import { useAtomValue } from "jotai";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import useSWR, { useSWRConfig } from "swr";
 
 import { githubReposSWRKey } from "@/hooks/use-github-repos";
 import {
+  GITHUB_APP_INSTALL_COMPLETE_CHANNEL,
   GITHUB_APP_INSTALL_COMPLETE_MESSAGE,
+  GITHUB_APP_INSTALL_COMPLETE_STORAGE_KEY,
   parseInstallNamespaceParam,
   parseInstallReturnPathParam,
 } from "@/lib/github-app/types";
@@ -99,7 +101,7 @@ async function createInstallSession(
   kubeconfig: string,
   userId: string,
   returnPath: string
-): Promise<{ installUrl: string }> {
+): Promise<{ installUrl: string; state: string }> {
   const response = await fetch("/api/github/install-session", {
     cache: "no-store",
     headers: { "Content-Type": "application/json" },
@@ -114,11 +116,17 @@ async function createInstallSession(
   if (!response.ok) {
     throw new Error(await response.text());
   }
-  const body = (await response.json()) as { installUrl?: unknown };
+  const body = (await response.json()) as {
+    installUrl?: unknown;
+    state?: unknown;
+  };
   if (typeof body.installUrl !== "string" || body.installUrl.trim() === "") {
     throw new Error("GitHub App install URL was not returned.");
   }
-  return { installUrl: body.installUrl };
+  if (typeof body.state !== "string" || body.state.trim() === "") {
+    throw new Error("GitHub App install state was not returned.");
+  }
+  return { installUrl: body.installUrl, state: body.state };
 }
 
 function centeredPopupFeatures(): string {
@@ -137,6 +145,51 @@ function centeredPopupFeatures(): string {
 
 function sameOriginPath(raw: unknown): string | null {
   return typeof raw === "string" ? parseInstallReturnPathParam(raw) : null;
+}
+
+function isGithubInstallCompleteMessage(
+  data: unknown
+): data is { returnPath?: unknown; state: string; type: string } {
+  return (
+    typeof data === "object" &&
+    data != null &&
+    "type" in data &&
+    data.type === GITHUB_APP_INSTALL_COMPLETE_MESSAGE &&
+    "state" in data &&
+    typeof data.state === "string" &&
+    data.state.trim() !== ""
+  );
+}
+
+function parseStoredInstallCompleteMessage(
+  raw: string | null
+): { returnPath?: unknown; state: string; type: string } | null {
+  if (raw == null || raw === "") {
+    return null;
+  }
+  try {
+    const data = JSON.parse(raw) as unknown;
+    return isGithubInstallCompleteMessage(data) ? data : null;
+  } catch {
+    return null;
+  }
+}
+
+export function githubInstallReturnPathForNavigation(
+  data: unknown,
+  options?: { applyReturnPath?: boolean }
+): string | null {
+  if (
+    options?.applyReturnPath !== true ||
+    !isGithubInstallCompleteMessage(data)
+  ) {
+    return null;
+  }
+  return sameOriginPath(data.returnPath);
+}
+
+function completedState(data: unknown): string | null {
+  return isGithubInstallCompleteMessage(data) ? data.state.trim() : null;
 }
 
 export function useGithubAuth(options?: {
@@ -169,6 +222,87 @@ export function useGithubAuth(options?: {
     err = new Error(String(error));
   }
 
+  const installCleanupRef = useRef<(() => void) | null>(null);
+  const pendingInstallStateRef = useRef<string | null>(null);
+  const handledInstallStatesRef = useRef<Set<string>>(new Set());
+
+  const refreshConnection = useCallback(() => {
+    if (!canCheck) {
+      return;
+    }
+    mutate().catch(() => undefined);
+    const reposKey = githubReposSWRKey({ kubeconfig, namespace, userId });
+    if (reposKey != null) {
+      mutateCache(reposKey).catch(() => undefined);
+    }
+  }, [canCheck, kubeconfig, mutate, mutateCache, namespace, userId]);
+
+  const handleInstallComplete = useCallback(
+    (data: unknown, options?: { applyReturnPath?: boolean }) => {
+      if (!isGithubInstallCompleteMessage(data)) {
+        return;
+      }
+      const state = completedState(data);
+      if (
+        state == null ||
+        (state !== pendingInstallStateRef.current &&
+          !handledInstallStatesRef.current.has(state))
+      ) {
+        return;
+      }
+      const alreadyHandled = handledInstallStatesRef.current.has(state);
+      if (!alreadyHandled) {
+        handledInstallStatesRef.current.add(state);
+        installCleanupRef.current?.();
+      }
+      const returnPath = githubInstallReturnPathForNavigation(data, options);
+      if (
+        returnPath &&
+        returnPath !== `${window.location.pathname}${window.location.search}`
+      ) {
+        window.history.replaceState(null, "", returnPath);
+      }
+      if (!alreadyHandled) {
+        refreshConnection();
+      }
+    },
+    [refreshConnection]
+  );
+
+  useEffect(() => {
+    if (!canCheck) {
+      return;
+    }
+    const handleMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) {
+        return;
+      }
+      handleInstallComplete(event.data, { applyReturnPath: true });
+    };
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== GITHUB_APP_INSTALL_COMPLETE_STORAGE_KEY) {
+        return;
+      }
+      handleInstallComplete(parseStoredInstallCompleteMessage(event.newValue));
+    };
+    let channel: BroadcastChannel | undefined;
+    if ("BroadcastChannel" in window) {
+      channel = new BroadcastChannel(GITHUB_APP_INSTALL_COMPLETE_CHANNEL);
+      channel.addEventListener("message", (event) => {
+        handleInstallComplete(event.data);
+      });
+    }
+
+    window.addEventListener("message", handleMessage);
+    window.addEventListener("storage", handleStorage);
+    return () => {
+      window.removeEventListener("message", handleMessage);
+      window.removeEventListener("storage", handleStorage);
+      channel?.close();
+      installCleanupRef.current?.();
+    };
+  }, [canCheck, handleInstallComplete]);
+
   const initiateGithubAuth = useCallback(() => {
     const next = `${window.location.pathname}${window.location.search}`;
     const normalizedNamespace = parseInstallNamespaceParam(namespace);
@@ -187,39 +321,16 @@ export function useGithubAuth(options?: {
 
     let closePoll: number | undefined;
     const cleanup = () => {
-      window.removeEventListener("message", handleMessage);
       if (closePoll !== undefined) {
         window.clearInterval(closePoll);
+        closePoll = undefined;
       }
+      if (installCleanupRef.current === cleanup) {
+        installCleanupRef.current = null;
+      }
+      pendingInstallStateRef.current = null;
     };
-    const refreshConnection = () => {
-      mutate().catch(() => undefined);
-      const reposKey = githubReposSWRKey({ kubeconfig, namespace, userId });
-      if (reposKey != null) {
-        mutateCache(reposKey).catch(() => undefined);
-      }
-    };
-    const handleMessage = (event: MessageEvent) => {
-      if (event.origin !== window.location.origin) {
-        return;
-      }
-      if (
-        typeof event.data !== "object" ||
-        event.data == null ||
-        event.data.type !== GITHUB_APP_INSTALL_COMPLETE_MESSAGE
-      ) {
-        return;
-      }
-      cleanup();
-      const returnPath = sameOriginPath(event.data.returnPath);
-      if (
-        returnPath &&
-        returnPath !== `${window.location.pathname}${window.location.search}`
-      ) {
-        window.history.replaceState(null, "", returnPath);
-      }
-      refreshConnection();
-    };
+    installCleanupRef.current = cleanup;
 
     const start = async (popup: Window | null) => {
       if (
@@ -231,18 +342,19 @@ export function useGithubAuth(options?: {
           "GitHub App installation requires workspace credentials and user ID."
         );
       }
-      const { installUrl } = await createInstallSession(
+      const { installUrl, state } = await createInstallSession(
         normalizedNamespace,
         kubeconfig,
         userId,
         next
       );
+      pendingInstallStateRef.current = state;
+      handledInstallStatesRef.current.delete(state);
       if (popup == null) {
         window.location.assign(installUrl);
         return;
       }
       popup.location.replace(installUrl);
-      window.addEventListener("message", handleMessage);
       closePoll = window.setInterval(() => {
         if (popup.closed) {
           cleanup();
@@ -259,7 +371,7 @@ export function useGithubAuth(options?: {
         startError
       );
     });
-  }, [kubeconfig, mutate, mutateCache, namespace, userId]);
+  }, [kubeconfig, namespace, refreshConnection, userId]);
 
   const disconnectGithubAuth = useCallback(async () => {
     if (!canCheck) {

--- a/apps/ui/src/lib/github-app/service.ts
+++ b/apps/ui/src/lib/github-app/service.ts
@@ -119,7 +119,7 @@ export async function completeAuthorization(
 
   const baseUrl = getCallbackBaseUrl(request);
   const response = NextResponse.redirect(
-    buildInstallPopupCompleteUrl(baseUrl, session.returnPath)
+    buildInstallPopupCompleteUrl(baseUrl, session.returnPath, session.state)
   );
   return response;
 }

--- a/apps/ui/src/lib/github-app/types.test.ts
+++ b/apps/ui/src/lib/github-app/types.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { parseInstallNamespaceParam } from "./types";
+import {
+  parseInstallNamespaceParam,
+  parseInstallReturnPathParam,
+} from "./types";
 
 test("parseInstallNamespaceParam accepts valid Kubernetes namespace names", () => {
   assert.equal(parseInstallNamespaceParam("ns-c9x2uti1"), "ns-c9x2uti1");
@@ -15,4 +18,10 @@ test("parseInstallNamespaceParam rejects invalid namespace values", () => {
   assert.equal(parseInstallNamespaceParam("default-"), null);
   assert.equal(parseInstallNamespaceParam("default/other"), null);
   assert.equal(parseInstallNamespaceParam("a".repeat(64)), null);
+});
+
+test("parseInstallReturnPathParam rejects paths that browsers may treat as external", () => {
+  assert.equal(parseInstallReturnPathParam("/projects"), "/projects");
+  assert.equal(parseInstallReturnPathParam("/%5Cevil.example"), null);
+  assert.equal(parseInstallReturnPathParam("/\\evil.example"), null);
 });

--- a/apps/ui/src/lib/github-app/types.ts
+++ b/apps/ui/src/lib/github-app/types.ts
@@ -13,6 +13,14 @@ export const GITHUB_APP_INSTALL_COMPLETE_PATH =
 export const GITHUB_APP_INSTALL_COMPLETE_MESSAGE =
   "github-app-install-complete" as const;
 
+/** Cross-tab channel used when the GitHub App flow returns in a browser tab. */
+export const GITHUB_APP_INSTALL_COMPLETE_CHANNEL =
+  "brain-github-app-install" as const;
+
+/** Local storage key used to fan out install completion to other tabs. */
+export const GITHUB_APP_INSTALL_COMPLETE_STORAGE_KEY =
+  "brain:github-app-install-complete" as const;
+
 /** Max length for path + search stored in pending install session / `next` query. */
 export const MAX_INSTALL_RETURN_PATH_LEN = 2048;
 
@@ -41,6 +49,7 @@ export function parseInstallReturnPathParam(raw: string | null): string | null {
     decoded.length > MAX_INSTALL_RETURN_PATH_LEN ||
     !decoded.startsWith("/") ||
     decoded.startsWith("//") ||
+    decoded.includes("\\") ||
     decoded.includes("://") ||
     decoded.includes("\n") ||
     decoded.includes("\r")

--- a/apps/ui/src/lib/github-app/urls.ts
+++ b/apps/ui/src/lib/github-app/urls.ts
@@ -62,7 +62,8 @@ export function getCallbackBaseUrl(request: Request): string {
 
 export function buildInstallPopupCompleteUrl(
   baseUrl: string,
-  storedReturnRaw: string | null | undefined
+  storedReturnRaw: string | null | undefined,
+  state?: string | null
 ): string {
   const doneUrl = new URL(
     GITHUB_APP_INSTALL_COMPLETE_PATH,
@@ -73,6 +74,10 @@ export function buildInstallPopupCompleteUrl(
     : null;
   if (returnPath) {
     doneUrl.searchParams.set("next", returnPath);
+  }
+  const stateParam = state?.trim();
+  if (stateParam) {
+    doneUrl.searchParams.set("state", stateParam);
   }
   return doneUrl.toString();
 }


### PR DESCRIPTION
## Summary

- Support GitHub App install completion when the flow returns in a new tab instead of a popup.
- Bind completion notifications to the verified install session state and dedupe repeated popup/channel/storage events.
- Reject backslash return paths that browsers may treat as external redirects.
- Extract the assistant composer into a memoized component from the current workspace changes.

## Validation

- bun test apps/ui/src/hooks/use-github-auth.test.ts apps/ui/src/lib/github-app/types.test.ts
- bun check
- bun run typecheck --force
