### PR TITLE
feat(ui): deploy templates from URL

### DIFF
--- a/apps/ui/src/app/deploy/page.tsx
+++ b/apps/ui/src/app/deploy/page.tsx
@@ -1,0 +1,14 @@
+import { redirect } from "next/navigation";
+import { templateDeployProjectPath } from "@/features/deploy/template-deploy-link";
+
+export default async function DeployPage({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    templateForm?: string | string[];
+    templateName?: string | string[];
+  }>;
+}) {
+  const { templateForm, templateName } = await searchParams;
+  redirect(templateDeployProjectPath(templateName, templateForm));
+}

--- a/apps/ui/src/features/deploy/template-deploy-link.test.ts
+++ b/apps/ui/src/features/deploy/template-deploy-link.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { parseProjectSideRouteState } from "@/features/panes/side-url-codec";
+import { templateDeployProjectPath } from "./template-deploy-link";
+import { TEMPLATE_NAME_MAX_LENGTH } from "./template-deployment-intent";
+
+function sideFromPath(path: string) {
+  const url = new URL(path, "https://brain.test");
+  return parseProjectSideRouteState({ side: url.searchParams.get("side") })
+    .side;
+}
+
+test("template deploy link opens the requested template creation entry", () => {
+  assert.deepEqual(sideFromPath(templateDeployProjectPath("flowise")), {
+    entryMode: "templateDirect",
+    kind: "projectCreation",
+    templateName: "flowise",
+  });
+});
+
+test("template deploy link trims and safely encodes a template name", () => {
+  assert.deepEqual(
+    sideFromPath(templateDeployProjectPath("  team:flow / v1  ")),
+    {
+      entryMode: "templateDirect",
+      kind: "projectCreation",
+      templateName: "team:flow / v1",
+    }
+  );
+});
+
+test("template deploy link carries the template form into the creation intent", () => {
+  assert.deepEqual(
+    sideFromPath(
+      templateDeployProjectPath(
+        "flowise",
+        JSON.stringify({ enabled: true, port: "3000" })
+      )
+    ),
+    {
+      entryMode: "templateDirect",
+      kind: "projectCreation",
+      templateForm: JSON.stringify({ enabled: "true", port: "3000" }),
+      templateName: "flowise",
+    }
+  );
+});
+
+test("missing, blank, repeated, and overlong names open generic template creation", () => {
+  for (const value of [
+    undefined,
+    null,
+    "   ",
+    ["flowise", "dify"],
+    "x".repeat(TEMPLATE_NAME_MAX_LENGTH + 1),
+  ]) {
+    assert.deepEqual(sideFromPath(templateDeployProjectPath(value)), {
+      entryMode: "templateDirect",
+      kind: "projectCreation",
+    });
+  }
+});

--- a/apps/ui/src/features/deploy/template-deploy-link.ts
+++ b/apps/ui/src/features/deploy/template-deploy-link.ts
@@ -1,0 +1,33 @@
+import { serializeProjectSideSurfaceEntry } from "@/features/panes/url-codec";
+import {
+  normalizeTemplateName,
+  parseTemplateForm,
+} from "./template-deployment-intent";
+
+export function templateDeployProjectPath(
+  templateName: string | string[] | null | undefined,
+  templateForm?: string | string[] | null
+): string {
+  const normalizedTemplateName =
+    typeof templateName === "string"
+      ? normalizeTemplateName(templateName)
+      : null;
+  const normalizedTemplateForm =
+    typeof templateForm === "string" ? parseTemplateForm(templateForm) : null;
+  const side = serializeProjectSideSurfaceEntry({
+    entryMode: "templateDirect",
+    kind: "projectCreation",
+    ...(normalizedTemplateName == null
+      ? {}
+      : { templateName: normalizedTemplateName }),
+    ...(normalizedTemplateName != null && normalizedTemplateForm != null
+      ? { templateForm: JSON.stringify(normalizedTemplateForm) }
+      : {}),
+  });
+  const searchParams = new URLSearchParams();
+  if (side != null) {
+    searchParams.set("side", side);
+  }
+  const query = searchParams.toString();
+  return query === "" ? "/project" : `/project?${query}`;
+}

