### PR TITLE
fix(deploy): restore configurable skill branch source

### DIFF
--- a/apps/ui/src/features/deploy/task/runner.github-ai-proxy.test.ts
+++ b/apps/ui/src/features/deploy/task/runner.github-ai-proxy.test.ts
@@ -13,6 +13,7 @@ import type { DeployTaskRow } from "./schema";
 
 const requireModule = createRequire(import.meta.url);
 const originalFetch = globalThis.fetch;
+const PINNED_SKILL_COMMIT_SOURCE_RE = /sealos-skills\.git#[0-9a-f]{7,}/;
 const ENV_KEYS = [
   "AI_PROXY_TOKEN_NAME",
   "CODEX_GATEWAY_MODEL",
@@ -35,9 +36,12 @@ mock.module("server-only", () => ({}));
 const {
   buildCodexGatewayEnv,
   ensureAiDeploymentDevbox,
-  installSkillsCommand,
+  buildDeploySkillInstallCommand,
   resolveGithubCodexGatewayCredentials,
 } = requireModule("./runner") as typeof import("./runner");
+const { getDeploySkillSourceFromEnv } = requireModule(
+  "./runtime-config"
+) as typeof import("./runtime-config");
 const {
   CodexGatewayApiError,
   CodexGatewayTimeoutError,
@@ -104,17 +108,33 @@ function devbox(name: string, phase = "Running") {
   };
 }
 
-describe("deployment skill revision", () => {
-  it("pins and refreshes the complete deploy skill set", () => {
-    const command = installSkillsCommand();
+describe("deploy skill installation", () => {
+  it("installs from the configured branch source without pinning a commit", () => {
+    const command = buildDeploySkillInstallCommand(
+      "https://github.com/labring/sealos-skills/tree/brain-deploy-preview"
+    );
 
-    expect(command).toContain("cbb428ca852db1c5076ff15e9524fc5c1eb4cee3");
-    expect(command).toContain("deploy-skills-revision");
-    expect(command).toContain("k8s-kaniko-job/SKILL.md");
+    expect(command).toContain(
+      "https://github.com/labring/sealos-skills/tree/brain-deploy-preview"
+    );
     expect(command).toContain('npx --yes skills@1.5.20 add "$skill_source" -y');
-    expect(command).not.toContain("installed_revision");
+    expect(command).toContain("k8s-kaniko-job/SKILL.md");
     expect(command).toContain(
       "for skill_name in sealos-deploy dockerfile-skill k8s-kaniko-job cloud-native-readiness docker-to-sealos"
+    );
+    expect(command).not.toContain("deploy-skills-revision");
+    expect(command).not.toMatch(PINNED_SKILL_COMMIT_SOURCE_RE);
+  });
+
+  it("defaults to the brain-deploy branch via runtime config", () => {
+    expect(getDeploySkillSourceFromEnv({})).toBe(
+      "https://github.com/labring/sealos-skills/tree/brain-deploy"
+    );
+    const command = buildDeploySkillInstallCommand(
+      getDeploySkillSourceFromEnv({})
+    );
+    expect(command).toContain(
+      "https://github.com/labring/sealos-skills/tree/brain-deploy"
     );
   });
 });

--- a/apps/ui/src/features/deploy/task/runner.ts
+++ b/apps/ui/src/features/deploy/task/runner.ts
@@ -112,6 +112,7 @@ import {
 import {
   DEPLOY_DEVBOX_RUNTIME_READY_TIMEOUT_MS,
   getDeployDevboxStorageLimitFromEnv,
+  getDeploySkillSourceFromEnv,
 } from "./runtime-config";
 import {
   CURRENT_AI_ARTIFACT_PUBLIC_PROJECTION_VERSION,
@@ -180,8 +181,6 @@ const DEPLOY_TEMPLATE_YAML_PATH = `${DEPLOY_WORKSPACE_DIR}/.sealos/template/inde
 const SKILL_INSTALL_COMMAND_TIMEOUT_SECONDS =
   DEPLOY_TIMEOUT_POLICY.skillInstallMs / 1000;
 const DEPLOY_SKILLS_CLI_VERSION = "1.5.20";
-const DEPLOY_SKILLS_REVISION = "cbb428ca852db1c5076ff15e9524fc5c1eb4cee3";
-const DEPLOY_SKILLS_SOURCE = `https://github.com/labring/sealos-skills.git#${DEPLOY_SKILLS_REVISION}`;
 const READ_OUTPUT_TIMEOUT_SECONDS = DEPLOY_TIMEOUT_POLICY.outputReadMs / 1000;
 const DEPLOY_OUTPUT_PROGRESS_POLL_MS = DEPLOY_TIMEOUT_POLICY.outputPollMs;
 const DIRECT_AP_READINESS_POLL_MS = 5000;
@@ -1688,13 +1687,12 @@ function prepareEmptyWorkspaceCommand(): string {
   ].join("\n");
 }
 
-export function installSkillsCommand(): string {
+/** Branch/tree URL for `skills add`; default brain-deploy, override via DEPLOY_SKILL_SOURCE. */
+export function buildDeploySkillInstallCommand(skillSource: string): string {
   return [
     "set -euo pipefail",
     `workspace_dir=${shellQuote(DEPLOY_WORKSPACE_DIR)}`,
-    `expected_revision=${shellQuote(DEPLOY_SKILLS_REVISION)}`,
-    `skill_source=${shellQuote(DEPLOY_SKILLS_SOURCE)}`,
-    'revision_marker="$workspace_dir/.sealos/deploy-skills-revision"',
+    `skill_source=${shellQuote(skillSource)}`,
     'agent_skill_marker="$workspace_dir/.agents/skills/sealos-deploy/SKILL.md"',
     'agent_build_skill_marker="$workspace_dir/.agents/skills/k8s-kaniko-job/SKILL.md"',
     'codex_skill_marker="$workspace_dir/.codex/skills/sealos-deploy/SKILL.md"',
@@ -1717,8 +1715,6 @@ export function installSkillsCommand(): string {
     "  printf 'ERROR: k8s-kaniko-job skill not found after install\\n' >&2",
     "  exit 1",
     "fi",
-    'mkdir -p "$(dirname "$revision_marker")"',
-    'printf "%s\\n" "$expected_revision" > "$revision_marker"',
   ].join("\n");
 }
 
@@ -3691,7 +3687,9 @@ async function runAiDeploymentTask(input: {
   });
   try {
     await execOrThrow({
-      command: installSkillsCommand(),
+      command: buildDeploySkillInstallCommand(
+        getDeploySkillSourceFromEnv(process.env)
+      ),
       deadlineAtMs: prepareDeadlineAtMs,
       namespace: input.task.namespace,
       runtimeName: runtime.name,


### PR DESCRIPTION
## Summary

- restore `DEPLOY_SKILL_SOURCE` when building the AI deployment skill installation command
- default to the `brain-deploy` branch while allowing environment-specific branch/tree sources
- keep the installer pinned to `skills@1.5.20` and continue refreshing the complete deployment skill set
- add regression coverage for configured/default branch sources and removal of the hard-coded skill commit

## Root cause

The deployment timeout policy change replaced the runtime-configured skill source with a hard-coded `sealos-skills` commit. That disabled the existing environment override and prevented deployments from following the configured deployment-skill branch.

## Impact

Production deployments again use the `brain-deploy` branch by default, while staging can select a preview branch through `DEPLOY_SKILL_SOURCE`. The CLI version remains deterministic.

## Validation

- `bun test src/features/deploy/task/runner.github-ai-proxy.test.ts src/features/deploy/task/runner.test.ts` — 32 passed
- `bun typecheck`
- `bun check`
- `git diff --check`