### PR TITLE
fix(canvas): stop modal dialogs from re-focusing the canvas

### DIFF
--- a/apps/ui/src/features/project-canvas/panels/exec-terminal-pane.tsx
+++ b/apps/ui/src/features/project-canvas/panels/exec-terminal-pane.tsx
@@ -342,6 +342,7 @@ export const ExecTerminalPane = memo(function ExecTerminalPane({
           : "project-surface-slide-y-offset pointer-events-none opacity-0 duration-[var(--project-surface-motion-exit-duration)]"
       )}
       data-slot="exec-terminal-plane"
+      data-state={open ? "open" : "closed"}
       ref={sectionRef}
       style={{
         height: terminalHeight,

--- a/apps/ui/src/features/project-canvas/workbench/project-canvas-viewport-insets.ts
+++ b/apps/ui/src/features/project-canvas/workbench/project-canvas-viewport-insets.ts
@@ -11,7 +11,10 @@ function activeSurfaceElement(
   selector: string
 ): HTMLElement | null {
   const element = root.querySelector<HTMLElement>(selector);
-  if (element == null || element.getAttribute("aria-hidden") === "true") {
+  // Read the surface's own `data-state`, never `aria-hidden`: a modal dialog
+  // marks everything outside its popup `aria-hidden="true"`, so reading that
+  // would make an open surface measure as absent and re-focus the canvas.
+  if (element == null || element.dataset.state === "closed") {
     return null;
   }
   return element;

--- a/packages/ui/src/components/side-pane.tsx
+++ b/packages/ui/src/components/side-pane.tsx
@@ -72,6 +72,7 @@ export function SidePane({
           : "project-surface-slide-x-offset pointer-events-none opacity-0 duration-[var(--project-surface-motion-exit-duration)]"
       )}
       data-slot="side-pane"
+      data-state={motionOpen ? "open" : "closed"}
     >
       <div
         className={cn(


### PR DESCRIPTION
## Symptom

Opening the **Review settings** (eye) button in an AP's **Version History** made the canvas animate the focused AP node back to the centre of the *full* canvas, ignoring the Side Pane covering the right half — then animate back when the dialog closed.

The eye button is just the entry point that happened to get noticed. **Any modal dialog opened from inside a Side Pane or the Session Drawer does this.**

## Root cause

A modal dialog marks everything outside its popup `aria-hidden="true"`. `activeSurfaceElement` in `project-canvas-viewport-insets.ts` read that attribute as "this surface is gone":

```ts
if (element == null || element.getAttribute("aria-hidden") === "true") {
  return null;   // ← Side Pane stops counting toward the insets
}
```

So `rightInset` dropped `640 → 0`, which changed the canvas viewport focus key, which re-ran the focus effect.

Instrumented on a live canvas, the frame the dialog opened:

```
t=3517   insetRight: 640 → 0    pane aria-hidden: (absent) → "true"    dialogOpen: 0 → 1
t=3568   transform starts moving …
t=3756   settled at translate(-251.6px, …)      (was -571.6px)
```

`571.6 - 251.6 = 320 = 640 / 2` — exactly the shift `targetX = visibleWidth / 2` produces when 640px of inset disappears. Symmetric on close.

## Fix

`aria-hidden` is an accessibility signal that **any overlay is entitled to write on our subtree**, so it cannot double as a private visibility flag. Each surface now publishes its own `data-state`, which only the component itself writes:

- `SidePane` → `data-state={motionOpen ? "open" : "closed"}`
- `ExecTerminalPane` → `data-state={open ? "open" : "closed"}`
- `activeSurfaceElement` reads `data-state`, with a comment recording why `aria-hidden` must not be read here

`aria-hidden` is left exactly as it was — it was correct as accessibility semantics; it just should never have been read back as layout state.

## Deliberately not changed

- **The focus key still includes the insets.** Re-focusing when a surface genuinely opens, closes, or is resized is intended behaviour (see the `setInstant(assistantPaneResizingAtom)` bridge for pane drags). Only the mis-measurement is fixed.
- **Missing `data-state` still counts as visible**, matching the previous "missing `aria-hidden` counts as visible" default — so nothing outside the modal case changes behaviour.
- No new domain terms. `CONTEXT.md` already specifies the correct behaviour under **Canvas Viewport Focus**: *"The currently available canvas area excludes temporary project surfaces that cover the canvas, such as a Side Pane or Session Drawer."* The glossary was right; the implementation contradicted it.

## Verification

`bun check` ✅ · `bun typecheck` ✅

Behaviour check on a branch preview: open an AP Side Pane, let the focus settle, then open and close **Review settings**. Expected — the Side Pane keeps `data-state="open"` while the modal sets `aria-hidden="true"` on it, `rightInset` stays at 640, and `.react-flow__viewport` does not move a single frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)