### PR TITLE
fix(chat): retire the Free counter the moment the allowance is exhausted

### DIFF
--- a/apps/ui/src/app/api/chat/route.test.ts
+++ b/apps/ui/src/app/api/chat/route.test.ts
@@ -1186,7 +1186,7 @@ test("does not persist or bill an empty assistant response on stream error", asy
     chatRequest(userMessage("user-error", "inspect the cluster"))
   );
   expect(response.status).toBe(200);
-  expect(response.headers.get("X-Chat-Free-Remaining")).toBe("5");
+  expect(response.headers.get("X-Chat-Free-Remaining")).toBe("4");
   await drain(response);
 
   expect(history).toEqual([userMessage("user-error", "inspect the cluster")]);

--- a/apps/ui/src/app/api/chat/route.ts
+++ b/apps/ui/src/app/api/chat/route.ts
@@ -19,6 +19,10 @@ import {
   isSystemOpenAiConfigured,
 } from "@/features/chat/persistence/free-tier";
 import {
+  freeTierPosture,
+  freeTierPostureAfterTurn,
+} from "@/features/chat/persistence/free-tier-core";
+import {
   acquireChatStreamLease,
   type ChatStreamLease,
   commitChatMessagesIfLeaseOwned,
@@ -550,8 +554,11 @@ async function runChatPipeline(input: {
     }
 
     const freeTier = await getFreeTierSnapshot(owner.namespace);
-    const billing: ChatBillingMode =
-      freeTier.remaining > 0 && isSystemOpenAiConfigured() ? "free" : "user";
+    const systemModelConfigured = isSystemOpenAiConfigured();
+    const billing: ChatBillingMode = freeTierPosture(
+      freeTier,
+      systemModelConfigured
+    ).billing;
 
     // Complete every fallible runtime preflight before committing an approval
     // or browser-tool continuation. A failed preflight must remain retryable.
@@ -631,10 +638,17 @@ async function runChatPipeline(input: {
       },
     });
 
+    // Headers carry the POST-turn posture: the turn spending the last free
+    // turn already reports `user`, so the pane retires the counter at
+    // exhaustion instead of pinning "Free 0/n" until the next message.
+    const clientFreeTier = freeTierPostureAfterTurn(
+      freeTier,
+      systemModelConfigured
+    );
     const responseHeaders: Record<string, string> = {
-      "X-Chat-Billing": billing,
-      "X-Chat-Free-Remaining": String(freeTier.remaining),
-      "X-Chat-Free-Limit": String(freeTier.limit),
+      "X-Chat-Billing": clientFreeTier.billing,
+      "X-Chat-Free-Remaining": String(clientFreeTier.remaining),
+      "X-Chat-Free-Limit": String(clientFreeTier.limit),
     };
 
     const streamHeartbeat = leaseHeartbeat;

--- a/apps/ui/src/features/chat/persistence/free-tier-core.test.ts
+++ b/apps/ui/src/features/chat/persistence/free-tier-core.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { freeTierPosture, freeTierPostureAfterTurn } from "./free-tier-core";
+
+test("posture is free while turns remain and a platform model is configured", () => {
+  assert.deepEqual(freeTierPosture({ limit: 5, remaining: 3 }, true), {
+    billing: "free",
+    limit: 5,
+    remaining: 3,
+  });
+});
+
+test("posture is user when no platform model is configured, even with a full allowance", () => {
+  assert.deepEqual(freeTierPosture({ limit: 5, remaining: 5 }, false), {
+    billing: "user",
+    limit: 5,
+    remaining: 5,
+  });
+});
+
+test("posture is user once the allowance is exhausted", () => {
+  assert.deepEqual(freeTierPosture({ limit: 5, remaining: 0 }, true), {
+    billing: "user",
+    limit: 5,
+    remaining: 0,
+  });
+});
+
+test("a mid-allowance free turn reports free with one fewer turn", () => {
+  assert.deepEqual(freeTierPostureAfterTurn({ limit: 5, remaining: 3 }, true), {
+    billing: "free",
+    limit: 5,
+    remaining: 2,
+  });
+});
+
+// Regression: the turn that spends the LAST free turn must already report
+// `user`, so the pane hides the Free counter and fires the crossing toast at
+// exhaustion — not "Free 0/5" until the next message (or forever, if the next
+// user-billed request fails and never delivers fresh headers).
+test("the turn that spends the last free turn reports user, not Free 0/n", () => {
+  assert.deepEqual(freeTierPostureAfterTurn({ limit: 5, remaining: 1 }, true), {
+    billing: "user",
+    limit: 5,
+    remaining: 0,
+  });
+});
+
+test("a user-billed turn leaves the snapshot untouched", () => {
+  assert.deepEqual(
+    freeTierPostureAfterTurn({ limit: 5, remaining: 5 }, false),
+    { billing: "user", limit: 5, remaining: 5 }
+  );
+});

--- a/apps/ui/src/features/chat/persistence/free-tier-core.ts
+++ b/apps/ui/src/features/chat/persistence/free-tier-core.ts
@@ -1,0 +1,43 @@
+import type { FreeTierState } from "./types";
+
+/** Usage-only view of a namespace's Free Chat Turns (no billing decision). */
+export interface FreeTurnsSnapshot {
+  limit: number;
+  remaining: number;
+}
+
+/**
+ * Chat Billing Posture for the next assistant turn (ADR 0033): `free` only
+ * while spendable Free Chat Turns remain AND a platform model is configured.
+ */
+export function freeTierPosture(
+  snapshot: FreeTurnsSnapshot,
+  systemModelConfigured: boolean
+): FreeTierState {
+  return {
+    billing: snapshot.remaining > 0 && systemModelConfigured ? "free" : "user",
+    limit: snapshot.limit,
+    remaining: snapshot.remaining,
+  };
+}
+
+/**
+ * Posture the client should hold once the current turn completes — what the
+ * `X-Chat-*` response headers report. A `free` turn spends one Free Chat Turn,
+ * so the turn that spends the last one already reports `user`: the pane hides
+ * the Free counter and fires the crossing toast at exhaustion, not one paid
+ * message later.
+ */
+export function freeTierPostureAfterTurn(
+  snapshot: FreeTurnsSnapshot,
+  systemModelConfigured: boolean
+): FreeTierState {
+  const pre = freeTierPosture(snapshot, systemModelConfigured);
+  if (pre.billing !== "free") {
+    return pre;
+  }
+  return freeTierPosture(
+    { limit: snapshot.limit, remaining: Math.max(0, snapshot.remaining - 1) },
+    systemModelConfigured
+  );
+}

--- a/apps/ui/src/features/chat/persistence/service-core.ts
+++ b/apps/ui/src/features/chat/persistence/service-core.ts
@@ -1,5 +1,6 @@
 import type { generateText, UIMessage } from "ai";
 
+import { freeTierPosture } from "./free-tier-core";
 import type {
   AssistantConversationRepository,
   ThreadRow,
@@ -72,14 +73,10 @@ export function createAssistantConversationService(
       const rows = await repository.selectThreadsByOwner(owner);
       // Free Chat Turns deliberately remain keyed only by namespace (ADR 0056).
       const snapshot = await dependencies.getFreeChatTurns(owner.namespace);
-      const freeChatTurns = {
-        billing: (snapshot.remaining > 0 &&
+      const freeChatTurns = freeTierPosture(
+        snapshot,
         dependencies.isSystemModelConfigured()
-          ? "free"
-          : "user") as "free" | "user",
-        remaining: snapshot.remaining,
-        limit: snapshot.limit,
-      };
+      );
       const latest = rows[0];
       if (latest === undefined) {
         return {


### PR DESCRIPTION
Supersedes #220 (closed: stale head after a history rewrite could not be reopened).

## Bug

After the free chat allowance was used up, the Project Assistant Pane kept showing `Free 0/5` instead of hiding the counter and firing the one-time crossing toast (ADR 0033).

## Root cause

The `X-Chat-*` response headers on `POST /api/chat` mixed two semantics: `X-Chat-Billing` reported the **pre-turn** billing mode while `X-Chat-Free-Remaining` reported the **post-turn** count. The turn that spent the last free turn therefore answered `billing: free` + `remaining: 0`, and the client — which treats the headers as the current billing posture — kept rendering `Free 0/5`. The flip to `user` only happened on the *next* message; if that next user-billed request failed (e.g. missing AI Proxy credentials → error response with no `X-Chat-*` headers), the pane stayed stuck on `Free 0/5` indefinitely.

## Fix

- Headers now report the **post-turn billing posture**: the turn spending the last free turn already answers `user`/`remaining: 0`, so the counter disappears and the crossing toast fires at exhaustion, not one paid message later.
- Extracted the posture decision into a pure helper (`free-tier-core.ts`, following the existing `*-core.ts` convention) and reused it in the session bootstrap (`service-core.ts`), so both paths share one decision instead of duplicating `remaining > 0 && configured`.
- This turn's *actual* billing mode — connection choice and free-turn consumption — is unchanged; only the client-facing headers moved. No client changes needed.

## Tests

- New `free-tier-core.test.ts` (6 cases); the regression case reproduces the exact symptom and was verified red before the fix, green after.
- All 54 chat feature tests pass; `bun check` clean; no tsc errors in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)