### PR TITLE
feat(api): provision per-DB RBAC on DB create

### DIFF
--- a/apps/api/route/db/mutation.go
+++ b/apps/api/route/db/mutation.go
@@ -114,6 +114,15 @@ spec:
 		if err != nil {
 			return nil, huma.Error400BadRequest("invalid DB direct resource request", err)
 		}
+		// Apply the account RBAC before the Cluster so the ServiceAccount referenced by
+		// componentSpec.serviceAccountName exists before KubeBlocks provisions the DB pods.
+		if err := k8ssvc.ApplyObjects(restConfig, []runtime.Object{
+			resources.ServiceAccount,
+			resources.Role,
+			resources.RoleBinding,
+		}, ns); err != nil {
+			return nil, huma.Error500InternalServerError("failed to create DB access resources", err)
+		}
 		if err := k8ssvc.ApplyUnstructured(restConfig, []*unstructured.Unstructured{resources.Cluster}, ns); err != nil {
 			return nil, huma.Error500InternalServerError("failed to create DB", err)
 		}
@@ -1341,7 +1350,7 @@ func deleteDBDirectResources(cfg *clientcmdapi.Config, name string, namespace st
 		return apierrors.NewNotFound(schema.GroupResource{Group: "apps.kubeblocks.io", Resource: "clusters"}, name)
 	}
 	selector := orchestration.BrainManagedByLabel + "=" + orchestration.BrainManagedByValue + "," + orchestration.BrainDeploymentKindLabel + "=" + orchestration.DeploymentKindDB + "," + orchestration.BrainDeploymentNameLabel + "=" + name