--- a/apps/ui/src/features/deploy/template-deployer.interaction.test.tsx
+++ b/apps/ui/src/features/deploy/template-deployer.interaction.test.tsx
@@ -1,0 +1,325 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { fireEvent, render } from "@testing-library/react/pure";
+
+import {
+  actAndDrain,
+  installTestDom,
+  restoreActEnvironment,
+  setActEnvironment,
+} from "@/features/project-canvas/react-test-harness";
+import {
+  TemplateDeployer,
+  type TemplateDeploymentChoice,
+  type TemplateDeploymentSettings,
+} from "./template-deployer";
+
+const FLOWISE = {
+  args: [
+    {
+      default: "3000",
+      description: "HTTP port",
+      key: "port",
+      required: true,
+      type: "string",
+    },
+  ],
+  description: "Flowise template",
+  name: "flowise",
+  title: "Flowise",
+} satisfies TemplateDeploymentChoice;
+
+const DIFY = {
+  args: [
+    {
+      default: "",
+      description: "Admin password",
+      key: "password",
+      required: true,
+      type: "password",
+    },
+  ],
+  description: "Dify template",
+  name: "dify",
+  title: "Dify",
+} satisfies TemplateDeploymentChoice;
+
+const CATALOG_ERROR_RE = /Could not load template catalog/;
+const FLOWISE_RE = /Flowise/;
+const LOADING_TEMPLATES_RE = /Loading templates/;
+const UNAVAILABLE_TEMPLATE_RE = /Template "missing-template" is unavailable/;
+
+async function withTestDom(run: (act: typeof actAndDrain) => Promise<void>) {
+  const dom = installTestDom();
+  const previousAct = setActEnvironment(true);
+  try {
+    await run(actAndDrain);
+  } finally {
+    restoreActEnvironment(previousAct);
+    await dom.restore();
+  }
+}
+
+test("async catalog loading preserves and selects the requested template", async () => {
+  await withTestDom(async (act) => {
+    const deployments: TemplateDeploymentSettings[] = [];
+    const initialSettings = { templateName: "flowise" };
+    let rendered: ReturnType<typeof render> | undefined;
+    try {
+      await act(() => {
+        rendered = render(
+          <TemplateDeployer
+            initialSettings={initialSettings}
+            loading
+            onDeploy={(settings) => {
+              deployments.push(settings);
+            }}
+            templateOptions={[]}
+          />
+        );
+      });
+      assert.match(rendered?.container.textContent ?? "", LOADING_TEMPLATES_RE);
+      assert.equal(deployments.length, 0);
+
+      await act(() => {
+        rendered?.rerender(
+          <TemplateDeployer
+            initialSettings={initialSettings}
+            onDeploy={(settings) => {
+              deployments.push(settings);
+            }}
+            templateOptions={[DIFY, FLOWISE]}
+          />
+        );
+      });
+
+      const combobox = rendered?.getByTestId(
+        "template.deployer.template-combobox"
+      );
+      const port = rendered?.getByLabelText("port") as
+        | HTMLInputElement
+        | undefined;
+      const submit = rendered?.getByTestId("template.deployer.submit") as
+        | HTMLButtonElement
+        | undefined;
+      assert.match(combobox?.textContent ?? "", FLOWISE_RE);
+      assert.equal(port?.value, "3000");
+      assert.equal(submit?.disabled, false);
+      assert.equal(deployments.length, 0);
+
+      await act(() => {
+        if (submit != null) {
+          fireEvent.click(submit);
+        }
+      });
+      assert.equal(deployments.length, 1);
+      assert.equal(deployments[0]?.templateName, "flowise");
+      assert.deepEqual(deployments[0]?.args, { port: "3000" });
+    } finally {
+      await act(() => rendered?.unmount());
+    }
+  });
+});
+
+test("an unavailable requested template never falls back or deploys", async () => {
+  await withTestDom(async (act) => {
+    let deploymentCount = 0;
+    let rendered: ReturnType<typeof render> | undefined;
+    try {
+      await act(() => {
+        rendered = render(
+          <TemplateDeployer
+            initialSettings={{ templateName: "missing-template" }}
+            onDeploy={() => {
+              deploymentCount += 1;
+            }}
+            templateOptions={[DIFY, FLOWISE]}
+          />
+        );
+      });
+
+      const submit = rendered?.getByTestId("template.deployer.submit") as
+        | HTMLButtonElement
+        | undefined;
+      assert.match(
+        rendered?.getByTestId("template.deployer.status").textContent ?? "",
+        UNAVAILABLE_TEMPLATE_RE
+      );
+      assert.equal(submit?.disabled, true);
+      await act(() => {
+        if (submit != null) {
+          fireEvent.click(submit);
+        }
+      });
+      assert.equal(deploymentCount, 0);
+    } finally {
+      await act(() => rendered?.unmount());
+    }
+  });
+});
+
+test("auto deploy waits for the catalog and applies template form values once", async () => {
+  await withTestDom(async (act) => {
+    const deployments: TemplateDeploymentSettings[] = [];
+    const initialSettings = {
+      args: { port: "8080" },
+      templateName: "flowise",
+    };
+    let rendered: ReturnType<typeof render> | undefined;
+    try {
+      await act(() => {
+        rendered = render(
+          <TemplateDeployer
+            autoDeploy
+            initialSettings={initialSettings}
+            loading
+            onDeploy={(settings) => {
+              deployments.push(settings);
+            }}
+            templateOptions={[]}
+          />
+        );
+      });
+      assert.equal(deployments.length, 0);
+
+      await act(() => {
+        rendered?.rerender(
+          <TemplateDeployer
+            autoDeploy
+            initialSettings={initialSettings}
+            onDeploy={(settings) => {
+              deployments.push(settings);
+            }}
+            templateOptions={[FLOWISE]}
+          />
+        );
+      });
+
+      assert.equal(deployments.length, 1);
+      assert.deepEqual(deployments[0]?.args, { port: "8080" });
+      assert.equal(deployments[0]?.templateName, "flowise");
+
+      await act(() => {
+        rendered?.rerender(
+          <TemplateDeployer
+            autoDeploy
+            initialSettings={initialSettings}
+            onDeploy={(settings) => {
+              deployments.push(settings);
+            }}
+            templateOptions={[FLOWISE]}
+          />
+        );
+      });
+      assert.equal(deployments.length, 1);
+    } finally {
+      await act(() => rendered?.unmount());
+    }
+  });
+});
+
+test("an incomplete initial form cancels auto deploy after values become valid", async () => {
+  await withTestDom(async (act) => {
+    const deployments: TemplateDeploymentSettings[] = [];
+    const onDeploy = (settings: TemplateDeploymentSettings) => {
+      deployments.push(settings);
+    };
+    let rendered: ReturnType<typeof render> | undefined;
+    try {
+      await act(() => {
+        rendered = render(
+          <TemplateDeployer
+            autoDeploy
+            initialSettings={{ args: {}, templateName: "dify" }}
+            onDeploy={onDeploy}
+            templateOptions={[DIFY]}
+          />
+        );
+      });
+      assert.equal(deployments.length, 0);
+
+      await act(() => {
+        rendered?.rerender(
+          <TemplateDeployer
+            autoDeploy
+            initialSettings={{
+              args: { password: "a" },
+              templateName: "dify",
+            }}
+            onDeploy={onDeploy}
+            templateOptions={[DIFY]}
+          />
+        );
+      });
+      assert.equal(deployments.length, 0);
+      assert.equal(
+        (rendered?.getByLabelText("password") as HTMLInputElement).value,
+        "a"
+      );
+
+      const submit = rendered?.getByTestId("template.deployer.submit") as
+        | HTMLButtonElement
+        | undefined;
+      assert.equal(submit?.disabled, false);
+      await act(() => {
+        if (submit != null) {
+          fireEvent.click(submit);
+        }
+      });
+      assert.equal(deployments.length, 1);
+      assert.deepEqual(deployments[0]?.args, { password: "a" });
+    } finally {
+      await act(() => rendered?.unmount());
+    }
+  });
+});
+
+test("catalog and initial settings changes never deploy automatically", async () => {
+  await withTestDom(async (act) => {
+    let deploymentCount = 0;
+    let rendered: ReturnType<typeof render> | undefined;
+    try {
+      const onDeploy = () => {
+        deploymentCount += 1;
+      };
+      await act(() => {
+        rendered = render(
+          <TemplateDeployer onDeploy={onDeploy} templateOptions={[]} />
+        );
+      });
+      await act(() => {
+        rendered?.rerender(
+          <TemplateDeployer
+            initialSettings={{ templateName: "flowise" }}
+            onDeploy={onDeploy}
+            templateOptions={[FLOWISE]}
+          />
+        );
+      });
+      await act(() => {
+        rendered?.rerender(
+          <TemplateDeployer
+            errorMessage="Could not load template catalog."
+            initialSettings={{ templateName: "flowise" }}
+            onDeploy={onDeploy}
+            templateOptions={[FLOWISE]}
+          />
+        );
+      });
+
+      assert.equal(deploymentCount, 0);
+      assert.equal(
+        (rendered?.getByTestId("template.deployer.submit") as HTMLButtonElement)
+          .disabled,
+        true
+      );
+      assert.match(
+        rendered?.getByTestId("template.deployer.status").textContent ?? "",
+        CATALOG_ERROR_RE
+      );
+    } finally {
+      await act(() => rendered?.unmount());
+    }
+  });
+});

