### PR TITLE
feat(deploy): make deploy skill source configurable

### DIFF
--- a/apps/ui/.env.example
+++ b/apps/ui/.env.example
@@ -22,6 +22,8 @@ DEVBOX_JWT_SIGNING_KEY=
 DEVBOX_RUNTIME_IMAGE=ghcr.io/labring-actions/devbox-base-images/sandbox-v1:2026-6-stable-zh-cn-amd64
 DEVBOX_ARCHIVE_AFTER_PAUSE_TIME=24h
 DEVBOX_JWT_TTL_SECONDS=14400
+# Optional. Defaults to the production brain-deploy skill source.
+DEPLOY_SKILL_SOURCE=
 
 GITHUB_APP_ID=
 GITHUB_APP_PRIVATE_KEY=

--- a/apps/ui/src/features/deploy/task/runner.github-ai-proxy.test.ts
+++ b/apps/ui/src/features/deploy/task/runner.github-ai-proxy.test.ts
@@ -34,6 +34,7 @@ mock.module("server-only", () => ({}));
 
 const {
   buildCodexGatewayEnv,
+  buildDeploySkillInstallCommand,
   ensureAiDeploymentDevbox,
   resolveGithubCodexGatewayCredentials,
 } = requireModule("./runner") as typeof import("./runner");
@@ -137,6 +138,21 @@ function setPlatformCredentials() {
   process.env.SYSTEM_OPENAI_API_KEY = "system-platform-key";
   process.env.SYSTEM_OPENAI_API_BASE_URL = "https://system-platform.example/v1";
 }
