### PR TITLE
fix(ui): update Sealos Skills install command

### DIFF
--- a/apps/ui/src/lib/sealos-skills-workflow-content.tsx
+++ b/apps/ui/src/lib/sealos-skills-workflow-content.tsx
@@ -6,7 +6,8 @@ import { Check, Copy } from "lucide-react";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 
-export const SEALOS_SKILLS_INSTALL_COMMAND = "npx skills add labring/seakills";
+export const SEALOS_SKILLS_INSTALL_COMMAND =
+  "npx skills add labring/sealos-skills";
 
 export const SEALOS_SKILLS_FLOW_STEPS = [
   {

--- a/apps/ui/src/lib/sealos-skills-workflow-pane.test.ts
+++ b/apps/ui/src/lib/sealos-skills-workflow-pane.test.ts
@@ -20,6 +20,9 @@ const COMMAND_HIGHLIGHT_BACKGROUND_RE = /isCommandHighlighted && "bg-input"/;
 const COMMAND_HIGHLIGHT_TEXT_RE = /isCommandHighlighted && "text-foreground"/;
 const COMMAND_ROW_HOVER_BACKGROUND_RE = /group[\s\S]*hover:bg-input/;
 const COMMAND_ROW_HOVER_TEXT_RE = /group-hover:text-foreground/;
+const CURRENT_INSTALL_COMMAND_RE =
+  /SEALOS_SKILLS_INSTALL_COMMAND[\s\S]{0,80}npx skills add labring\/sealos-skills/;
+const LEGACY_INSTALL_COMMAND_RE = /labring\/seakills/;
 const INSTALL_COMMAND_ROW_SOURCE =
   SKILLS_WORKFLOW_CONTENT_SOURCE.match(
     /function SealosSkillsInstallCommandRow[\s\S]*?function SealosSkillsSectionHeader/
@@ -27,6 +30,14 @@ const INSTALL_COMMAND_ROW_SOURCE =
 
 test("skills workflow pane subtitle stays concise enough for the header", () => {
   assert.match(SKILLS_WORKFLOW_PANE_SOURCE, CONCISE_SUBTITLE_RE);
+});
+
+test("skills workflow install command points to the renamed repository", () => {
+  assert.match(SKILLS_WORKFLOW_CONTENT_SOURCE, CURRENT_INSTALL_COMMAND_RE);
+  assert.doesNotMatch(
+    SKILLS_WORKFLOW_CONTENT_SOURCE,
+    LEGACY_INSTALL_COMMAND_RE
+  );
 });
 
 test("skills workflow flow step titles use continuous numbering", () => {


### PR DESCRIPTION
## Summary

- Update the Skills workflow install command from `labring/seakills` to `labring/sealos-skills`.
- Add regression coverage to prevent the legacy repository name from returning.

## Why

The `labring/seakills` repository has been renamed to `labring/sealos-skills`, so the workflow UI must copy the current repository path.

## Validation

- `bun test apps/ui/src/lib/sealos-skills-workflow-pane.test.ts`
- `bun typecheck`
- `bun check`
- Verified the refreshed local Skills Workflow pane displays `npx skills add labring/sealos-skills`.