--- a/apps/ui/src/features/deploy/template-deployer.tsx
+++ b/apps/ui/src/features/deploy/template-deployer.tsx
@@ -53,11 +53,7 @@ function selectedChoice(
   options: readonly TemplateDeploymentChoice[],
   selectedName: string
 ) {
-  return (
-    options.find((option) => option.name === selectedName) ??
-    options.find((option) => option.name === defaultTemplateName(options)) ??
-    null
-  );
+  return options.find((option) => option.name === selectedName) ?? null;
 }
 
 function defaultArgs(choice: TemplateDeploymentChoice | null) {
@@ -149,19 +145,24 @@ export function templateSensitiveKeys(
 }
 
 export function TemplateDeployer({
+  autoDeploy = false,
   busy = false,
   className,
   deployLabel = "Deploy",
   emptyMessage = "No templates are available.",
+  errorMessage,
   initialSettings,
+  loading = false,
   onDeploy,
   onSettingsChange,
   templateOptions: choices,
 }: {
+  autoDeploy?: boolean;
   busy?: boolean;
   className?: string;
   deployLabel?: string;
   emptyMessage?: string;
+  errorMessage?: string;
   onDeploy?: (
     settings: TemplateDeploymentSettings,
     choice: TemplateDeploymentChoice
@@ -171,6 +172,7 @@ export function TemplateDeployer({
     choice: TemplateDeploymentChoice | null
   ) => void;
   initialSettings?: TemplateDeploymentInitialSettings;
+  loading?: boolean;
   templateOptions: readonly TemplateDeploymentChoice[];
 }) {
   const inputIdPrefix = useId();
@@ -181,6 +183,10 @@ export function TemplateDeployer({
   const [args, setArgs] = useState<Record<string, string>>(() =>
     defaultArgs(choice)
   );
+  const [initialSettingsReady, setInitialSettingsReady] = useState(false);
+  const autoDeployStateRef = useRef<
+    "cancelled" | "eligible" | "pending" | "triggered"
+  >("pending");
   // Prefill args apply once, when the initial template's choice first
   // resolves from the catalog; switching templates resets to defaults.
   const initialArgsRef = useRef<{
@@ -194,22 +200,51 @@ export function TemplateDeployer({
         }
       : null
   );
+  const appliedInitialSettingsRef = useRef(initialSettings);
 
   useEffect(() => {
-    setTemplateName(
-      (current) =>
-        selectedChoice(choices, current)?.name ?? defaultTemplateName(choices)
+    setTemplateName((current) =>
+      current.trim() === "" ? defaultTemplateName(choices) : current
     );
   }, [choices]);
+
+  useEffect(() => {
+    if (appliedInitialSettingsRef.current === initialSettings) {
+      return;
+    }
+    setInitialSettingsReady(false);
+    appliedInitialSettingsRef.current = initialSettings;
+    const nextTemplateName = initialSettings?.templateName?.trim() ?? "";
+    initialArgsRef.current =
+      nextTemplateName !== "" && initialSettings?.args != null
+        ? { args: initialSettings.args, templateName: nextTemplateName }
+        : null;
+    const nextSelectedName = nextTemplateName || defaultTemplateName(choices);
+    const nextChoice = selectedChoice(choices, nextSelectedName);
+    const seed = initialArgsRef.current;
+    if (nextChoice != null) {
+      setArgs(
+        seed?.templateName === nextChoice.name
+          ? { ...defaultArgs(nextChoice), ...seed.args }
+          : defaultArgs(nextChoice)
+      );
+      if (seed?.templateName === nextChoice.name) {
+        initialArgsRef.current = null;
+      }
+    }
+    setTemplateName(nextSelectedName);
+  }, [choices, initialSettings]);
 
   useEffect(() => {
     const seed = initialArgsRef.current;
     if (seed != null && choice != null && choice.name === seed.templateName) {
       initialArgsRef.current = null;
       setArgs({ ...defaultArgs(choice), ...seed.args });
+      setInitialSettingsReady(true);
       return;
     }
     setArgs(defaultArgs(choice));
+    setInitialSettingsReady(choice != null);
   }, [choice]);
 
   const settings = useMemo<TemplateDeploymentSettings>(
@@ -223,13 +258,54 @@ export function TemplateDeployer({
   const missingRequired = (choice?.args ?? []).find(
     (arg) => arg.required && (args[arg.key]?.trim() ?? "") === ""
   );
-  const canDeploy = !busy && choice != null && missingRequired == null;
+  const requiredArgsComplete = missingRequired == null;
+  const catalogError = errorMessage?.trim() ?? "";
+  const canDeploy =
+    !(busy || loading) &&
+    catalogError === "" &&
+    choice != null &&
+    missingRequired == null;
 
   useEffect(() => {
     onSettingsChange?.(settings, choice);
   }, [choice, onSettingsChange, settings]);
 
+  useEffect(() => {
+    if (!(autoDeploy && initialSettingsReady) || choice == null) {
+      return;
+    }
+
+    if (autoDeployStateRef.current === "pending") {
+      const requestedTemplateName = initialSettings?.templateName?.trim();
+      autoDeployStateRef.current =
+        requestedTemplateName === choice.name && requiredArgsComplete
+          ? "eligible"
+          : "cancelled";
+    }
+
+    if (
+      autoDeployStateRef.current !== "eligible" ||
+      !canDeploy ||
+      onDeploy == null
+    ) {
+      return;
+    }
+    autoDeployStateRef.current = "triggered";
+    onDeploy(settings, choice);
+  }, [
+    autoDeploy,
+    canDeploy,
+    choice,
+    initialSettings,
+    initialSettingsReady,
+    onDeploy,
+    requiredArgsComplete,
+    settings,
+  ]);
+
   if (choices.length === 0) {
+    const statusMessage =
+      catalogError || (loading ? "Loading templates..." : emptyMessage);
     return (
       <div
         className={cn(
@@ -239,7 +315,7 @@ export function TemplateDeployer({
         data-slot="template-deployer-empty"
         data-testid="template.deployer.empty"
       >
-        {emptyMessage}
+        {statusMessage}
       </div>
     );
   }
@@ -257,12 +333,22 @@ export function TemplateDeployer({
         <DeploymentSettings.Control>
           <TemplateSearchSelect
             choices={choices}
-            disabled={busy}
-            onValueChange={setTemplateName}
+            disabled={busy || loading}
+            onValueChange={(nextTemplateName) => {
+              initialArgsRef.current = null;
+              setTemplateName(nextTemplateName);
+            }}
             value={templateName}
           />
-          <p className="text-muted-foreground text-sm leading-5">
-            {choice?.description || "Choose a template to deploy."}
+          <p
+            className="text-muted-foreground text-sm leading-5"
+            data-testid="template.deployer.status"
+          >
+            {catalogError ||
+              choice?.description ||
+              (templateName.trim() === ""
+                ? "Choose a template to deploy."
+                : `Template "${templateName}" is unavailable. Choose another template.`)}
           </p>
         </DeploymentSettings.Control>
       </DeploymentSettings.Section>
@@ -290,10 +376,9 @@ export function TemplateDeployer({
                       aria-label={arg.key}
                       data-template-arg={arg.key}
                       data-testid="template.deployer.parameter-input"
-                      disabled={busy}
+                      disabled={busy || loading}
                       id={inputId}
-                      onChange={(event) => {
-                        const nextValue = event.currentTarget.value;
+                      onValueChange={(nextValue) => {
                         setArgs((current) => ({
                           ...current,
                           [arg.key]: nextValue,

--- a/apps/ui/src/features/deploy/template-deployment-intent.ts
+++ b/apps/ui/src/features/deploy/template-deployment-intent.ts
@@ -1,0 +1,43 @@
+export const TEMPLATE_NAME_MAX_LENGTH = 256;
+
+export type TemplateForm = Record<string, string>;
+
+export function normalizeTemplateName(value: string | null | undefined) {
+  const normalized = value?.trim() ?? "";
+  return normalized !== "" && normalized.length <= TEMPLATE_NAME_MAX_LENGTH
+    ? normalized
+    : null;
+}
+
+export function parseTemplateForm(
+  value: string | null | undefined
+): TemplateForm | null {
+  if (value == null) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+
+    const entries = Object.entries(parsed);
+    if (
+      entries.some(
+        ([, entryValue]) =>
+          typeof entryValue !== "string" &&
+          typeof entryValue !== "boolean" &&
+          typeof entryValue !== "number"
+      )
+    ) {
+      return null;
+    }
+
+    return Object.fromEntries(
+      entries.map(([key, entryValue]) => [key, String(entryValue)])
+    );
+  } catch {
+    return null;
+  }
+}

--- a/apps/ui/src/features/deploy/template-deployment-pane.tsx
+++ b/apps/ui/src/features/deploy/template-deployment-pane.tsx
@@ -135,10 +135,9 @@ export function TemplateDeploymentPane({
           deploying || currentProject.isLoading || templateCatalog.isLoading
         }
         deployLabel={redeploy == null ? undefined : "Redeploy"}
-        emptyMessage={
-          templateCatalog.error?.message ?? "No templates are available."
-        }
+        errorMessage={templateCatalog.error?.message}
         initialSettings={initialSettings}
+        loading={templateCatalog.isLoading}
         onDeploy={(settings) => {
           overwriteGate.gate(() => {
             deploy(settings).catch(() => undefined);

--- a/apps/ui/src/features/panes/surface-state.ts
+++ b/apps/ui/src/features/panes/surface-state.ts
@@ -26,7 +26,16 @@ export type ProjectGlobalSidePaneEntry =
   | { kind: "deploymentTaskTimeline"; projectId: string; taskId: string }
   | { kind: "dockerDeployment"; projectId: string }
   | { kind: "githubDeployment"; projectId: string }
-  | { kind: "projectCreation"; entryMode: ProjectCreationPaneEntryMode }
+  | {
+      kind: "projectCreation";
+      entryMode: Exclude<ProjectCreationPaneEntryMode, "templateDirect">;
+    }
+  | {
+      kind: "projectCreation";
+      entryMode: "templateDirect";
+      templateForm?: string;
+      templateName?: string;
+    }
   | { kind: "skillsWorkflow" }
   | { kind: "templateDeployment"; projectId: string };
 

--- a/apps/ui/src/features/panes/url-codec.test.ts
+++ b/apps/ui/src/features/panes/url-codec.test.ts
@@ -154,3 +154,72 @@ test("project surface URL codec preserves template direct project creation", () 
     side: "project-creation:templateDirect",
   });
 });
+
+test("project surface URL codec preserves a template name on direct creation", () => {
+  const parsed = parseProjectSurfaceUrlState({
+    side: "project-creation:templateDirect:team%3Aflow%20v1",
+  });
+
+  assert.deepEqual(parsed.side, {
+    entryMode: "templateDirect",
+    kind: "projectCreation",
+    templateName: "team:flow v1",
+  });
+  assert.deepEqual(serializeProjectSurfaceUrlState(parsed), {
+    side: "project-creation:templateDirect:team%3Aflow%20v1",
+  });
+});
+
+test("project surface URL codec preserves a template form on direct creation", () => {
+  const templateForm = JSON.stringify({ enabled: "true", port: "3000" });
+  const encodedTemplateForm = encodeURIComponent(templateForm);
+  const parsed = parseProjectSurfaceUrlState({
+    side: `project-creation:templateDirect:flowise:${encodedTemplateForm}`,
+  });
+
+  assert.deepEqual(parsed.side, {
+    entryMode: "templateDirect",
+    kind: "projectCreation",
+    templateForm,
+    templateName: "flowise",
+  });
+  assert.deepEqual(serializeProjectSurfaceUrlState(parsed), {
+    side: `project-creation:templateDirect:flowise:${encodedTemplateForm}`,
+  });
+});
+
+test("project surface URL codec rejects template names on other creation modes", () => {
+  assert.equal(
+    parseProjectSurfaceUrlState({
+      side: "project-creation:dockerDirect:flowise",
+    }).side,
+    null
+  );
+});
+
+test("project surface URL codec rejects blank and overlong template names", () => {
+  assert.equal(
+    parseProjectSurfaceUrlState({
+      side: "project-creation:templateDirect:%20%20",
+    }).side,
+    null
+  );
+  assert.equal(
+    parseProjectSurfaceUrlState({
+      side: `project-creation:templateDirect:${"x".repeat(257)}`,
+    }).side,
+    null
+  );
+  assert.deepEqual(
+    serializeProjectSurfaceUrlState({
+      drawer: null,
+      main: null,
+      side: {
+        entryMode: "templateDirect",
+        kind: "projectCreation",
+        templateName: "   ",
+      },
+    }),
+    { side: "project-creation:templateDirect" }
+  );
+});

--- a/apps/ui/src/features/panes/url-codec.ts
+++ b/apps/ui/src/features/panes/url-codec.ts
@@ -1,3 +1,4 @@
+import { normalizeTemplateName } from "@/features/deploy/template-deployment-intent";
 import type {
   ProjectDrawerSurfaceEntry,
   ProjectMainSurfaceEntry,
@@ -137,8 +138,19 @@ export function serializeProjectSideSurfaceEntry(
       return `docker-deployment:${encodePart(entry.projectId)}`;
     case "githubDeployment":
       return `github-deployment:${encodePart(entry.projectId)}`;
-    case "projectCreation":
-      return `project-creation:${encodePart(entry.entryMode)}`;
+    case "projectCreation": {
+      const templateName =
+        entry.entryMode === "templateDirect"
+          ? normalizeTemplateName(entry.templateName)
+          : null;
+      const templateForm =
+        entry.entryMode === "templateDirect" && templateName != null
+          ? entry.templateForm
+          : undefined;
+      return `project-creation:${encodePart(entry.entryMode)}${
+        templateName == null ? "" : `:${encodePart(templateName)}`
+      }${templateForm == null ? "" : `:${encodePart(templateForm)}`}`;
+    }
     case "skillsWorkflow":
       return "skills-workflow";
     case "templateDeployment":
@@ -193,7 +205,7 @@ function parseResourceSideSurfaceEntry(
 function parseProjectCreationSideEntry(
   parts: readonly string[]
 ): ProjectSideSurfaceEntry | null {
-  if (parts.length !== 2) {
+  if (parts.length !== 2 && parts.length !== 3 && parts.length !== 4) {
     return null;
   }
   const entryMode = decodePart(parts[1]);
@@ -205,6 +217,22 @@ function parseProjectCreationSideEntry(
     entryMode !== "templateDirect"
   ) {
     return null;
+  }
+  if (parts.length >= 3) {
+    if (entryMode !== "templateDirect") {
+      return null;
+    }
+    const templateName = normalizeTemplateName(decodePart(parts[2]));
+    const templateForm = decodePart(parts[3]);
+    if (templateName == null || (parts.length === 4 && templateForm == null)) {
+      return null;
+    }
+    return {
+      entryMode,
+      kind: "projectCreation",
+      templateName,
+      ...(templateForm == null ? {} : { templateForm }),
+    };
   }
   return { entryMode, kind: "projectCreation" };
 }

--- a/apps/ui/src/features/projects/creation/creator/project-creator.context.tsx
+++ b/apps/ui/src/features/projects/creation/creator/project-creator.context.tsx
@@ -101,12 +101,20 @@ export interface ProjectCreatorRootProps {
   githubDeployer?: ProjectCreatorGithubDeployerSlot;
   /** Optional initial source step for direct assistant/tool entry paths. */
   initialStep?: ProjectCreatorSourceKind | null;
+  /** Template form values supplied by a direct URL entry. */
+  initialTemplateArgs?: Record<string, string>;
+  /** Template requested by a direct URL entry. */
+  initialTemplateName?: string;
   /** Reports active source changes to outer chrome such as pane headers. */
   onStepChange?: (step: ProjectCreatorSourceKind | null) => void;
   /** Direct Template entry derives the Project Display Name from the selected template. */
   templateDirect?: boolean;
   /** Options for the template step combobox. */
   templateOptions?: ProjectCreatorTemplateChoice[];
+  /** Catalog error shown within the existing Template deployment form. */
+  templateOptionsError?: string;
+  /** Disables Template deployment while the catalog is loading. */
+  templateOptionsLoading?: boolean;
 }
 
 function normalizeProjectCreatorDisplayName(name: string): string {
@@ -158,9 +166,13 @@ export function ProjectCreatorRoot({
   existingProjectDisplayNames = [],
   githubDeployer: githubDeployerProp,
   initialStep = null,
+  initialTemplateArgs,
+  initialTemplateName,
   onStepChange,
   templateDirect = false,
   templateOptions = [],
+  templateOptionsError,
+  templateOptionsLoading = false,
 }: ProjectCreatorRootProps) {
   const [step, setStep] = useState<ProjectCreatorSourceKind | null>(
     initialStep
@@ -330,6 +342,8 @@ export function ProjectCreatorRoot({
           actionsProp?.deriveDatabaseProjectDisplayName,
         deriveDockerProjectDisplayName:
           actionsProp?.deriveDockerProjectDisplayName,
+        deriveTemplateProjectDisplayName:
+          actionsProp?.deriveTemplateProjectDisplayName,
         onGithubConfirm: actionsProp?.onGithubConfirm,
         onDockerConfirm: actionsProp?.onDockerConfirm,
         onDatabaseConfirm: actionsProp?.onDatabaseConfirm,
@@ -341,8 +355,12 @@ export function ProjectCreatorRoot({
         dockerDirect,
         enabledSources,
         githubDeployer: githubDeployerProp,
+        initialTemplateArgs,
+        initialTemplateName,
         templateDirect,
         templateOptions,
+        templateOptionsError,
+        templateOptionsLoading,
       },
     }),
     [
@@ -356,6 +374,8 @@ export function ProjectCreatorRoot({
       dockerDirect,
       enabledSources,
       githubDeployerProp,
+      initialTemplateArgs,
+      initialTemplateName,
       projectDisplayName,
       projectDisplayNameError,
       projectDescription,
@@ -364,6 +384,8 @@ export function ProjectCreatorRoot({
       setProjectDisplayName,
       templateDirect,
       templateOptions,
+      templateOptionsError,
+      templateOptionsLoading,
       validateAndSetProjectDescriptionError,
       validateAndSetProjectDisplayNameError,
     ]

--- a/apps/ui/src/features/projects/creation/creator/project-creator.stage.tsx
+++ b/apps/ui/src/features/projects/creation/creator/project-creator.stage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { DatabaseDeployer } from "@/features/deploy/database-deployer";
 import {
   DockerDeployer,
@@ -212,16 +212,19 @@ function DatabasePanel({
 
 function TemplatePanel() {
   const { actions, meta, states } = useProjectCreator();
-  const [templateTitle, setTemplateTitle] = useState("");
-  const { setProjectDisplayName } = actions;
   const busy = states.confirmApplying;
-
-  useEffect(() => {
-    if (!meta.templateDirect || templateTitle.trim() === "") {
-      return;
-    }
-    setProjectDisplayName(templateTitle.trim());
-  }, [meta.templateDirect, setProjectDisplayName, templateTitle]);
+  const initialSettings = useMemo(
+    () =>
+      meta.initialTemplateName == null
+        ? undefined
+        : {
+            ...(meta.initialTemplateArgs == null
+              ? {}
+              : { args: meta.initialTemplateArgs }),
+            templateName: meta.initialTemplateName,
+          },
+    [meta.initialTemplateArgs, meta.initialTemplateName]
+  );
 
   return (
     <div
@@ -229,10 +232,15 @@ function TemplatePanel() {
       data-slot="project-creator-template"
     >
       <TemplateDeployer
+        autoDeploy={meta.templateDirect && meta.initialTemplateArgs != null}
         busy={busy}
+        errorMessage={meta.templateOptionsError}
+        initialSettings={initialSettings}
+        loading={meta.templateOptionsLoading}
         onDeploy={(settings: TemplateDeploymentSettings, choice) => {
           const projectDisplayName = meta.templateDirect
-            ? choice.title.trim() || choice.name.trim() || "Template Project"
+            ? (actions.deriveTemplateProjectDisplayName?.(choice) ??
+              (choice.title.trim() || choice.name.trim() || "Template Project"))
             : states.projectDisplayName.trim();
           const projectDescription = meta.templateDirect
             ? ""
@@ -250,9 +258,6 @@ function TemplatePanel() {
             projectDisplayName,
             projectDescription
           );
-        }}
-        onSettingsChange={(_settings, choice) => {
-          setTemplateTitle(choice?.title ?? "");
         }}
         templateOptions={meta.templateOptions}
       />

--- a/apps/ui/src/features/projects/creation/creator/project-creator.test.tsx
+++ b/apps/ui/src/features/projects/creation/creator/project-creator.test.tsx
@@ -66,6 +66,7 @@ test("project creator description field warns on soft over-limit drafts", () => 
           enabledSources: [],
           templateDirect: false,
           templateOptions: [],
+          templateOptionsLoading: false,
         },
         states: {
           confirmApplying: false,

--- a/apps/ui/src/features/projects/creation/creator/project-creator.types.ts
+++ b/apps/ui/src/features/projects/creation/creator/project-creator.types.ts
@@ -41,6 +41,9 @@ export interface ProjectCreatorActions {
     choice: ProjectCreatorDatabaseChoice
   ) => string;
   deriveDockerProjectDisplayName?: (imageRef: string) => string;
+  deriveTemplateProjectDisplayName?: (
+    choice: ProjectCreatorTemplateChoice
+  ) => string;
   onDatabaseConfirm?: (
     settings: DatabaseDeploymentSettings,
     projectDisplayName: string,
@@ -96,7 +99,11 @@ export interface ProjectCreatorValue {
   meta: {
     databaseOptions: ProjectCreatorDatabaseChoice[];
     enabledSources: readonly ProjectCreatorSourceKind[];
+    initialTemplateArgs?: Record<string, string>;
     templateOptions: ProjectCreatorTemplateChoice[];
+    initialTemplateName?: string;
+    templateOptionsError?: string;
+    templateOptionsLoading: boolean;
     /** Direct Database entry derives the Project Display Name from the selected engine. */
     databaseDirect: boolean;
     dockerDirect: boolean;

--- a/apps/ui/src/features/projects/creation/project-creation-pane-state.test.ts
+++ b/apps/ui/src/features/projects/creation/project-creation-pane-state.test.ts
@@ -75,6 +75,17 @@ test("project creation pane can open directly into template creation", () => {
   assert.equal(directOpen.open, true);
   assert.equal(directOpen.entryMode, "templateDirect");
   assert.equal(directOpen.resetKey, 1);
+  assert.equal(directOpen.templateName, undefined);
+
+  const prefilledOpen = projectCreationPaneStateReducer(directOpen, {
+    entryMode: "templateDirect",
+    templateArgs: { port: "3000" },
+    templateName: "flowise",
+    type: "open",
+  });
+  assert.equal(prefilledOpen.templateName, "flowise");
+  assert.deepEqual(prefilledOpen.templateArgs, { port: "3000" });
+  assert.equal(prefilledOpen.resetKey, 2);
 });
 
 test("project creation pane close hides the pane without mutating the next reset key", () => {

--- a/apps/ui/src/features/projects/creation/project-creation-pane-state.ts
+++ b/apps/ui/src/features/projects/creation/project-creation-pane-state.ts
@@ -9,11 +9,18 @@ export interface ProjectCreationPaneState {
   entryMode: ProjectCreationPaneEntryMode;
   open: boolean;
   resetKey: number;
+  templateArgs?: Record<string, string>;
+  templateName?: string;
 }
 
 export type ProjectCreationPaneStateAction =
   | { type: "close" }
-  | { entryMode?: ProjectCreationPaneEntryMode; type: "open" };
+  | {
+      entryMode?: ProjectCreationPaneEntryMode;
+      templateArgs?: Record<string, string>;
+      templateName?: string;
+      type: "open";
+    };
 
 export const initialProjectCreationPaneState: ProjectCreationPaneState = {
   entryMode: "general",
@@ -26,12 +33,20 @@ export function projectCreationPaneStateReducer(
   action: ProjectCreationPaneStateAction
 ): ProjectCreationPaneState {
   switch (action.type) {
-    case "open":
+    case "open": {
+      const entryMode = action.entryMode ?? "general";
       return {
-        entryMode: action.entryMode ?? "general",
+        entryMode,
         open: true,
         resetKey: state.resetKey + 1,
+        ...(entryMode === "templateDirect" && action.templateName != null
+          ? { templateName: action.templateName }
+          : {}),
+        ...(entryMode === "templateDirect" && action.templateArgs != null
+          ? { templateArgs: action.templateArgs }
+          : {}),
       };
+    }
     case "close":
       return { ...state, open: false };
     default:

--- a/apps/ui/src/features/projects/creation/project-creation-pane.tsx
+++ b/apps/ui/src/features/projects/creation/project-creation-pane.tsx
@@ -79,7 +79,11 @@ export function ProjectCreationPane({
     | "enabledSources"
     | "existingProjectDisplayNames"
     | "githubDeployer"
+    | "initialTemplateArgs"
+    | "initialTemplateName"
     | "templateOptions"
+    | "templateOptionsError"
+    | "templateOptionsLoading"
   >;
   entryMode?: ProjectCreationPaneEntryMode;
   onActiveSourceChange?: (source: ProjectCreatorSourceKind | null) => void;

--- a/apps/ui/src/features/projects/creation/project-creation-template-direct.test.tsx
+++ b/apps/ui/src/features/projects/creation/project-creation-template-direct.test.tsx
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { render } from "@testing-library/react/pure";
+
+import type {
+  TemplateDeploymentChoice,
+  TemplateDeploymentSettings,
+} from "@/features/deploy/template-deployer";
+import {
+  actAndDrain,
+  installTestDom,
+  restoreActEnvironment,
+  setActEnvironment,
+} from "@/features/project-canvas/react-test-harness";
+import { ProjectCreationPane } from "./project-creation-pane";
+
+const FLOWISE = {
+  args: [
+    {
+      default: "3000",
+      description: "HTTP port",
+      key: "port",
+      required: true,
+      type: "string",
+    },
+    {
+      default: "",
+      description: "Optional API token",
+      key: "api_token",
+      required: false,
+      type: "password",
+    },
+  ],
+  description: "Flowise template",
+  name: "flowise",
+  title: "Flowise",
+} satisfies TemplateDeploymentChoice;
+
+const FLOWISE_RE = /Flowise/;
+
+test("template URL intent prefills parameters and deploys automatically", async () => {
+  const dom = installTestDom();
+  const previousAct = setActEnvironment(true);
+  const confirmations: Array<{
+    projectDisplayName: string;
+    settings: TemplateDeploymentSettings;
+  }> = [];
+  let rendered: ReturnType<typeof render> | undefined;
+  try {
+    await actAndDrain(() => {
+      rendered = render(
+        <ProjectCreationPane
+          creatorRootProps={{
+            actions: {
+              deriveTemplateProjectDisplayName: () => "Flowise-2",
+              onTemplateConfirm: (settings, _choice, projectDisplayName) => {
+                confirmations.push({ projectDisplayName, settings });
+              },
+            },
+            databaseOptions: [],
+            initialTemplateArgs: { port: "8080" },
+            initialTemplateName: "flowise",
+            templateOptions: [FLOWISE],
+            templateOptionsLoading: false,
+          }}
+          entryMode="templateDirect"
+          onClose={() => undefined}
+          resetKey="templateDirect:flowise"
+        />
+      );
+    });
+
+    assert.match(
+      rendered?.getByTestId("template.deployer.template-combobox")
+        .textContent ?? "",
+      FLOWISE_RE
+    );
+    assert.equal(
+      (rendered?.getByLabelText("port") as HTMLInputElement).value,
+      "8080"
+    );
+    assert.equal(confirmations.length, 1);
+    assert.equal(confirmations[0]?.projectDisplayName, "Flowise-2");
+    assert.equal(confirmations[0]?.settings.templateName, "flowise");
+    assert.deepEqual(confirmations[0]?.settings.args, {
+      api_token: "",
+      port: "8080",
+    });
+    assert.deepEqual(confirmations[0]?.settings.sensitiveKeys, ["api_token"]);
+  } finally {
+    await actAndDrain(() => rendered?.unmount());
+    restoreActEnvironment(previousAct);
+    await dom.restore();
+  }
+});

--- a/apps/ui/src/features/projects/creation/template-project-display-name.test.ts
+++ b/apps/ui/src/features/projects/creation/template-project-display-name.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { TemplateDeploymentChoice } from "@/features/deploy/template-deployer";
+import { deriveTemplateProjectDisplayName } from "./template-project-display-name";
+
+const choice = {
+  args: [],
+  description: "Flowise template",
+  name: "flowise",
+  title: "Flowise",
+} satisfies TemplateDeploymentChoice;
+
+test("template project display name uses the title", () => {
+  assert.equal(
+    deriveTemplateProjectDisplayName({
+      choice,
+      existingProjectDisplayNames: [],
+    }),
+    "Flowise"
+  );
+});
+
+test("template project display name avoids trimmed case-insensitive conflicts", () => {
+  assert.equal(
+    deriveTemplateProjectDisplayName({
+      choice,
+      existingProjectDisplayNames: [" flowise ", "FLOWISE-2"],
+    }),
+    "Flowise-3"
+  );
+});
+
+test("template project display name falls back to name and a generic label", () => {
+  assert.equal(
+    deriveTemplateProjectDisplayName({
+      choice: { ...choice, title: "" },
+      existingProjectDisplayNames: [],
+    }),
+    "flowise"
+  );
+  assert.equal(
+    deriveTemplateProjectDisplayName({
+      choice: { ...choice, name: "", title: "" },
+      existingProjectDisplayNames: [],
+    }),
+    "Template Project"
+  );
+});

--- a/apps/ui/src/features/projects/creation/template-project-display-name.ts
+++ b/apps/ui/src/features/projects/creation/template-project-display-name.ts
@@ -1,0 +1,39 @@
+import type { TemplateDeploymentChoice } from "@/features/deploy/template-deployer";
+
+const TEMPLATE_PROJECT_FALLBACK_DISPLAY_NAME = "Template Project";
+
+function normalizeProjectDisplayName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function templateChoiceName(choice: TemplateDeploymentChoice): string {
+  return (
+    choice.title.trim() ||
+    choice.name.trim() ||
+    TEMPLATE_PROJECT_FALLBACK_DISPLAY_NAME
+  );
+}
+
+export function deriveTemplateProjectDisplayName({
+  choice,
+  existingProjectDisplayNames,
+}: {
+  choice: TemplateDeploymentChoice;
+  existingProjectDisplayNames: readonly string[];
+}): string {
+  const base = templateChoiceName(choice);
+  const existing = new Set(
+    existingProjectDisplayNames.map(normalizeProjectDisplayName).filter(Boolean)
+  );
+
+  if (!existing.has(normalizeProjectDisplayName(base))) {
+    return base;
+  }
+
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${base}-${suffix}`;
+    if (!existing.has(normalizeProjectDisplayName(candidate))) {
+      return candidate;
+    }
+  }
+}

--- a/apps/ui/src/features/projects/creation/use-project-creator.ts
+++ b/apps/ui/src/features/projects/creation/use-project-creator.ts
@@ -36,6 +36,7 @@ import {
   type ProjectCreationPaneEntryMode,
   projectCreationPaneStateReducer,
 } from "@/features/projects/creation/project-creation-pane-state";
+import { deriveTemplateProjectDisplayName } from "@/features/projects/creation/template-project-display-name";
 import type { ProjectExplorerProject } from "@/features/projects/explorer/project-explorer";
 import { desktopUserIdAtom } from "@/lib/auth-store";
 import { errorDescription, toastErrorDetail } from "@/lib/toast-utils";
@@ -88,7 +89,11 @@ type CreatorRootPropsForCreationPane = Pick<
   | "enabledSources"
   | "existingProjectDisplayNames"
   | "githubDeployer"
+  | "initialTemplateArgs"
+  | "initialTemplateName"
   | "templateOptions"
+  | "templateOptionsError"
+  | "templateOptionsLoading"
 >;
 
 export interface ProjectCreatedContext {
@@ -122,7 +127,11 @@ export function useProjectCreator(options?: UseProjectCreatorOptions): {
   lastConfirmedKind: string | null;
   onCreationPaneSourceChange: (source: ProjectCreatorSourceKind | null) => void;
   onCreationPaneOpenChange: (open: boolean) => void;
-  openCreationPane: (entryMode?: ProjectCreationPaneEntryMode) => void;
+  openCreationPane: (
+    entryMode?: ProjectCreationPaneEntryMode,
+    templateName?: string,
+    templateArgs?: Record<string, string>
+  ) => void;
 } {
   const kubeconfig = options?.kubeconfig?.trim() ?? "";
   const namespace = options?.namespace?.trim() ?? "";
@@ -168,10 +177,19 @@ export function useProjectCreator(options?: UseProjectCreatorOptions): {
   });
 
   const openCreationPane = useCallback(
-    (entryMode: ProjectCreationPaneEntryMode = "general") => {
+    (
+      entryMode: ProjectCreationPaneEntryMode = "general",
+      templateName?: string,
+      templateArgs?: Record<string, string>
+    ) => {
       setConfirmApplying(false);
       setActiveSource(sourceKindFromEntryMode(entryMode));
-      dispatchCreationPaneState({ entryMode, type: "open" });
+      dispatchCreationPaneState({
+        entryMode,
+        templateArgs,
+        templateName,
+        type: "open",
+      });
     },
     []
   );
@@ -288,6 +306,13 @@ export function useProjectCreator(options?: UseProjectCreatorOptions): {
           ),
           imageRef,
         }),
+      deriveTemplateProjectDisplayName: (choice) =>
+        deriveTemplateProjectDisplayName({
+          choice,
+          existingProjectDisplayNames: existingProjects.map(
+            (project) => project.name
+          ),
+        }),
       onDockerConfirm: async (
         settings: DockerDeploymentSettings,
         projectDisplayName,
@@ -352,6 +377,7 @@ export function useProjectCreator(options?: UseProjectCreatorOptions): {
           const outcome = await runDeployment({
             args: settings.args,
             kind: "template",
+            sensitiveKeys: settings.sensitiveKeys,
             target: newProjectDeploymentTarget(displayName, description),
             templateName: settings.templateName,
           });
@@ -476,6 +502,7 @@ export function useProjectCreator(options?: UseProjectCreatorOptions): {
         const outcome = await runDeployment({
           args: input.settings.args,
           kind: "template",
+          sensitiveKeys: input.settings.sensitiveKeys,
           target: newProjectDeploymentTarget(displayName),
           templateName: input.settings.templateName,
         });
@@ -545,7 +572,19 @@ export function useProjectCreator(options?: UseProjectCreatorOptions): {
       ),
       enabledSources: CREATION_PANE_SOURCES,
       githubDeployer,
+      ...(creationPaneState.entryMode === "templateDirect" &&
+      creationPaneState.templateName != null
+        ? { initialTemplateName: creationPaneState.templateName }
+        : {}),
+      ...(creationPaneState.entryMode === "templateDirect" &&
+      creationPaneState.templateArgs != null
+        ? { initialTemplateArgs: creationPaneState.templateArgs }
+        : {}),
       templateOptions: templateCatalog.templates,
+      ...(templateCatalog.error?.message == null
+        ? {}
+        : { templateOptionsError: templateCatalog.error.message }),
+      templateOptionsLoading: templateCatalog.isLoading,
     }),
     [
       actions,
@@ -553,6 +592,11 @@ export function useProjectCreator(options?: UseProjectCreatorOptions): {
       databaseOptions,
       existingProjects,
       githubDeployer,
+      creationPaneState.entryMode,
+      creationPaneState.templateArgs,
+      creationPaneState.templateName,
+      templateCatalog.error,
+      templateCatalog.isLoading,
       templateCatalog.templates,
     ]
   );

--- a/apps/ui/src/features/projects/project-index/project-index.tsx
+++ b/apps/ui/src/features/projects/project-index/project-index.tsx
@@ -5,6 +5,7 @@ import { cn } from "@workspace/ui/lib/utils";
 import { useAtomValue } from "jotai";
 import { useRouter } from "next/navigation";
 import { type ReactNode, useCallback, useEffect, useMemo } from "react";
+import { parseTemplateForm } from "@/features/deploy/template-deployment-intent";
 import type { ProjectSidePaneAssistantSurface } from "@/features/panes/assistant-router";
 import { useProjectSidePaneSurface } from "@/features/panes/react";
 import { PROJECT_SIDE_QUERY_KEY } from "@/features/panes/side-url-codec";
@@ -48,6 +49,16 @@ export function ProjectIndex() {
       ? projectSideRouteEntry
       : null;
   const creationSideEntryMode = creationSideEntry?.entryMode ?? null;
+  const creationSideTemplateName =
+    creationSideEntry?.entryMode === "templateDirect"
+      ? creationSideEntry.templateName
+      : undefined;
+  const creationSideTemplateArgs = useMemo(() => {
+    if (creationSideEntry?.entryMode !== "templateDirect") {
+      return undefined;
+    }
+    return parseTemplateForm(creationSideEntry.templateForm) ?? undefined;
+  }, [creationSideEntry]);
 
   const onProjectCreated = useCallback(
     async (projectId: string | undefined, context?: ProjectCreatedContext) => {
@@ -99,15 +110,26 @@ export function ProjectIndex() {
       onCreationPaneOpenChange(false);
       return;
     }
-    prepareCreationPane(creationSideEntryMode);
-  }, [creationSideEntryMode, onCreationPaneOpenChange, prepareCreationPane]);
+    prepareCreationPane(
+      creationSideEntryMode,
+      creationSideTemplateName,
+      creationSideTemplateArgs
+    );
+  }, [
+    creationSideEntryMode,
+    creationSideTemplateArgs,
+    creationSideTemplateName,
+    onCreationPaneOpenChange,
+    prepareCreationPane,
+  ]);
 
   const openProjectCreationPane = useCallback(
     (entryMode: ProjectCreationPaneEntryMode = "general") => {
-      openProjectSideRoute({
-        entryMode,
-        kind: "projectCreation",
-      });
+      if (entryMode === "templateDirect") {
+        openProjectSideRoute({ entryMode, kind: "projectCreation" });
+        return;
+      }
+      openProjectSideRoute({ entryMode, kind: "projectCreation" });
     },
     [openProjectSideRoute]
   );

--- a/docs/agent-friendly-tests/template/CORE_TEMPLATE_TEST_CASES.md
+++ b/docs/agent-friendly-tests/template/CORE_TEMPLATE_TEST_CASES.md
@@ -136,6 +136,37 @@ Failure handling:
 
 ## 4. Template Catalog And Parameters
 
+### TC-TPL-CAT-00 Open A Preselected Template From URL
+
+Goal: 验证公开 Template URL 使用 `templateForm` 预填参数并自动部署。
+
+Preconditions:
+
+- 从 `GET /api/templates` 选择一个存在的 template name，例如 `<template-name>`。
+- 打开浏览器 Network 面板或等价请求捕获工具。
+
+Steps:
+
+1. 为目标 Template 准备完整参数 JSON，例如 `{"PORT":"3000","ENABLE_AUTH":true}`。
+2. 打开 `/deploy?templateName=<template-name>&templateForm=<encoded-json>`。
+3. 等待 Brain 跳转到 Project 页面并加载 Template catalog。
+4. 记录 Network 请求和创建结果。
+
+Expected:
+
+- 没有 URL 专用确认页或额外部署 UI，也不需要再次点击 Deploy。
+- `<template-name>` 被精确选中，`templateForm` 的值覆盖对应模板 defaults。
+- catalog 和参数初始化完成后自动创建一个 Template Deployment Task。
+- boolean 参数按 `"true"` / `"false"` 传入 Template 部署参数；其他表单值保持字符串。
+- Task 的 `source.templateName = <template-name>`、`source.kind = "template"`、`runner.kind = "template"`、`target.kind = "newProject"`。
+- 成功后进入新 Project Canvas，并打开对应 Deployment Task Timeline。
+
+Evidence:
+
+- 公开入口 URL。
+- `/api/deploy-tasks` 请求数量和包含预填参数的 request body 摘要。
+- Project Canvas URL、task id 和 Timeline 截图。
+
 ### TC-TPL-CAT-01 Load Template Catalog
 
 Goal: 验证 Template 入口可以加载模板列表，并展示 Agent 可理解的模板信息。
@@ -847,4 +878,3 @@ List only failing or blocked cases here, with the exact UI state, Network status
 - Resources remaining:
 - Evidence:
 ```
-


### PR DESCRIPTION
## Summary

- add a public `/deploy` entry that accepts `templateName` and serialized `templateForm` parameters
- carry the deployment intent through the existing Project creation flow, prefill Template arguments, and automatically create the deployment task once initialization completes
- preserve sensitive Template input metadata and generate conflict-free Project display names
- cancel automatic deployment when the initial URL parameters omit required values, leaving later edits for explicit Deploy confirmation

## Why

Sealos website and Desktop links already use the `templateName` plus `templateForm` contract. Brain needs to consume that contract directly so a user can follow a prepared Template link without re-entering configuration or clicking a second deployment confirmation.

## Impact

A valid URL such as `/deploy?templateName=flowise&templateForm=<encoded-json>` opens the existing Template creation flow, applies the supplied values over Template defaults, and deploys once. Normal in-product Template creation remains manual. Incomplete initial forms never become auto-deployable after the user starts editing.

## Validation

- `bun check`
- `bun typecheck`
- 35 focused tests covering URL codecs, Template form initialization, automatic deployment, incomplete-form cancellation, Project creation, and display-name derivation
- `bun run build --filter=@sealai/ui`