### PR TITLE
Remove stale AP database env helpers

### DIFF
--- a/apps/ui/src/features/project-settings/ap/k8s/ap-env-patch.test.ts
+++ b/apps/ui/src/features/project-settings/ap/k8s/ap-env-patch.test.ts
@@ -152,6 +152,74 @@ test("AP env settings patch preserves existing valueFrom rows omitted by raw sou
   ]);
 });
 
+test("AP settings draft removes unused compiled DB helpers with a deleted reference", () => {
+  const dbSecretRefs = {
+    host: { key: "endpoint", name: "postgres-conn-credential" },
+    password: { key: "passwd", name: "postgres-conn-credential" },
+    port: { key: "port", name: "postgres-conn-credential" },
+    username: { key: "user", name: "postgres-conn-credential" },
+  };
+  const unrelatedSecretRef = {
+    secretKeyRef: { key: "token", name: "app-secret" },
+  };
+  const previousRawSource = `DATABASE_URL=${referenceExpression(
+    "postgres",
+    "DATABASE_URL"
+  )}`;
+  const previousEnv = [
+    {
+      name: "DATABASE_URL",
+      value:
+        "postgresql://$(POSTGRES_USERNAME):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)",
+    },
+    {
+      name: "POSTGRES_USERNAME",
+      valueFrom: { secretKeyRef: dbSecretRefs.username },
+    },
+    {
+      name: "POSTGRES_PASSWORD",
+      valueFrom: { secretKeyRef: dbSecretRefs.password },
+    },
+    {
+      name: "POSTGRES_HOST",
+      valueFrom: { secretKeyRef: dbSecretRefs.host },
+    },
+    {
+      name: "POSTGRES_PORT",
+      valueFrom: { secretKeyRef: dbSecretRefs.port },
+    },
+    { name: "SECRET_TOKEN", valueFrom: unrelatedSecretRef },
+  ];
+
+  const ops = patchOpsForApSettingsDraft(
+    { input: { env: previousEnv, envRawSource: previousRawSource } },
+    { env: [], envRawSource: "" },
+    { env: previousEnv, envRawSource: previousRawSource },
+    {
+      dbDsnReferenceSources: [
+        {
+          name: "postgres",
+          namespace: "default",
+          primitiveSecretRefs: dbSecretRefs,
+        },
+      ],
+    }
+  );
+
+  assert.deepEqual(ops, [
+    {
+      op: "replace",
+      path: "/spec/input/env",
+      value: [{ name: "SECRET_TOKEN", valueFrom: unrelatedSecretRef }],
+    },
+    {
+      op: "replace",
+      path: "/spec/input/envRawSource",
+      value: "",
+    },
+  ]);
+});
+
 test("AP env settings patch compiles raw DB references into runtime env helpers", () => {
   const secretRefs = {
     host: { key: "endpoint", name: "postgres-conn-credential" },

--- a/apps/ui/src/features/project-settings/ap/k8s/ap-json-patch.ts
+++ b/apps/ui/src/features/project-settings/ap/k8s/ap-json-patch.ts
@@ -370,7 +370,10 @@ export function mibToMemoryLimit(mib: number): string {
 function buildEnvArray(
   originalEnv: unknown,
   edited: ApEnvVar[],
-  options: { preserveOmittedValueFrom?: boolean } = {}
+  options: {
+    dropOmittedValueFromNames?: ReadonlySet<string>;
+    preserveOmittedValueFrom?: boolean;
+  } = {}
 ): Record<string, unknown>[] {
   const originalRecords = namedEnvRecords(originalEnv);
   const originalByName = envRecordsByName(originalRecords);
@@ -378,7 +381,8 @@ function buildEnvArray(
   const merged = mergeExistingEnvRecords(
     originalRecords,
     editedByName,
-    options.preserveOmittedValueFrom === true
+    options.preserveOmittedValueFrom === true,
+    options.dropOmittedValueFromNames
   );
   appendNewEditedEnvRecords(merged.out, edited, editedByName, merged.emitted);
   return merged.out;
@@ -431,7 +435,8 @@ function editedEnvRecordsByName(
 function mergeExistingEnvRecords(
   originalRecords: readonly Record<string, unknown>[],
   editedByName: ReadonlyMap<string, Record<string, unknown>>,
-  preserveOmittedValueFrom: boolean
+  preserveOmittedValueFrom: boolean,
+  dropOmittedValueFromNames: ReadonlySet<string> | undefined
 ): { emitted: Set<string>; out: Record<string, unknown>[] } {
   const out: Record<string, unknown>[] = [];
   const emitted = new Set<string>();
@@ -442,11 +447,36 @@ function mergeExistingEnvRecords(
     if (editedRecord !== undefined && name !== undefined) {
       out.push(editedRecord);
       emitted.add(name);
-    } else if (preserveOmittedValueFrom && name !== undefined) {
+    } else if (
+      preserveOmittedValueFrom &&
+      name !== undefined &&
+      !dropOmittedValueFromNames?.has(name)
+    ) {
       appendPreservedValueFromRecord(out, name, record);
     }
   }
   return { emitted, out };
+}
+
+function compiledAutomaticHelperNames(
+  rawSource: unknown,
+  dbDsnReferenceSources: readonly ApEnvDbDsnSource[] | undefined
+): ReadonlySet<string> {
+  if (typeof rawSource !== "string" || rawSource === "") {
+    return new Set();
+  }
+  const compiled = compileApEnvRawSourceForRuntime(
+    rawSource,
+    dbDsnReferenceSources
+  );
+  if (!compiled.valid) {
+    return new Set();
+  }
+  return new Set(
+    compiled.env
+      .filter((row) => row.helper?.automatic === true)
+      .map((row) => row.name)
+  );
 }
 
 function appendPreservedValueFromRecord(
@@ -991,6 +1021,10 @@ export function patchOpsForApEnvSettings(
     }
     return patchOpsForApInput(spec, {
       env: buildEnvArray(input.env, result.env, {
+        dropOmittedValueFromNames: compiledAutomaticHelperNames(
+          input.envRawSource,
+          options.dbDsnReferenceSources
+        ),
         preserveOmittedValueFrom: true,
       }),
       envRawSource: result.envRawSource,
@@ -1249,6 +1283,10 @@ function patchOpsForApSettingsDraftInput(
         );
       }
       inputPatch.env = buildEnvArray(readApInput(spec ?? {}).env, result.env, {
+        dropOmittedValueFromNames: compiledAutomaticHelperNames(
+          readApInput(spec ?? {}).envRawSource,
+          options.dbDsnReferenceSources
+        ),
         preserveOmittedValueFrom: true,
       });
       inputPatch.envRawSource = result.envRawSource;


### PR DESCRIPTION
## What changed

- remove stale automatic database helper environment variables when an AP database reference is deleted
- preserve unrelated `valueFrom` environment variables
- add a regression test covering removal of `DATABASE_URL` and its compiled database secret helpers

## Why

Deleting `DATABASE_URL` from an AP's Environment list removed the raw reference but preserved the automatically compiled `POSTGRES_*` helper variables. Those stale helpers kept the AP-to-database canvas connection visible.

The patch derives the automatic helper names from the previous raw source and excludes only those names from the existing `valueFrom` preservation path.

## Impact

Deleting an AP database reference now removes the generated helper variables, allowing the corresponding AP-to-database connection to disappear while leaving unrelated secret-backed environment variables intact.

## Validation

- `bun typecheck`
- `bun check`
- targeted regression test: `AP settings draft removes unused compiled DB helpers with a deleted reference`
