### PR TITLE
fix(ui): prevent Brain restore on desktop return

### DIFF
--- a/apps/ui/src/features/shell/app-sidebar.test.ts
+++ b/apps/ui/src/features/shell/app-sidebar.test.ts
@@ -19,7 +19,7 @@ const CREATE_SEALOS_APP_RE = /createSealosApp/;
 const HARDCODED_USAGE_VALUE_RE = /"0\.0\/0"/;
 const DESKTOP_RETURN_BUTTON_RE = /aria-label="Back to Sealos Desktop"/;
 const DESKTOP_RETURN_URL_RE =
-  /const SEALOS_DESKTOP_URL = "https:\/\/usw-1\.sealos\.io"/;
+  /const SEALOS_DESKTOP_URL = "https:\/\/usw-1\.sealos\.io\/\?openapp="/;
 const DESKTOP_RETURN_NEW_TAB_RE =
   /href=\{SEALOS_DESKTOP_URL\}[\s\S]*rel="noopener noreferrer"[\s\S]*target="_blank"/;
 const CLOSE_BRAIN_EVENT_RE = /closeDesktopApp/;

--- a/apps/ui/src/features/shell/app-sidebar.tsx
+++ b/apps/ui/src/features/shell/app-sidebar.tsx
@@ -116,7 +116,7 @@ function ProjectsShortcutIcon({
 
 const APP_SIDEBAR_LINK_CLASS =
   "shrink-0 border-0 text-neutral-50 active:translate-y-0! aria-[current=page]:text-blue-400!";
-const SEALOS_DESKTOP_URL = "https://usw-1.sealos.io";
+const SEALOS_DESKTOP_URL = "https://usw-1.sealos.io/?openapp=";
 const EMPTY_PROJECT_IDS: readonly string[] = Object.freeze([]);
 
 const EMPTY_UPGRADE_USAGE_ROWS = formatWorkspaceQuotaRows([]);


### PR DESCRIPTION
## What changed

- Append an empty `openapp` query parameter to the Sealos Desktop return URL.
- Update the sidebar regression test to lock the new URL contract.

## Why

Sealos Desktop persists `system-brain` as the current app across tabs. Opening the bare Desktop URL in a new tab therefore restored Brain instead of showing the Desktop. The presence of `openapp` bypasses session restoration, while an empty value launches no application.

## Impact

Clicking the sidebar Home button still opens a new tab, but the new tab now remains on Sealos Desktop instead of reopening Brain.

## Validation

- `bun test apps/ui/src/features/shell/app-sidebar.test.ts`
- `bun typecheck`
- `bun check`