-	for _, resource := range []string{"services", "opsrequests", "configmaps", "secrets"} {
+	for _, resource := range []string{"services", "opsrequests", "configmaps", "secrets", "serviceaccounts", "roles", "rolebindings"} {
 		_, err := k8ssvc.Delete(cfg, k8ssvc.DeleteOptions{
 			LabelSelector: selector,
 			Namespace:     namespace,

--- a/apps/api/service/orchestration/db.go
+++ b/apps/api/service/orchestration/db.go
@@ -315,12 +315,16 @@ func RenderDBResources(input DBResourcesInput) (*DBResources, error) {
 // KubeBlocks Cluster's pods run as. The Cluster's componentSpec references this account through
 // serviceAccountName, so KubeBlocks lifecycle, probe, and reconfigure sidecars get the in-namespace
 // permissions they need. This mirrors the legacy sealos dbprovider account template; the objects
-// carry Brain ownership labels so db-delete's label sweep reclaims them with the Cluster.
+// carry Brain ownership labels so db-delete's label sweep reclaims them with the Cluster, plus
+// app.kubernetes.io/managed-by=kbcli for parity with the legacy sealos dbprovider account objects.
 func RenderDBAccountResources(name, namespace string, labels map[string]string) (*corev1.ServiceAccount, *rbacv1.Role, *rbacv1.RoleBinding) {
+	accountLabels := mergeStringMap(labels, map[string]string{
+		DBProviderManagedByLabel: DBProviderManagedByValue,
+	})
 	serviceAccount := &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ServiceAccount"},
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:    labels,
+			Labels:    accountLabels,
 			Name:      name,
 			Namespace: namespace,
 		},
@@ -328,7 +332,7 @@ func RenderDBAccountResources(name, namespace string, labels map[string]string) 
 	role := &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:    labels,
+			Labels:    accountLabels,
 			Name:      name,
 			Namespace: namespace,
 		},
@@ -339,7 +343,7 @@ func RenderDBAccountResources(name, namespace string, labels map[string]string) 
 	roleBinding := &rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"},
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:    labels,
+			Labels:    accountLabels,
 			Name:      name,
 			Namespace: namespace,
 		},

--- a/apps/api/service/orchestration/db.go
+++ b/apps/api/service/orchestration/db.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -195,8 +196,11 @@ func dbOpsRequest(clusterName, namespace, operation, suffix string, spec map[str
 }
 
 type DBResources struct {
-	Cluster       *unstructured.Unstructured
-	ExportService *corev1.Service
+	Cluster        *unstructured.Unstructured
+	ExportService  *corev1.Service
+	ServiceAccount *corev1.ServiceAccount
+	Role           *rbacv1.Role
+	RoleBinding    *rbacv1.RoleBinding
 }
 
 func RenderDBResources(input DBResourcesInput) (*DBResources, error) {
@@ -228,9 +232,10 @@ func RenderDBResources(input DBResourcesInput) (*DBResources, error) {
 		componentResources = dbComponentResources(profile.Engine, DBResourcesInput{Quota: input.Quota})
 	}
 	componentSpec := map[string]interface{}{
-		"componentDefRef": profile.ComponentName,
-		"name":            profile.ComponentName,
-		"replicas":        replicas,
+		"componentDefRef":    profile.ComponentName,
+		"name":               profile.ComponentName,
+		"replicas":           replicas,
+		"serviceAccountName": name,
 		"volumeClaimTemplates": []interface{}{
 			map[string]interface{}{
 				"name": "data",
@@ -295,7 +300,59 @@ func RenderDBResources(input DBResourcesInput) (*DBResources, error) {
 		exportService = RenderDBExportService(name, namespace, engine, labels)
 	}
 
-	return &DBResources{Cluster: cluster, ExportService: exportService}, nil
+	serviceAccount, role, roleBinding := RenderDBAccountResources(name, namespace, labels)
+
+	return &DBResources{
+		Cluster:        cluster,
+		ExportService:  exportService,
+		ServiceAccount: serviceAccount,
+		Role:           role,
+		RoleBinding:    roleBinding,
+	}, nil
+}
+
+// RenderDBAccountResources renders the per-DB ServiceAccount, Role, and RoleBinding that the
+// KubeBlocks Cluster's pods run as. The Cluster's componentSpec references this account through
+// serviceAccountName, so KubeBlocks lifecycle, probe, and reconfigure sidecars get the in-namespace
+// permissions they need. This mirrors the legacy sealos dbprovider account template; the objects
+// carry Brain ownership labels so db-delete's label sweep reclaims them with the Cluster.
+func RenderDBAccountResources(name, namespace string, labels map[string]string) (*corev1.ServiceAccount, *rbacv1.Role, *rbacv1.RoleBinding) {
+	serviceAccount := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ServiceAccount"},
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:    labels,
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	role := &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:    labels,
+			Name:      name,
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"*"}},
+		},
+	}
+	roleBinding := &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"},
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:    labels,
+			Name:      name,
+			Namespace: namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     name,
+		},
+		Subjects: []rbacv1.Subject{
+			{Kind: "ServiceAccount", Name: name, Namespace: namespace},
+		},
+	}
+	return serviceAccount, role, roleBinding
 }
 
 func applyDBRestoreFromBackupAnnotation(cluster *unstructured.Unstructured, componentName string, input *DBRestoreFromBackupInput) error {

--- a/apps/api/service/orchestration/labels.go
+++ b/apps/api/service/orchestration/labels.go
@@ -34,6 +34,8 @@ const (
 	DBProviderClusterDefinitionLabel = "clusterdefinition.kubeblocks.io/name"
 	DBProviderClusterVersionLabel    = "clusterversion.kubeblocks.io/name"
 	DBProviderCRLabel                = "sealos-db-provider-cr"
+	DBProviderManagedByLabel         = "app.kubernetes.io/managed-by"
+	DBProviderManagedByValue         = "kbcli"
 )
 
 func mergeStringMap(maps ...map[string]string) map[string]string {

--- a/apps/api/service/orchestration/render_test.go
+++ b/apps/api/service/orchestration/render_test.go
@@ -914,6 +914,10 @@ func TestRenderDBResourcesRendersAccountRBAC(t *testing.T) {
 		if got := meta.Labels[DBProviderCRLabel]; got != "pg" {
 			t.Fatalf("%s = %q, want pg", DBProviderCRLabel, got)
 		}
+		// dbprovider-parity label sits alongside the accurate brain.io/managed-by.
+		if got := meta.Labels[DBProviderManagedByLabel]; got != DBProviderManagedByValue {
+			t.Fatalf("%s = %q, want %q", DBProviderManagedByLabel, got, DBProviderManagedByValue)
+		}
 	}
 
 	// GVK must be set so ApplyObjects can route these through the dynamic apply path.

--- a/apps/api/service/orchestration/render_test.go
+++ b/apps/api/service/orchestration/render_test.go
@@ -874,6 +874,81 @@ func TestRenderDBResourcesLabelsAndNames(t *testing.T) {
 	}
 }
 
+func TestRenderDBResourcesRendersAccountRBAC(t *testing.T) {
+	resources, err := RenderDBResources(DBResourcesInput{
+		Engine:    "postgresql",
+		Name:      "pg",
+		Namespace: "ns-a",
+		ProjectID: "project-a",
+	})
+	if err != nil {
+		t.Fatalf("RenderDBResources returned error: %v", err)
+	}
+
+	// The Cluster's pods must run as the rendered ServiceAccount.
+	spec := resources.Cluster.Object["spec"].(map[string]interface{})
+	component := spec["componentSpecs"].([]interface{})[0].(map[string]interface{})
+	if got := component["serviceAccountName"]; got != "pg" {
+		t.Fatalf("componentSpec serviceAccountName = %v, want pg", got)
+	}
+
+	if resources.ServiceAccount == nil || resources.Role == nil || resources.RoleBinding == nil {
+		t.Fatalf("account RBAC must be rendered: sa=%v role=%v rb=%v", resources.ServiceAccount, resources.Role, resources.RoleBinding)
+	}
+
+	for _, meta := range []metav1.ObjectMeta{
+		resources.ServiceAccount.ObjectMeta,
+		resources.Role.ObjectMeta,
+		resources.RoleBinding.ObjectMeta,
+	} {
+		if meta.Name != "pg" || meta.Namespace != "ns-a" {
+			t.Fatalf("account object name/namespace = %q/%q, want pg/ns-a", meta.Name, meta.Namespace)
+		}
+		// Brain ownership labels are what db-delete's label sweep selects on.
+		if got := meta.Labels[BrainDeploymentNameLabel]; got != "pg" {
+			t.Fatalf("%s = %q, want pg", BrainDeploymentNameLabel, got)
+		}
+		if got := meta.Labels[BrainManagedByLabel]; got != BrainManagedByValue {
+			t.Fatalf("%s = %q, want %q", BrainManagedByLabel, got, BrainManagedByValue)
+		}
+		if got := meta.Labels[DBProviderCRLabel]; got != "pg" {
+			t.Fatalf("%s = %q, want pg", DBProviderCRLabel, got)
+		}
+	}
+
+	// GVK must be set so ApplyObjects can route these through the dynamic apply path.
+	if resources.ServiceAccount.APIVersion != "v1" || resources.ServiceAccount.Kind != "ServiceAccount" {
+		t.Fatalf("service account TypeMeta = %q/%q", resources.ServiceAccount.APIVersion, resources.ServiceAccount.Kind)
+	}
+	if resources.Role.APIVersion != "rbac.authorization.k8s.io/v1" || resources.Role.Kind != "Role" {
+		t.Fatalf("role TypeMeta = %q/%q", resources.Role.APIVersion, resources.Role.Kind)
+	}
+	if resources.RoleBinding.APIVersion != "rbac.authorization.k8s.io/v1" || resources.RoleBinding.Kind != "RoleBinding" {
+		t.Fatalf("role binding TypeMeta = %q/%q", resources.RoleBinding.APIVersion, resources.RoleBinding.Kind)
+	}
+
+	if len(resources.Role.Rules) != 1 {
+		t.Fatalf("role rules = %d, want 1", len(resources.Role.Rules))
+	}
+	rule := resources.Role.Rules[0]
+	if len(rule.APIGroups) != 1 || rule.APIGroups[0] != "*" ||
+		len(rule.Resources) != 1 || rule.Resources[0] != "*" ||
+		len(rule.Verbs) != 1 || rule.Verbs[0] != "*" {
+		t.Fatalf("role rule = %+v, want */*/*", rule)
+	}
+
+	if resources.RoleBinding.RoleRef.Kind != "Role" || resources.RoleBinding.RoleRef.Name != "pg" {
+		t.Fatalf("role binding roleRef = %+v, want Role/pg", resources.RoleBinding.RoleRef)
+	}
+	if len(resources.RoleBinding.Subjects) != 1 {
+		t.Fatalf("role binding subjects = %d, want 1", len(resources.RoleBinding.Subjects))
+	}
+	subject := resources.RoleBinding.Subjects[0]
+	if subject.Kind != "ServiceAccount" || subject.Name != "pg" || subject.Namespace != "ns-a" {
+		t.Fatalf("role binding subject = %+v, want ServiceAccount/pg/ns-a", subject)
+	}
+}
+
 func TestRenderDBResourcesOmitsExportServiceWhenPublicAccessDisabled(t *testing.T) {
 	resources, err := RenderDBResources(DBResourcesInput{
 		Engine:    "postgresql",


### PR DESCRIPTION
## What

Brain's DB create path rendered only the KubeBlocks `Cluster` (+ optional `<name>-export` Service), but not the per-DB `ServiceAccount` / `Role` / `RoleBinding` that the legacy sealos **dbprovider** creates and wires into the Cluster via `componentSpec.serviceAccountName`. A Brain-created DB therefore ran its pods on the `default` ServiceAccount with no Role — unlike every DB created through dbprovider (whose SA/Role/RoleBinding are the `managed-by: kbcli` objects seen in-cluster).

This ports that behavior into `apps/api`.

## Changes

- **`service/orchestration/db.go`** — new `RenderDBAccountResources` renders `ServiceAccount` + `Role` (`*/*/*`, faithful to dbprovider) + `RoleBinding`, all named `<dbName>` and labeled with the DB's `brain.io/*` labels; `RenderDBResources` returns them and sets `componentSpec.serviceAccountName=<dbName>`.
- **`route/db/mutation.go`** — `db-create` applies the RBAC before the Cluster (so the SA exists before KubeBlocks provisions pods); `db-delete`'s existing `brain.io` label sweep now also covers `serviceaccounts` / `roles` / `rolebindings`.
- **`service/orchestration/render_test.go`** — unit coverage for the rendered RBAC and the `serviceAccountName` wiring.

## Design note

dbprovider cleans up the RBAC via `ownerReferences` (Cluster owns them → K8s GC). Brain instead reclaims them through its existing `brain.io` label sweep in `deleteDBDirectResources`, matching how the export Service and OpsRequests are already cleaned up — one teardown mechanism instead of two. Trade-off: an out-of-band `kubectl delete cluster` would orphan the RBAC (the same limitation the export Service already has); adding `ownerReferences` is a possible follow-up.

The `*/*/*` Role is copied verbatim from dbprovider for functional parity; tightening it to least privilege is a separate hardening follow-up.

## Verification

- `go build` / `go vet` / `gofmt` clean; unit tests pass.
- Live-cluster E2E: KubeBlocks accepts the explicit `serviceAccountName` (read back as `<dbName>`), and the `brain.io` label sweep matched and reclaimed the SA + Role + RoleBinding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
