### PR TITLE
fix(ui): show units for used CPU quota

### DIFF
--- a/apps/ui/src/components/app-sidebar-upgrade.test.ts
+++ b/apps/ui/src/components/app-sidebar-upgrade.test.ts
@@ -15,7 +15,7 @@ test("formatWorkspaceQuotaRows maps Sealos quota items to sidebar rows", () => {
   ];
 
   assert.deepEqual(formatWorkspaceQuotaRows(quota), [
-    ["CPU", "0.5/16C"],
+    ["CPU", "0.5C/16C"],
     ["Memory", "1Gi/64Gi"],
     ["Storage", "3Gi/200Gi"],
     ["Ports", "0/10"],
@@ -26,7 +26,7 @@ test("formatWorkspaceQuotaRows keeps stable rows for missing quota items", () =>
   assert.deepEqual(
     formatWorkspaceQuotaRows([{ limit: 2000, type: "cpu", used: 1000 }]),
     [
-      ["CPU", "1/2C"],
+      ["CPU", "1C/2C"],
       ["Memory", "--/--"],
       ["Storage", "--/--"],
       ["Ports", "--/--"],

--- a/apps/ui/src/components/app-sidebar-upgrade.ts
+++ b/apps/ui/src/components/app-sidebar-upgrade.ts
@@ -58,7 +58,7 @@ function formatBinaryQuotaNumberFromMi(value: number) {
 function formatQuotaValue(item: WorkspaceQuotaItem) {
   switch (item.type) {
     case "cpu":
-      return `${formatCpuQuotaNumber(item.used)}/${formatCpuQuotaNumber(
+      return `${formatCpuQuotaNumber(item.used)}C/${formatCpuQuotaNumber(
         item.limit
       )}C`;
     case "memory":


### PR DESCRIPTION
## Summary

- show the CPU unit on both used and total workspace quota values
- update quota formatting tests for outputs such as `0.5C/16C`

## Testing

- `bun test apps/ui/src/components/app-sidebar-upgrade.test.ts`
- `bun typecheck`
- `bun check`