### PR TITLE
fix(chat): stop killing assistant turns at 110s, restore Devbox warmup

### DIFF
--- a/apps/ui/src/app/api/chat/route.test.ts
+++ b/apps/ui/src/app/api/chat/route.test.ts
@@ -718,7 +718,7 @@ test("accepts a client-tool continuation without server-injected metadata", asyn
   );
 });
 
-test("passes a hard timeout signal to the model stream", async () => {
+test("never binds the model stream to a wall-clock deadline", async () => {
   const timeoutController = new AbortController();
   const timeoutSpy = spyOn(AbortSignal, "timeout").mockReturnValue(
     timeoutController.signal
@@ -731,14 +731,13 @@ test("passes a hard timeout signal to the model stream", async () => {
     expect(response.status).toBe(200);
     await drain(response);
 
-    expect(timeoutSpy).toHaveBeenCalledWith(110_000);
-    expect(timeoutSpy).toHaveBeenCalledWith(5000);
+    // The auto-title deadline is the only timer left; the turn itself ends on
+    // client disconnect or lease loss, never on elapsed time.
+    expect(timeoutSpy.mock.calls.flat()).toEqual([5000]);
     const modelSignal = modelAbortSignals[0];
     expect(modelSignal).toBeDefined();
-    expect(modelSignal).not.toBe(timeoutController.signal);
-    expect(modelSignal?.aborted).toBe(false);
     timeoutController.abort();
-    expect(modelSignal?.aborted).toBe(true);
+    expect(modelSignal?.aborted).toBe(false);
   } finally {
     timeoutSpy.mockRestore();
   }
@@ -767,7 +766,6 @@ test("request abort stops the model and releases the lease", async () => {
     requestController.abort();
     await waitUntil(() => activeLease == null);
 
-    expect(timeoutSpy).toHaveBeenCalledWith(110_000);
     expect(timeoutController.signal.aborted).toBe(false);
     expect(modelAbortSignals[0]?.aborted).toBe(true);
     expect(leaseReleaseCalls).toBe(1);

--- a/apps/ui/src/app/api/chat/route.ts
+++ b/apps/ui/src/app/api/chat/route.ts
@@ -62,9 +62,6 @@ import { buildChatToolset } from "@/features/chat/runtime/tools";
 import { decodeKubeconfig } from "@/lib/kubeconfig";
 import { authorizeWorkspaceActor } from "@/lib/request-kubeconfig-auth";
 
-export const maxDuration = 120;
-
-const CHAT_STREAM_TIMEOUT_MS = 110_000;
 const CHAT_TITLE_TIMEOUT_MS = 5000;
 
 const INTERRUPTED_TOOL_ERROR =
@@ -617,9 +614,12 @@ async function runChatPipeline(input: {
       initialLease: ownedLease,
       renew: renewOwnedChatStreamLease,
     });
+    // No wall-clock ceiling: the turn ends when the client disconnects or the
+    // stream lease is lost. A fixed deadline only manufactured interrupted
+    // tools, since a cold Devbox plus one command already exceeds any value
+    // small enough to be useful.
     const streamAbortSignal = AbortSignal.any([
       requestAbortSignal,
-      AbortSignal.timeout(CHAT_STREAM_TIMEOUT_MS),
       leaseAbortController.signal,
     ]);
 

--- a/apps/ui/src/app/project/layout.test.tsx
+++ b/apps/ui/src/app/project/layout.test.tsx
@@ -1,0 +1,46 @@
+import { mock, test } from "bun:test";
+import assert from "node:assert/strict";
+import { isValidElement, type ReactNode } from "react";
+
+// `server-only` throws outside a React server runtime (repo pattern); the
+// layout reaches it through the Devbox warmup server action.
+mock.module("server-only", () => ({}));
+
+const { DevboxBootstrap, SealosSdkBootstrap } = await import(
+  "@/features/shell/auth-bootstrap"
+);
+const { default: ProjectLayout } = await import("./layout");
+
+/**
+ * Collects the component types in a returned element tree without rendering,
+ * so this stays a structural assertion instead of booting the whole app shell.
+ */
+function mountedComponents(
+  node: ReactNode,
+  found: Set<unknown> = new Set()
+): Set<unknown> {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      mountedComponents(child, found);
+    }
+    return found;
+  }
+  if (!isValidElement(node)) {
+    return found;
+  }
+  found.add(node.type);
+  return mountedComponents(
+    (node.props as { children?: ReactNode }).children,
+    found
+  );
+}
+
+// `DevboxBootstrap` stayed exported and unit-tested for weeks after it was
+// unmounted, which silently pushed Devbox cold start onto the streaming path.
+// Assert the mount itself, not just the component's behaviour.
+test("project layout mounts the Devbox warmup", () => {
+  const mounted = mountedComponents(ProjectLayout({ children: null }));
+
+  assert.ok(mounted.has(DevboxBootstrap), "DevboxBootstrap is mounted");
+  assert.ok(mounted.has(SealosSdkBootstrap), "SealosSdkBootstrap is mounted");
+});

--- a/apps/ui/src/app/project/layout.tsx
+++ b/apps/ui/src/app/project/layout.tsx
@@ -4,6 +4,7 @@ import {
   AppShellView,
 } from "@/features/shell/app-shell";
 import AuthBootstrap, {
+  DevboxBootstrap,
   SealosSdkBootstrap,
 } from "@/features/shell/auth-bootstrap";
 import ProjectWorkspaceLayout from "@/features/shell/project-workspace-layout";
@@ -20,6 +21,7 @@ export default function ProjectLayout({
     <AppShellChrome>
       <AuthBootstrap serverEncodedKubeconfig="" serverNamespace="" />
       <SealosSdkBootstrap />
+      <DevboxBootstrap />
       <AppShellSidebar />
       <AppShellView className="min-w-0 flex-1 basis-0">
         <ProjectWorkspaceLayout>{children}</ProjectWorkspaceLayout>

--- a/apps/ui/src/features/chat/devbox/devbox.actions.ts
+++ b/apps/ui/src/features/chat/devbox/devbox.actions.ts
@@ -2,16 +2,28 @@
 
 import { after } from "next/server";
 import { bootstrapChatDevboxIfNeeded } from "@/features/chat/devbox/chat-runtime";
+import { isDevboxConfigured } from "@/lib/devbox/config";
 import { decodeKubeconfig } from "@/lib/kubeconfig";
+
+export type ChatDevboxWarmupResult =
+  | { ok: true }
+  | { ok: false; reason: "credentials" | "unconfigured" };
 
 /**
  * Schedules Devbox create/reuse + kubectl permission bootstrap after the action
  * returns, so the client is not blocked on runtime startup.
+ *
+ * Fires on every project page load, so a deployment without Devbox env skips
+ * silently rather than logging a failed bootstrap each time.
  */
 export async function scheduleChatDevboxWarmup(
   encodedKubeconfig: string,
   namespace: string
-): Promise<{ ok: true } | { ok: false }> {
+): Promise<ChatDevboxWarmupResult> {
+  if (!isDevboxConfigured()) {
+    return { ok: false, reason: "unconfigured" };
+  }
+
   const kubeconfig = decodeKubeconfig(encodedKubeconfig);
   const trimmedNamespace = namespace.trim();
   if (
@@ -19,7 +31,7 @@ export async function scheduleChatDevboxWarmup(
     kubeconfig.trim() === "" ||
     trimmedNamespace === ""
   ) {
-    return { ok: false };
+    return { ok: false, reason: "credentials" };
   }
 
   after(() => {

--- a/apps/ui/src/features/shell/auth-bootstrap.tsx
+++ b/apps/ui/src/features/shell/auth-bootstrap.tsx
@@ -150,7 +150,7 @@ export function DevboxBootstrap() {
           encodeURIComponent(kubeconfigDecoded),
           namespaceTrimmed
         );
-        if (!result.ok) {
+        if (!result.ok && result.reason === "credentials") {
           console.warn("[DevboxBootstrap] skipped: invalid credentials");
         }
       } catch (e: unknown) {

--- a/apps/ui/src/lib/devbox/config-core.test.ts
+++ b/apps/ui/src/lib/devbox/config-core.test.ts
@@ -5,6 +5,7 @@ import { getDevboxExecRequestTimeoutMs } from "./client-core";
 import {
   getDevboxAuthTokenFromEnv,
   getDevboxBaseUrlFromEnv,
+  isDevboxConfiguredFromEnv,
 } from "./config-core";
 
 const MISSING_SIGNING_KEY_ERROR =
@@ -33,6 +34,44 @@ test("getDevboxAuthTokenFromEnv reports clear error when no auth source is confi
   await assert.rejects(
     () => getDevboxAuthTokenFromEnv({}, "ns-user"),
     MISSING_SIGNING_KEY_ERROR
+  );
+});
+
+test("isDevboxConfiguredFromEnv requires a base URL and one auth source", () => {
+  assert.equal(
+    isDevboxConfiguredFromEnv({
+      DEVBOX_API_BASE_URL: "https://devbox-server.example.sealos.io",
+      DEVBOX_TOKEN: "static-token",
+    }),
+    true
+  );
+  assert.equal(
+    isDevboxConfiguredFromEnv({
+      DEVBOX_API_BASE_URL: "https://devbox-server.example.sealos.io",
+      DEVBOX_JWT_SIGNING_KEY: "signing-key",
+    }),
+    true
+  );
+});
+
+test("isDevboxConfiguredFromEnv rejects blank or half-configured env", () => {
+  assert.equal(isDevboxConfiguredFromEnv({}), false);
+  assert.equal(
+    isDevboxConfiguredFromEnv({
+      DEVBOX_API_BASE_URL: "https://devbox-server.example.sealos.io",
+    }),
+    false
+  );
+  assert.equal(
+    isDevboxConfiguredFromEnv({ DEVBOX_TOKEN: "static-token" }),
+    false
+  );
+  assert.equal(
+    isDevboxConfiguredFromEnv({
+      DEVBOX_API_BASE_URL: "   ",
+      DEVBOX_TOKEN: "   ",
+    }),
+    false
   );
 });
 

--- a/apps/ui/src/lib/devbox/config-core.ts
+++ b/apps/ui/src/lib/devbox/config-core.ts
@@ -24,6 +24,22 @@ export function getDevboxBaseUrlFromEnv(env: DevboxEnv): string {
   return normalizeBaseUrl(getRequiredEnv(env, "DEVBOX_API_BASE_URL"));
 }
 
+/**
+ * Whether this deployment can talk to a Devbox API at all.
+ *
+ * Mirrors what {@link getDevboxBaseUrlFromEnv} and
+ * {@link getDevboxAuthTokenFromEnv} require, so background callers can skip
+ * quietly instead of throwing on every invocation. On-demand callers (bash
+ * tools) should still let the throw surface as a real tool error.
+ */
+export function isDevboxConfiguredFromEnv(env: DevboxEnv): boolean {
+  const hasBaseUrl = (env.DEVBOX_API_BASE_URL?.trim() ?? "") !== "";
+  const hasAuth =
+    (env.DEVBOX_TOKEN?.trim() ?? "") !== "" ||
+    (env.DEVBOX_JWT_SIGNING_KEY?.trim() ?? "") !== "";
+  return hasBaseUrl && hasAuth;
+}
+
 export function getDevboxDefaultImageFromEnv(
   env: DevboxEnv
 ): string | undefined {

--- a/apps/ui/src/lib/devbox/config.ts
+++ b/apps/ui/src/lib/devbox/config.ts
@@ -6,7 +6,12 @@ import {
   getDevboxAuthTokenFromEnv,
   getDevboxBaseUrlFromEnv,
   getDevboxDefaultImageFromEnv,
+  isDevboxConfiguredFromEnv,
 } from "./config-core";
+
+export function isDevboxConfigured(): boolean {
+  return isDevboxConfiguredFromEnv(process.env);
+}
 
 export function getDevboxBaseUrl(): string {
   return getDevboxBaseUrlFromEnv(process.env);


### PR DESCRIPTION
Two fixes for the same user-visible symptom: an assistant turn that dies mid-answer with a tool row stuck on `Failed` and no error shown.

## Remove the self-imposed 110s stream deadline

`apps/ui/src/app/api/chat/route.ts` carried `maxDuration = 120` — Vercel scaffolding that has no effect on our self-hosted standalone deployment — and `CHAT_STREAM_TIMEOUT_MS = 110_000` derived from it, on the theory that the platform would execute the request at 120s and we should bow out first to clean up.

Nothing in a K8s pod kills the request at 120s, so the timer was the only executioner. Any turn past 110s was chopped mid-flight, and `onFinish` persisted its in-flight tool calls as `output-error`.

The arithmetic makes it unwinnable on a cold Devbox:

| step | worst case | constant |
| --- | --- | --- |
| create/resume, poll to Running | 60s | `DEVBOX_RUNTIME_READY_TIMEOUT_MS` |
| kubectl readiness check | 30s | `DEVBOX_WARMUP_TIMEOUT_SECONDS` |
| one bash command | 60s | `DEVBOX_COMMAND_TIMEOUT_SECONDS` |

150s before counting model reasoning, against a 110s budget. The first bash call could not fit.

The stream now aborts on the two signals that mean something — the client disconnecting (`req.signal`) and the stream lease being lost. The Postgres lease plus its 60s heartbeat remains the reaper for genuinely dead streams; it is the liveness record, and elapsed wall time never was.

## Restore the Devbox warmup mount

`DevboxBootstrap` was dropped from `app/project/layout.tsx` in 52d615b9 (a commit about GitHub OAuth and project bootstrap) while staying exported, unit-tested, and fully wired. Nothing failed and nobody noticed.

The consequence was that there was no warmup at all — the Devbox cold start above happened *after* the model had started streaming, instead of when the user opened the page.

Remounted, plus a structural test asserting the mount itself. `auth-bootstrap.test.ts` stayed green throughout the regression because it tests `applySealosSdkHydration` in isolation and knows nothing about whether anyone renders the component.

The warmup action now also skips silently when Devbox env is absent, since it fires on every project page load and would otherwise log a failed bootstrap each time. That skip is scoped to the background path only: on-demand bash tools still surface the configuration error, because there a user is waiting on a result.

## Testing

`bun typecheck` and `bun check` clean; 157 tests across the touched surface pass.

Three tests pin the changes: `never binds the model stream to a wall-clock deadline` asserts `AbortSignal.timeout` is only ever called for the 5s auto-title deadline; `isDevboxConfiguredFromEnv` covers base-URL and auth-source combinations; `project layout mounts the Devbox warmup` guards the mount, and was mutation-checked by removing the mount and confirming it fails.

Not verifiable in CI, needs a real environment:

- A turn longer than 110s (three sequential `sleep 50` bash calls) should now complete instead of failing partway.
- Opening a project page should leave the Devbox `Running` before the first message.
- Killing the server mid-stream should leave the thread locked for the 180s lease TTL, then recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
