### PR TITLE
fix(deploy): filter template Instance input fields

### DIFF
--- a/apps/ui/src/features/deploy/template-renderer.test.ts
+++ b/apps/ui/src/features/deploy/template-renderer.test.ts
@@ -13,6 +13,7 @@ import {
   TemplateInputValidationError,
   type TemplateInputValidationErrorCode,
   type TemplateInputValidationValueSource,
+  templateSourceFromInlineYaml,
 } from "./template-renderer";
 
 const source = {
@@ -841,6 +842,53 @@ spec:
   assert.equal(instance.metadata.name, "template-inline");
   assert.equal(service?.metadata?.name, "template-inline");
   assert.match(ingressYaml ?? "", TEMPLATE_SECRET_NAME_RE);
+});
+
+test("renderTemplateDeployment keeps declaration-only input fields off Instance", () => {
+  const templateYaml = `
+apiVersion: app.sealos.io/v1
+kind: Template
+metadata:
+  name: mastodon
+spec:
+  title: Mastodon
+  inputs:
+    registrations_mode:
+      default: approved
+      description: Who can create accounts
+      options:
+        - approved
+        - open
+      required: true
+      type: string
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mastodon
+spec:
+  ports:
+    - port: 80
+`;
+  const { source: template, templateName } =
+    templateSourceFromInlineYaml(templateYaml);
+  const rendered = renderTemplateDeployment({
+    instanceName: "mastodon",
+    namespace: "ns-admin",
+    projectId: "project-uid",
+    projectName: "project-uid",
+    source: template,
+    templateName,
+  });
+  const instance = YAML.parse(rendered.instanceYaml);
+
+  assert.deepEqual(template.source.inputs?.[0]?.options, ["approved", "open"]);
+  assert.deepEqual(instance.spec.inputs.registrations_mode, {
+    default: "approved",
+    description: "Who can create accounts",
+    required: true,
+    type: "string",
+  });
 });
 
 test("renderTemplateDeploymentFromYaml renders base64 expressions with JSON braces", () => {

--- a/apps/ui/src/features/deploy/template-renderer.ts
+++ b/apps/ui/src/features/deploy/template-renderer.ts
@@ -613,6 +613,29 @@ function hasUnsafeTemplateScalarCharacter(value: string): boolean {
   return false;
 }
 
+const INSTANCE_INPUT_FIELDS = new Set([
+  "default",
+  "description",
+  "required",
+  "type",
+]);
+
+function instanceInputs(
+  value: unknown
+): Record<string, Record<string, unknown>> {
+  const inputs = asRecord(value) ?? {};
+  return Object.fromEntries(
+    Object.entries(inputs).map(([key, input]) => [
+      key,
+      Object.fromEntries(
+        Object.entries(asRecord(input) ?? {}).filter(([field]) =>
+          INSTANCE_INPUT_FIELDS.has(field)
+        )
+      ),
+    ])
+  );
+}
+
 /*
  * Keep user-provided template inputs as plain scalar values. They are substituted
  * into provider YAML before parsing, so multi-line values would be able to alter
@@ -637,7 +660,7 @@ function templateInstanceObject(
       draft: spec.draft === true,
       gitRepo: spec.gitRepo,
       icon: requiredString(spec.icon),
-      inputs: asRecord(spec.inputs) ?? {},
+      inputs: instanceInputs(spec.inputs),
       readme: requiredString(spec.readme),
       templateType: spec.templateType ?? spec.template_type,
       title: requiredString(spec.title),


### PR DESCRIPTION
## Summary
- Filter template input declarations before emitting runtime `Instance` resources.
- Preserve declaration-only metadata such as `options` for the Template configuration flow.
- Add a regression test for `registrations_mode.options`.

## Root cause
The renderer copied Template `spec.inputs` into `app.sealos.io/v1` Instance resources unchanged. Staging rejects `options`, which is not declared in the Instance CRD schema.

## Validation
- `bun test src/features/deploy/template-renderer.test.ts`
- `bun typecheck`
- `bun check`