### PR TITLE
perf(ui): throttle work while hidden in the Sealos desktop iframe

### DIFF
--- a/apps/ui/next.config.mjs
+++ b/apps/ui/next.config.mjs
@@ -12,6 +12,22 @@ const nextConfig = {
     /** Enables `unauthorized()` from `next/navigation` for server-side auth checks. */
     authInterrupts: true,
   },
+  headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          // The app runs inside a Sealos desktop iframe on a same-site origin
+          // (*.cloud.sealos.io), so Chromium co-hosts it with the desktop
+          // shell and every other open app on ONE renderer main thread.
+          // Origin-Agent-Cluster asks for an origin-keyed agent cluster,
+          // which desktop Chromium backs with a dedicated process when
+          // resources allow. Verify via `window.originAgentCluster`.
+          { key: "Origin-Agent-Cluster", value: "?1" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/apps/ui/src/app/project/horizon-webgl.tsx
+++ b/apps/ui/src/app/project/horizon-webgl.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import {
+  isEffectivelyVisible,
+  subscribeEffectiveVisibility,
+} from "@workspace/ui/lib/effective-visibility";
 import { Mesh, Program, Renderer, Triangle } from "ogl";
 import { useEffect, useRef } from "react";
 
@@ -493,8 +497,16 @@ export default function HorizonWebgl({ onPhase, values }: HorizonWebglProps) {
     // which measured nearly as expensive as drawing (~129 wakes/s ≈ +180ms/s
     // task time on a 120Hz display).
     const RAF_HANDOFF_MS = 4;
+    let parked = false;
     const schedule = () => {
       if (disposed) {
+        return;
+      }
+      // Park while hidden. A hidden tab starves rAF on its own, but a
+      // Sealos-desktop window hidden with opacity 0 keeps rAF firing at
+      // full rate — the loop has to gate itself.
+      if (!isEffectivelyVisible()) {
+        parked = true;
         return;
       }
       const waitMs = nextDueMs - performance.now();
@@ -558,9 +570,16 @@ export default function HorizonWebgl({ onPhase, values }: HorizonWebglProps) {
       schedule();
     };
     rafId = requestAnimationFrame(tick);
+    const unsubscribeVisibility = subscribeEffectiveVisibility((visible) => {
+      if (visible && parked && !disposed) {
+        parked = false;
+        schedule();
+      }
+    });
 
     return () => {
       disposed = true;
+      unsubscribeVisibility();
       cancelAnimationFrame(rafId);
       clearTimeout(timeoutId);
       resizeObserver.disconnect();

--- a/apps/ui/src/features/project-canvas/snapshot/use-project-canvas-resource-snapshot.ts
+++ b/apps/ui/src/features/project-canvas/snapshot/use-project-canvas-resource-snapshot.ts
@@ -5,6 +5,10 @@ import { apItemsFromList } from "@workspace/api/lib/ap-list";
 import type { K8sGetResponse } from "@workspace/api/schemas/k8s-get";
 import type { CanvasState } from "@workspace/ui/components/canvas/canvas.types";
 import {
+  isEffectivelyVisible,
+  subscribeEffectiveVisibility,
+} from "@workspace/ui/lib/effective-visibility";
+import {
   useCallback,
   useEffect,
   useMemo,
@@ -283,21 +287,15 @@ export function useProjectCanvasResourceSnapshot(options: {
   }, [revalidate, resetWorkloadDiscoveryPollWindow]);
 
   useEffect(() => {
-    const nextIsPageVisible =
-      typeof document === "undefined" ? true : !document.hidden;
-    setIsPageVisible(nextIsPageVisible);
-
-    const onVisibilityChange = () => {
-      const visible = !document.hidden;
+    // Effective visibility also covers being hidden by the Sealos desktop
+    // (opacity-0 iframe), which `document.hidden` never reports.
+    setIsPageVisible(isEffectivelyVisible());
+    return subscribeEffectiveVisibility((visible) => {
       setIsPageVisible(visible);
       if (visible) {
         revalidate().catch(() => undefined);
       }
-    };
-    document.addEventListener("visibilitychange", onVisibilityChange);
-    return () => {
-      document.removeEventListener("visibilitychange", onVisibilityChange);
-    };
+    });
   }, [revalidate]);
 
   const error = apsError ?? dbsError ?? deploymentTasksStore.error;

--- a/apps/ui/src/features/project-canvas/telemetry/workload-telemetry-react.tsx
+++ b/apps/ui/src/features/project-canvas/telemetry/workload-telemetry-react.tsx
@@ -4,6 +4,10 @@ import { API_ROUTES } from "@workspace/api/constants";
 import { fetcher } from "@workspace/api/fetch";
 import { ApiUrl } from "@workspace/api/utils";
 import {
+  isEffectivelyVisible,
+  subscribeEffectiveVisibility,
+} from "@workspace/ui/lib/effective-visibility";
+import {
   createContext,
   type ReactNode,
   useCallback,
@@ -60,12 +64,21 @@ export function WorkloadTelemetryProvider({
       return;
     }
     const id = window.setInterval(() => {
-      if (!store.hasActiveTargets()) {
+      // Skip while the tab or the embedding desktop window hides the app.
+      if (!(isEffectivelyVisible() && store.hasActiveTargets())) {
         return;
       }
       store.refresh().catch(() => undefined);
     }, refreshIntervalMs);
-    return () => window.clearInterval(id);
+    const unsubscribe = subscribeEffectiveVisibility((visible) => {
+      if (visible && store.hasActiveTargets()) {
+        store.refresh().catch(() => undefined);
+      }
+    });
+    return () => {
+      window.clearInterval(id);
+      unsubscribe();
+    };
   }, [refreshIntervalMs, store]);
 
   return (

--- a/apps/ui/src/features/project-canvas/workbench/use-project-canvas-module.ts
+++ b/apps/ui/src/features/project-canvas/workbench/use-project-canvas-module.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { isEffectivelyVisible } from "@workspace/ui/lib/effective-visibility";
 import {
   createElement,
   Fragment,
@@ -60,7 +61,7 @@ function deploymentTaskCanStartCompletionNotice(
 }
 
 function currentPageVisible(): boolean {
-  return typeof document === "undefined" ? true : !document.hidden;
+  return isEffectivelyVisible();
 }
 
 function pruneExpiredCompletionNotices(

--- a/packages/ui/src/lib/effective-visibility.test.ts
+++ b/packages/ui/src/lib/effective-visibility.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { createEffectiveVisibilityTracker } from "./effective-visibility";
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const CONFIRM_MS = 30;
+
+function trackerWithFocus(hasFocus: () => boolean) {
+  const tracker = createEffectiveVisibilityTracker({
+    confirmHiddenMs: CONFIRM_MS,
+    hasFocus,
+  });
+  const emitted: boolean[] = [];
+  tracker.subscribe((visible) => emitted.push(visible));
+  return { emitted, tracker };
+}
+
+test("starts visible and stays visible without sentinel reports", async () => {
+  const { emitted, tracker } = trackerWithFocus(() => false);
+  assert.equal(tracker.isVisible(), true);
+  await sleep(CONFIRM_MS * 2);
+  assert.equal(tracker.isVisible(), true);
+  assert.deepEqual(emitted, []);
+});
+
+test("a not-visible sentinel flips hidden only after the confirm window", async () => {
+  const { emitted, tracker } = trackerWithFocus(() => false);
+
+  tracker.reportSentinelVisibility(false);
+  assert.equal(tracker.isVisible(), true);
+  await sleep(CONFIRM_MS / 3);
+  assert.equal(tracker.isVisible(), true);
+
+  await sleep(CONFIRM_MS * 2);
+  assert.equal(tracker.isVisible(), false);
+  assert.deepEqual(emitted, [false]);
+});
+
+test("a focused document postpones the hidden flip until focus is lost", async () => {
+  let focused = true;
+  const { tracker } = trackerWithFocus(() => focused);
+
+  tracker.reportSentinelVisibility(false);
+  await sleep(CONFIRM_MS * 2);
+  assert.equal(tracker.isVisible(), true);
+
+  // Focus leaves; the re-armed confirm window now completes.
+  focused = false;
+  await sleep(CONFIRM_MS * 2);
+  assert.equal(tracker.isVisible(), false);
+});
+
+test("a visible sentinel report resumes immediately", async () => {
+  const { emitted, tracker } = trackerWithFocus(() => false);
+
+  tracker.reportSentinelVisibility(false);
+  await sleep(CONFIRM_MS * 2);
+  assert.equal(tracker.isVisible(), false);
+
+  tracker.reportSentinelVisibility(true);
+  assert.equal(tracker.isVisible(), true);
+  assert.deepEqual(emitted, [false, true]);
+});
+
+test("interaction resumes immediately and restarts the confirm window", async () => {
+  const { tracker } = trackerWithFocus(() => false);
+
+  tracker.reportSentinelVisibility(false);
+  await sleep(CONFIRM_MS * 2);
+  assert.equal(tracker.isVisible(), false);
+
+  tracker.reportInteraction();
+  assert.equal(tracker.isVisible(), true);
+
+  // Sentinel state is still not-visible, so with no further interaction the
+  // tracker re-confirms hidden one window later.
+  await sleep(CONFIRM_MS * 2);
+  assert.equal(tracker.isVisible(), false);
+});
+
+test("interaction keeps a spuriously occluded app visible", async () => {
+  const { tracker } = trackerWithFocus(() => false);
+
+  tracker.reportSentinelVisibility(false);
+  for (let i = 0; i < 4; i += 1) {
+    await sleep(CONFIRM_MS / 3);
+    tracker.reportInteraction();
+    assert.equal(tracker.isVisible(), true);
+  }
+});
+
+test("tab visibility folds into the effective state without duplicate emits", async () => {
+  const { emitted, tracker } = trackerWithFocus(() => false);
+
+  tracker.setTabVisible(false);
+  assert.equal(tracker.isVisible(), false);
+  tracker.setTabVisible(true);
+  assert.equal(tracker.isVisible(), true);
+  assert.deepEqual(emitted, [false, true]);
+
+  // Already embedded-hidden: tab flips must not re-emit an unchanged state.
+  tracker.reportSentinelVisibility(false);
+  await sleep(CONFIRM_MS * 2);
+  assert.deepEqual(emitted, [false, true, false]);
+  tracker.setTabVisible(false);
+  tracker.setTabVisible(true);
+  assert.deepEqual(emitted, [false, true, false]);
+});
+
+test("unsubscribe stops notifications", async () => {
+  const tracker = createEffectiveVisibilityTracker({
+    confirmHiddenMs: CONFIRM_MS,
+    hasFocus: () => false,
+  });
+  const emitted: boolean[] = [];
+  const unsubscribe = tracker.subscribe((visible) => emitted.push(visible));
+  unsubscribe();
+
+  tracker.reportSentinelVisibility(false);
+  await sleep(CONFIRM_MS * 2);
+  assert.equal(tracker.isVisible(), false);
+  assert.deepEqual(emitted, []);
+});

--- a/packages/ui/src/lib/effective-visibility.ts
+++ b/packages/ui/src/lib/effective-visibility.ts
@@ -1,0 +1,255 @@
+/**
+ * Effective visibility: whether the user can actually see this app.
+ *
+ * `document.visibilityState` only reflects the browser tab. When the app runs
+ * embedded in the Sealos desktop, hidden windows are kept mounted with
+ * `opacity: 0` on an ancestor in the PARENT document — the tab stays
+ * "visible", timers run at foreground speed, and every poller keeps burning
+ * the renderer main thread it shares with the desktop shell.
+ *
+ * This module folds two signals into one boolean:
+ * - tab visibility (`visibilitychange`), identical to the old behavior;
+ * - an IntersectionObserver v2 sentinel (`trackVisibility`) that sees
+ *   ancestor-frame opacity/transform/occlusion across the iframe boundary.
+ *
+ * IOv2 `isVisible` is deliberately conservative (false while actually
+ * visible is possible, e.g. content overlapping the frame edge), so the
+ * sentinel is a 4px element at the viewport CENTER, painted above all
+ * in-document content, and a not-visible report only flips the state after
+ * it persists for a confirm window with no user interaction and no document
+ * focus. Any interaction or a visible report resumes immediately. Browsers
+ * without IOv2 (Firefox/Safari) never leave the visible state, which is
+ * exactly the pre-existing behavior.
+ */
+
+export const EFFECTIVE_VISIBILITY_CONFIRM_HIDDEN_MS = 5000;
+/** IOv2 requires `delay >= 100` when `trackVisibility` is on. */
+const TRACK_VISIBILITY_DELAY_MS = 100;
+
+type VisibilityTrackingObserverInit = IntersectionObserverInit & {
+  delay?: number;
+  trackVisibility?: boolean;
+};
+
+type VisibilityTrackingEntry = IntersectionObserverEntry & {
+  isVisible?: boolean;
+};
+
+export interface EffectiveVisibilityTrackerOptions {
+  /** Continuous not-visible time required before flipping hidden. */
+  confirmHiddenMs?: number;
+  /**
+   * Focus probe checked before confirming hidden: a focused document means
+   * the user is (or was last) interacting here, so a not-visible report is
+   * treated as a false positive and re-checked one confirm window later.
+   */
+  hasFocus?: () => boolean;
+}
+
+export function createEffectiveVisibilityTracker(
+  options?: EffectiveVisibilityTrackerOptions
+) {
+  const confirmHiddenMs =
+    options?.confirmHiddenMs ?? EFFECTIVE_VISIBILITY_CONFIRM_HIDDEN_MS;
+  const hasFocus =
+    options?.hasFocus ??
+    (() => (typeof document === "undefined" ? false : document.hasFocus()));
+
+  let tabVisible = true;
+  let embeddedVisible = true;
+  /** Last IOv2 report; null until the sentinel produces one. */
+  let sentinelVisible: boolean | null = null;
+  let confirmTimer: ReturnType<typeof setTimeout> | null = null;
+  const listeners = new Set<(visible: boolean) => void>();
+
+  function isVisible() {
+    return tabVisible && embeddedVisible;
+  }
+
+  function emitAfter(previous: boolean) {
+    const next = isVisible();
+    if (next === previous) {
+      return;
+    }
+    for (const listener of [...listeners]) {
+      listener(next);
+    }
+  }
+
+  function cancelConfirm() {
+    if (confirmTimer === null) {
+      return;
+    }
+    clearTimeout(confirmTimer);
+    confirmTimer = null;
+  }
+
+  function armConfirm() {
+    if (confirmTimer !== null || !embeddedVisible) {
+      return;
+    }
+    confirmTimer = setTimeout(() => {
+      confirmTimer = null;
+      if (sentinelVisible !== false) {
+        return;
+      }
+      if (hasFocus()) {
+        // Likely a conservative false positive — re-check next window.
+        armConfirm();
+        return;
+      }
+      const previous = isVisible();
+      embeddedVisible = false;
+      emitAfter(previous);
+    }, confirmHiddenMs);
+  }
+
+  return {
+    isVisible,
+    /**
+     * User input proves the app is visible right now. It also restarts the
+     * confirm window: a stale not-visible sentinel state must re-earn the
+     * hidden flip after the interaction stops.
+     */
+    reportInteraction() {
+      cancelConfirm();
+      if (!embeddedVisible) {
+        const previous = isVisible();
+        embeddedVisible = true;
+        emitAfter(previous);
+      }
+      if (sentinelVisible === false) {
+        armConfirm();
+      }
+    },
+    reportSentinelVisibility(visible: boolean) {
+      sentinelVisible = visible;
+      if (visible) {
+        cancelConfirm();
+        if (!embeddedVisible) {
+          const previous = isVisible();
+          embeddedVisible = true;
+          emitAfter(previous);
+        }
+        return;
+      }
+      armConfirm();
+    },
+    setTabVisible(visible: boolean) {
+      if (visible === tabVisible) {
+        return;
+      }
+      const previous = isVisible();
+      tabVisible = visible;
+      emitAfter(previous);
+    },
+    subscribe(listener: (visible: boolean) => void) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+
+type EffectiveVisibilityTracker = ReturnType<
+  typeof createEffectiveVisibilityTracker
+>;
+
+const INTERACTION_EVENTS = [
+  "keydown",
+  "pointerdown",
+  "pointermove",
+  "wheel",
+] as const;
+
+function installSentinel(tracker: EffectiveVisibilityTracker) {
+  const sentinel = document.createElement("div");
+  sentinel.setAttribute("data-slot", "effective-visibility-sentinel");
+  sentinel.setAttribute("aria-hidden", "true");
+  // Center of the viewport (edges get occluded by desktop chrome like the
+  // dock), above every in-document stacking context so own content never
+  // counts as occlusion. Transparent background keeps effective opacity 1.
+  sentinel.style.cssText =
+    "position:fixed;left:calc(50% - 2px);top:calc(50% - 2px);width:4px;height:4px;z-index:2147483647;pointer-events:none;background:transparent;";
+  document.body.appendChild(sentinel);
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      const entry = entries.at(-1) as VisibilityTrackingEntry | undefined;
+      if (!entry) {
+        return;
+      }
+      if (entry.isVisible === undefined) {
+        // No IOv2 support — fall back to tab visibility only.
+        observer.disconnect();
+        sentinel.remove();
+        return;
+      }
+      tracker.reportSentinelVisibility(entry.isVisible);
+    },
+    {
+      delay: TRACK_VISIBILITY_DELAY_MS,
+      threshold: 0,
+      trackVisibility: true,
+    } as VisibilityTrackingObserverInit
+  );
+  observer.observe(sentinel);
+}
+
+function installDomSources(tracker: EffectiveVisibilityTracker) {
+  tracker.setTabVisible(document.visibilityState !== "hidden");
+  document.addEventListener("visibilitychange", () => {
+    tracker.setTabVisible(document.visibilityState !== "hidden");
+  });
+
+  const onInteraction = () => tracker.reportInteraction();
+  for (const type of INTERACTION_EVENTS) {
+    window.addEventListener(type, onInteraction, {
+      capture: true,
+      passive: true,
+    });
+  }
+
+  try {
+    if (document.body === null) {
+      document.addEventListener(
+        "DOMContentLoaded",
+        () => installSentinel(tracker),
+        { once: true }
+      );
+    } else {
+      installSentinel(tracker);
+    }
+  } catch {
+    // Observer construction failed — tab visibility keeps working alone.
+  }
+}
+
+let sharedTracker: EffectiveVisibilityTracker | null = null;
+
+function getSharedTracker(): EffectiveVisibilityTracker {
+  if (sharedTracker === null) {
+    sharedTracker = createEffectiveVisibilityTracker();
+    installDomSources(sharedTracker);
+  }
+  return sharedTracker;
+}
+
+/** True while the user can plausibly see the app. Always true during SSR. */
+export function isEffectivelyVisible(): boolean {
+  if (typeof document === "undefined") {
+    return true;
+  }
+  return getSharedTracker().isVisible();
+}
+
+/** Calls `listener` on every effective-visibility flip; returns unsubscribe. */
+export function subscribeEffectiveVisibility(
+  listener: (visible: boolean) => void
+): () => void {
+  if (typeof document === "undefined") {
+    return () => undefined;
+  }
+  return getSharedTracker().subscribe(listener);
+}

--- a/packages/ui/src/lib/status-heartbeat.test.ts
+++ b/packages/ui/src/lib/status-heartbeat.test.ts
@@ -65,6 +65,51 @@ test("beat survives while any ref remains", async () => {
   releaseB();
 });
 
+test("setSuspended pauses beats and resuming restarts them immediately", async () => {
+  const root = fakeRoot();
+  const heartbeat = createStatusHeartbeat(root, FAST);
+
+  const release = heartbeat.acquire();
+  heartbeat.setSuspended(true);
+  const paused = root.attributes.get("data-status-heartbeat");
+  await sleep(40);
+  assert.equal(root.attributes.get("data-status-heartbeat"), paused);
+
+  heartbeat.setSuspended(false);
+  assert.notEqual(root.attributes.get("data-status-heartbeat"), paused);
+
+  release();
+});
+
+test("acquire while suspended defers the first beat to resume", async () => {
+  const root = fakeRoot();
+  const heartbeat = createStatusHeartbeat(root, FAST);
+
+  heartbeat.setSuspended(true);
+  const release = heartbeat.acquire();
+  await sleep(40);
+  assert.equal(root.attributes.has("data-status-heartbeat"), false);
+
+  heartbeat.setSuspended(false);
+  assert.equal(root.attributes.has("data-status-heartbeat"), true);
+
+  release();
+});
+
+test("releasing the last ref while suspended clears the attribute", async () => {
+  const root = fakeRoot();
+  const heartbeat = createStatusHeartbeat(root, FAST);
+
+  const release = heartbeat.acquire();
+  heartbeat.setSuspended(true);
+  release();
+  assert.equal(root.attributes.has("data-status-heartbeat"), false);
+
+  heartbeat.setSuspended(false);
+  await sleep(40);
+  assert.equal(root.attributes.has("data-status-heartbeat"), false);
+});
+
 test("setPeriodMs clamps to the minimum period", async () => {
   const root = fakeRoot();
   const heartbeat = createStatusHeartbeat(root, {

--- a/packages/ui/src/lib/status-heartbeat.ts
+++ b/packages/ui/src/lib/status-heartbeat.ts
@@ -2,6 +2,11 @@
 
 import { useEffect } from "react";
 
+import {
+  isEffectivelyVisible,
+  subscribeEffectiveVisibility,
+} from "./effective-visibility";
+
 /**
  * Shared scheduler for status-dot ping pulses. Breathing dots opt in with
  * `useStatusHeartbeat` plus the `status-heartbeat-ping` class (globals.css):
@@ -36,6 +41,7 @@ export function createStatusHeartbeat(
   let periodMs = Math.max(minPeriodMs, options?.periodMs ?? DEFAULT_PERIOD_MS);
   let phase: "a" | "b" = "b";
   let refCount = 0;
+  let suspended = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
 
   function beat() {
@@ -43,7 +49,18 @@ export function createStatusHeartbeat(
     root.setAttribute(ATTRIBUTE, phase);
   }
 
+  function stopTimer() {
+    if (timer === null) {
+      return;
+    }
+    clearTimeout(timer);
+    timer = null;
+  }
+
   function schedule() {
+    if (suspended) {
+      return;
+    }
     timer = setTimeout(() => {
       beat();
       schedule();
@@ -54,19 +71,37 @@ export function createStatusHeartbeat(
     /** Starts beating on first acquire; returns the matching release. */
     acquire() {
       refCount += 1;
-      if (refCount === 1) {
+      if (refCount === 1 && !suspended) {
         beat();
         schedule();
       }
       return () => {
         refCount -= 1;
-        if (refCount > 0 || timer === null) {
+        if (refCount > 0) {
           return;
         }
-        clearTimeout(timer);
-        timer = null;
+        stopTimer();
         root.removeAttribute(ATTRIBUTE);
       };
+    },
+    /**
+     * Pauses beats while the app is not effectively visible (hidden tab or
+     * hidden desktop window); each flip forces a root-attribute style recalc
+     * that nobody can see. Resuming beats immediately.
+     */
+    setSuspended(next: boolean) {
+      if (next === suspended) {
+        return;
+      }
+      suspended = next;
+      if (suspended) {
+        stopTimer();
+        return;
+      }
+      if (refCount > 0) {
+        beat();
+        schedule();
+      }
     },
     setPeriodMs(nextMs: number) {
       const clamped = Math.max(minPeriodMs, Math.round(nextMs));
@@ -87,7 +122,14 @@ type StatusHeartbeat = ReturnType<typeof createStatusHeartbeat>;
 let sharedHeartbeat: StatusHeartbeat | null = null;
 
 function getSharedHeartbeat(): StatusHeartbeat {
-  sharedHeartbeat ??= createStatusHeartbeat(document.documentElement);
+  if (sharedHeartbeat === null) {
+    const heartbeat = createStatusHeartbeat(document.documentElement);
+    heartbeat.setSuspended(!isEffectivelyVisible());
+    subscribeEffectiveVisibility((visible) => {
+      heartbeat.setSuspended(!visible);
+    });
+    sharedHeartbeat = heartbeat;
+  }
   return sharedHeartbeat;
 }
 


### PR DESCRIPTION
The desktop hides background app windows with opacity: 0, which never triggers iframe render throttling and never flips document.hidden, so an invisible brain window kept polling at foreground cadence, beating the status heartbeat, and rendering the index horizon at 24fps — all on a renderer main thread shared same-site with the desktop shell.

- Send Origin-Agent-Cluster: ?1 so Chromium can give the app its own renderer process despite being same-site with the desktop. Verify via window.originAgentCluster === true.
- Add effective-visibility (packages/ui/lib): tab visibility combined with an IntersectionObserver v2 sentinel that sees parent-frame hiding across the iframe boundary; a not-visible report needs 5s with no interaction and no document focus before flipping hidden, and any interaction or visible report resumes instantly. Falls back to tab-visibility-only where IOv2 is unsupported.
- Gate workload/deployment polling, the telemetry interval, the status heartbeat, and the horizon WebGL loop on it; revalidate immediately when the window is shown again.