### PR TITLE
feat(ui): add return-to-desktop sidebar action

### DIFF
--- a/apps/ui/src/components/app-sidebar.test.ts
+++ b/apps/ui/src/components/app-sidebar.test.ts
@@ -17,6 +17,12 @@ const PROJECTS_BUTTON_PROJECT_HOVER_RE =
 const WORKSPACE_QUOTA_LOADER_RE = /sealosApp\.getWorkspaceQuota\(\)/;
 const CREATE_SEALOS_APP_RE = /createSealosApp/;
 const HARDCODED_USAGE_VALUE_RE = /"0\.0\/0"/;
+const CLOSE_BRAIN_EVENT_RE =
+  /sealosApp\.runEvents\("closeDesktopApp",\s*\{\s*appKey: "system-brain",?\s*\}\s*\)/s;
+const DESKTOP_RETURN_BUTTON_RE = /aria-label="Back to Sealos Desktop"/;
+const DESKTOP_RETURN_BEFORE_UPGRADE_RE =
+  /data-slot="app-sidebar-bottom-actions"[\s\S]*<AppSidebarDesktopReturn \/>[\s\S]*<AppSidebarUpgrade \/>/;
+const EMBEDDED_WINDOW_CHECK_RE = /window\.(?:self|top)/;
 
 test("app sidebar does not reserve space for the Brain v2 logo", () => {
   assert.doesNotMatch(APP_SIDEBAR_SOURCE, BRAIN_V2_ARIA_LABEL_RE);
@@ -37,4 +43,14 @@ test("app sidebar upgrade popover reads workspace quota from the Sealos SDK", ()
   assert.match(APP_SIDEBAR_SOURCE, WORKSPACE_QUOTA_LOADER_RE);
   assert.doesNotMatch(APP_SIDEBAR_SOURCE, CREATE_SEALOS_APP_RE);
   assert.doesNotMatch(APP_SIDEBAR_SOURCE, HARDCODED_USAGE_VALUE_RE);
+});
+
+test("app sidebar requests that Desktop close Brain", () => {
+  assert.match(APP_SIDEBAR_SOURCE, CLOSE_BRAIN_EVENT_RE);
+});
+
+test("app sidebar always renders the Desktop return button above Upgrade", () => {
+  assert.match(APP_SIDEBAR_SOURCE, DESKTOP_RETURN_BUTTON_RE);
+  assert.match(APP_SIDEBAR_SOURCE, DESKTOP_RETURN_BEFORE_UPGRADE_RE);
+  assert.doesNotMatch(APP_SIDEBAR_SOURCE, EMBEDDED_WINDOW_CHECK_RE);
 });

--- a/apps/ui/src/components/app-sidebar.tsx
+++ b/apps/ui/src/components/app-sidebar.tsx
@@ -22,7 +22,7 @@ import {
 } from "@workspace/ui/components/tooltip";
 import { cn } from "@workspace/ui/lib/utils";
 import { useAtomValue } from "jotai";
-import { PanelsTopLeft, Sparkles } from "lucide-react";
+import { House, PanelsTopLeft, Sparkles } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
@@ -157,6 +157,12 @@ async function openCostCenterApp() {
   });
 }
 
+async function closeBrain() {
+  await sealosApp.runEvents("closeDesktopApp", {
+    appKey: "system-brain",
+  });
+}
+
 type AppSidebarLinkButtonProps = Pick<
   ComponentProps<typeof AppIconButton>,
   "aria-label" | "children" | "className"
@@ -192,6 +198,34 @@ function AppSidebarLinkButton({
         }
       />
       <TooltipContent side="right">{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function AppSidebarDesktopReturn() {
+  const handleClick = () => {
+    closeBrain().catch((error: unknown) => {
+      console.warn("[AppSidebarDesktopReturn] close Brain failed:", error);
+    });
+  };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <AppIconButton
+            aria-label="Back to Sealos Desktop"
+            className={APP_SIDEBAR_LINK_CLASS}
+            onClick={handleClick}
+            size="lg"
+            type="button"
+            variant="quiet"
+          >
+            <House aria-hidden className="size-4" strokeWidth={1.8} />
+          </AppIconButton>
+        }
+      />
+      <TooltipContent side="right">Back to Sealos Desktop</TooltipContent>
     </Tooltip>
   );
 }
@@ -420,6 +454,7 @@ export default function AppSidebar() {
             className="w-9 rounded-full bg-border"
             data-slot="app-sidebar-bottom-separator"
           />
+          <AppSidebarDesktopReturn />
           <AppSidebarUpgrade />
         </div>
       </div>


### PR DESCRIPTION
## Summary

- add an always-visible return-to-Sealos-Desktop action above the sidebar Upgrade control
- request `closeDesktopApp` with the canonical `system-brain` app key
- add sidebar contract tests for the event payload, placement, and intentionally unconditional rendering

## Why

Sealos Desktop suppresses the normal window title bar for `system-brain`, so Brain needs its own explicit control to close the app iframe and return users to the desktop.

## Validation

- `bun test apps/ui/src/components/app-sidebar.test.ts apps/ui/src/components/app-sidebar-upgrade.test.ts` — 7 passed
- `bunx ultracite check apps/ui/src/components/app-sidebar.tsx apps/ui/src/components/app-sidebar.test.ts`
- `bun typecheck`
- `git diff --check upstream/main...HEAD`

## Known repository check

The full `bun check` remains blocked by pre-existing formatting findings in `apps/ui/drizzle/meta/0004_snapshot.json` and `apps/ui/drizzle/meta/_journal.json`; this PR does not modify either file.