+
+describe("deploy skill installation", () => {
+  it("uses the configured source while keeping the sealos-deploy marker", () => {
+    const command = buildDeploySkillInstallCommand(
+      "https://github.com/labring/sealos-skills/tree/brain-deploy-preview"
+    );
+
+    expect(command).toContain(
+      "npx --yes skills add 'https://github.com/labring/sealos-skills/tree/brain-deploy-preview' -y"
+    );
+    expect(command).toContain(".agents/skills/sealos-deploy/SKILL.md");
+    expect(command).toContain(".codex/skills/sealos-deploy/SKILL.md");
+    expect(command).not.toContain("--skill");
+  });
+});
 
 describe("GitHub deployment AI Proxy credentials", () => {
   beforeEach(() => {

--- a/apps/ui/src/features/deploy/task/runner.test.ts
+++ b/apps/ui/src/features/deploy/task/runner.test.ts
@@ -5,8 +5,10 @@ import { deployTaskFailureSummary } from "./failure-summary";
 import { deployOutputProgressSummary } from "./output-progress";
 import {
   DEFAULT_DEPLOY_DEVBOX_STORAGE_LIMIT,
+  DEFAULT_DEPLOY_SKILL_SOURCE,
   DEPLOY_DEVBOX_RUNTIME_READY_TIMEOUT_MS,
   getDeployDevboxStorageLimitFromEnv,
+  getDeploySkillSourceFromEnv,
 } from "./runtime-config";
 
 describe("deploy task runner failure summaries", () => {
@@ -101,6 +103,29 @@ describe("deploy task runtime config", () => {
         DEPLOY_DEVBOX_STORAGE_LIMIT: " 20Gi ",
       })
     ).toBe("20Gi");
+  });
+
+  it("defaults the deploy skill source to the brain-deploy branch", () => {
+    expect(DEFAULT_DEPLOY_SKILL_SOURCE).toBe(
+      "https://github.com/labring/sealos-skills/tree/brain-deploy"
+    );
+    expect(getDeploySkillSourceFromEnv({})).toBe(DEFAULT_DEPLOY_SKILL_SOURCE);
+    expect(
+      getDeploySkillSourceFromEnv({
+        DEPLOY_SKILL_SOURCE: "   ",
+      })
+    ).toBe(DEFAULT_DEPLOY_SKILL_SOURCE);
+  });
+
+  it("uses a configured deploy skill source", () => {
+    expect(
+      getDeploySkillSourceFromEnv({
+        DEPLOY_SKILL_SOURCE:
+          " https://github.com/labring/sealos-skills/tree/brain-deploy-preview ",
+      })
+    ).toBe(
+      "https://github.com/labring/sealos-skills/tree/brain-deploy-preview"
+    );
   });
 
   it("waits up to one hour for deploy DevBox runtime readiness", () => {

--- a/apps/ui/src/features/deploy/task/runner.ts
+++ b/apps/ui/src/features/deploy/task/runner.ts
@@ -111,6 +111,7 @@ import {
 import {
   DEPLOY_DEVBOX_RUNTIME_READY_TIMEOUT_MS,
   getDeployDevboxStorageLimitFromEnv,
+  getDeploySkillSourceFromEnv,
 } from "./runtime-config";
 import {
   CURRENT_AI_ARTIFACT_PUBLIC_PROJECTION_VERSION,
@@ -1511,7 +1512,7 @@ function prepareEmptyWorkspaceCommand(): string {
   ].join("\n");
 }
 
-function installSkillsCommand(): string {
+export function buildDeploySkillInstallCommand(skillSource: string): string {
   return [
     "set -euo pipefail",
     `workspace_dir=${shellQuote(DEPLOY_WORKSPACE_DIR)}`,
@@ -1520,7 +1521,7 @@ function installSkillsCommand(): string {
     'if [ ! -f "$agent_skill_marker" ] && [ ! -f "$codex_skill_marker" ]; then',
     "if command -v npx >/dev/null 2>&1; then",
     '  cd "$workspace_dir"',
-    "  timeout 120 npx --yes skills add https://github.com/labring/sealos-skills/tree/brain-deploy -y",
+    `  timeout 120 npx --yes skills add ${shellQuote(skillSource)} -y`,
     "else",
     "  printf 'ERROR: npx is required to install sealos-deploy skill\\n' >&2",
     "  exit 1",
@@ -3226,7 +3227,9 @@ async function runAiDeploymentTask(input: {
   });
   try {
     await execOrThrow({
-      command: installSkillsCommand(),
+      command: buildDeploySkillInstallCommand(
+        getDeploySkillSourceFromEnv(process.env)
+      ),
       namespace: input.task.namespace,
       runtimeName: runtime.name,
       timeoutSeconds: SKILL_INSTALL_TIMEOUT_SECONDS,

--- a/apps/ui/src/features/deploy/task/runtime-config.ts
+++ b/apps/ui/src/features/deploy/task/runtime-config.ts
@@ -1,5 +1,8 @@
 export const DEFAULT_DEPLOY_DEVBOX_STORAGE_LIMIT = "10Gi";
 
+export const DEFAULT_DEPLOY_SKILL_SOURCE =
+  "https://github.com/labring/sealos-skills/tree/brain-deploy";
+
 export const DEPLOY_DEVBOX_RUNTIME_READY_TIMEOUT_MS = 60 * 60_000;
 
 export function getDeployDevboxStorageLimitFromEnv(
@@ -9,4 +12,10 @@ export function getDeployDevboxStorageLimitFromEnv(
     env.DEPLOY_DEVBOX_STORAGE_LIMIT?.trim() ||
     DEFAULT_DEPLOY_DEVBOX_STORAGE_LIMIT
   );
+}
+
+export function getDeploySkillSourceFromEnv(
+  env: Record<string, string | undefined>
+): string {
+  return env.DEPLOY_SKILL_SOURCE?.trim() || DEFAULT_DEPLOY_SKILL_SOURCE;
 }

--- a/charts/brain-system/values.local.example.yaml
+++ b/charts/brain-system/values.local.example.yaml
@@ -59,6 +59,9 @@ ui:
     DEVBOX_JWT_TTL_SECONDS: "14400"
     # Storage ceiling for newly created deployment runtimes; existing Devboxes are unchanged.
     DEPLOY_DEVBOX_STORAGE_LIMIT: "10Gi"
+    # Optional. Leave empty for brain-deploy. Staging may use:
+    # https://github.com/labring/sealos-skills/tree/brain-deploy-preview
+    DEPLOY_SKILL_SOURCE: ""
 
 imagePullSecret:
   # App workload pods reference ghcr-cred when this chart creates it.

--- a/charts/brain-system/values.yaml
+++ b/charts/brain-system/values.yaml
@@ -130,6 +130,8 @@ ui:
     DEVBOX_ARCHIVE_AFTER_PAUSE_TIME: "24h"
     DEVBOX_JWT_TTL_SECONDS: "14400"
     DEPLOY_DEVBOX_STORAGE_LIMIT: "10Gi"
+    # Optional. Leave empty to use the production brain-deploy skill source.
+    DEPLOY_SKILL_SOURCE: ""
   resources:
     requests:
       cpu: 500m

--- a/docs/deployment/brain-system-launch.zh.md
+++ b/docs/deployment/brain-system-launch.zh.md
@@ -79,8 +79,22 @@ cp charts/brain-system/values.local.example.yaml /tmp/brain-system.values.yaml
 - `ui.env.FREE_CHAT_TURNS`
 - `ui.env.AI_PROXY_TOKEN_NAME`
 - `ui.env.DEVBOX_TOKEN` 或 `ui.env.DEVBOX_JWT_SIGNING_KEY`
+- 可选的 `ui.env.DEPLOY_SKILL_SOURCE`；留空时默认使用
+  `https://github.com/labring/sealos-skills/tree/brain-deploy`
 
 不要修改已有生产环境的 `GITHUB_USER_TOKEN_ENCRYPTION_KEY`。
+
+GitHub 和 prompt AI 部署固定调用 `sealos-deploy`。如需在 staging 验证
+preview 分支，只设置：
+
+```yaml
+ui:
+  env:
+    DEPLOY_SKILL_SOURCE: "https://github.com/labring/sealos-skills/tree/brain-deploy-preview"
+```
+
+修改后需要 rollout UI。配置只影响新的部署 runtime；已经安装
+`sealos-deploy` 的 Devbox 不会被覆盖。
 
 ### 3. 渲染检查
 

--- a/docs/deployment/brain-system.md
+++ b/docs/deployment/brain-system.md
@@ -40,6 +40,8 @@ Edit `/tmp/brain-system.values.yaml`, especially:
 - `GITHUB_USER_TOKEN_ENCRYPTION_KEY`: keep stable; changing it prevents decrypting previously stored GitHub user tokens
 - assistant model values
 - Devbox runtime values
+- optional `DEPLOY_SKILL_SOURCE`; leave empty to use
+  `https://github.com/labring/sealos-skills/tree/brain-deploy`
 - `imagePullSecret.create`
 
 Configure the GitHub App registration to match the UI origin:
@@ -54,6 +56,14 @@ Request user authorization (OAuth) during installation: disabled
 and the GitHub popup can close after users add or remove repositories.
 
 The install script reads `cloudDomain` and `cloudPort` from `sealos-system/sealos-config` and passes them to Helm. When left empty, `ui.env.API_URL` and `ui.env.NEXT_PUBLIC_APP_URL` are derived from the API/UI Ingress hosts rendered by this chart. `ui.env.DATABASE_URL` and `api.env.DATABASE_URL` are derived from the chart-created `brain-pg-conn-credential` Secret. `api.env.DB_PUBLIC_HOST`, `api.env.WHODB_URL`, and `ui.env.DEVBOX_API_BASE_URL` are also derived from the release namespace or platform cloud domain when left empty.
+
+GitHub and prompt AI deployments install `sealos-deploy` from the production
+`brain-deploy` source by default. To exercise another source in an environment,
+set `ui.env.DEPLOY_SKILL_SOURCE`; for example, staging can use
+`https://github.com/labring/sealos-skills/tree/brain-deploy-preview`. The skill
+name and `/sealos-deploy` invocation do not change. The value is read by the UI
+server process, so changing it requires a UI rollout and affects new deployment
+runtimes; a Devbox where the skill is already installed is not overwritten.
 
 Install or upgrade:
 


### PR DESCRIPTION
## Summary

- add one optional `DEPLOY_SKILL_SOURCE` environment variable for AI deployment skill installation
- keep `https://github.com/labring/sealos-skills/tree/brain-deploy` as the default when the variable is unset or blank
- allow staging to select sources such as `https://github.com/labring/sealos-skills/tree/brain-deploy-preview`
- keep the skill name, installation markers, `/sealos-deploy` invocation, and multi-skill `-y` installation behavior unchanged
- expose the setting through the UI env example, Helm values, and deployment documentation

## Why

This lets staging validate another branch of `sealos-skills` without changing the production default or introducing a configurable skill name.

The setting is consumed by the shared AI deployment runner, so it applies to GitHub and prompt deployments. Existing Devboxes that already contain the `sealos-deploy` marker are not overwritten.

## Validation

- `bun test src/features/deploy/task/runner.test.ts src/features/deploy/task/runner.github-ai-proxy.test.ts src/features/deploy/task/gateway-prompt.test.ts src/features/deploy/pipeline.test.ts` — 36 passed
- `bun typecheck`
- `bun check`
- `helm lint charts/brain-system`
- Helm template rendering with both the default empty value and the staging preview source
- `git diff --check`