### PR TITLE
Hide unsupported GitHub configure action

### DIFF
--- a/apps/ui/src/features/deploy/github-deployer/github-deployer.test.tsx
+++ b/apps/ui/src/features/deploy/github-deployer/github-deployer.test.tsx
@@ -76,7 +76,7 @@ test("GithubDeployer keeps URL input while showing authorized repo choices", () 
   assert.match(html, REPOSITORY_SECTION_RE);
   assert.doesNotMatch(html, URL_AUTH_REQUIRED_RE);
   assert.match(html, AUTHORIZED_RE);
-  assert.match(html, CONFIGURE_BUTTON_RE);
+  assert.doesNotMatch(html, CONFIGURE_BUTTON_RE);
   assert.match(html, DISCONNECT_BUTTON_RE);
   assert.match(html, REPO_SELECT_RE);
   assert.match(html, REPO_CARD_RE);
@@ -151,7 +151,7 @@ test("GithubDeployer shows authorized empty repository state", () => {
   );
 
   assert.match(html, AUTHORIZED_RE);
-  assert.match(html, CONFIGURE_BUTTON_RE);
+  assert.doesNotMatch(html, CONFIGURE_BUTTON_RE);
   assert.match(html, REPO_EMPTY_RE);
   assert.doesNotMatch(html, AUTH_BUTTON_RE);
 });
@@ -172,7 +172,7 @@ test("GithubDeployer shows repository load errors after authorization", () => {
   );
 
   assert.match(html, AUTHORIZED_RE);
-  assert.match(html, CONFIGURE_BUTTON_RE);
+  assert.doesNotMatch(html, CONFIGURE_BUTTON_RE);
   assert.match(html, REPO_ERROR_RE);
   assert.match(html, BAD_CREDENTIALS_RE);
   assert.doesNotMatch(html, AUTH_BUTTON_RE);

--- a/apps/ui/src/features/deploy/github-deployer/github-deployer.tsx
+++ b/apps/ui/src/features/deploy/github-deployer/github-deployer.tsx
@@ -13,7 +13,6 @@ import {
   RefreshCw,
   Rocket,
   Search,
-  Settings2,
   ShieldCheck,
 } from "lucide-react";
 import { type ComponentProps, type ReactNode, useMemo, useState } from "react";
@@ -446,7 +445,7 @@ function GithubDeployerRepoSelect({ className }: { className?: string }) {
 
 function GithubDeployerAccountStatus() {
   const {
-    actions: { onAuthorize, onDisconnect },
+    actions: { onDisconnect },
     states: { deployedRepo, isAuthorized, isLoading },
   } = useGithubDeployer();
 
@@ -468,18 +467,8 @@ function GithubDeployerAccountStatus() {
         />
         <span className="truncate">Workspace GitHub connected</span>
       </div>
-      <Button
-        aria-label="Configure workspace GitHub access"
-        className="size-9 rounded-lg bg-white/5 text-muted-foreground hover:bg-input hover:text-foreground"
-        data-slot="github-deployer-configure"
-        disabled={isLoading || !onAuthorize}
-        onClick={onAuthorize}
-        size="icon-lg"
-        type="button"
-        variant="ghost"
-      >
-        <Settings2 aria-hidden className="size-4" strokeWidth={2} />
-      </Button>
+      {/* OAuth connections cannot configure repository-level access. Restore a
+          configure control only when it is backed by a GitHub App installation. */}
       <Button
         aria-label="Disconnect GitHub"
         className="size-9 rounded-lg bg-white/5 text-muted-foreground hover:bg-input hover:text-foreground"


### PR DESCRIPTION
## Summary

- hide the unsupported GitHub configure control from the connected workspace state
- let the connected status fill the space while preserving the disconnect action
- document why the control is hidden and update authorized-state coverage

## Why

The configure control reused the OAuth authorization action. For an already authorized account, that opened a popup which immediately completed and closed without offering repository-level configuration. The current OAuth integration does not support selecting repository access, so the control was misleading.

## Impact

Connected users now see an expanded `Workspace GitHub connected` status alongside the existing disconnect action, without the non-functional configure popup.

## Validation

- `bun test apps/ui/src/features/deploy/github-deployer/github-deployer.test.tsx`
- `bun typecheck`
- `bun check`
