### PR TITLE
feat(chat): add guarded project management tools

### DIFF
--- a/apps/ui/drizzle/0010_tiny_cardiac.sql
+++ b/apps/ui/drizzle/0010_tiny_cardiac.sql
@@ -1,0 +1,45 @@
+CREATE TABLE "sealai_project"."project_delete_operations" (
+	"namespace" text NOT NULL,
+	"project_id" text NOT NULL,
+	"actor_uid" text NOT NULL,
+	"preview_id" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "project_delete_operations_pk" PRIMARY KEY("namespace","project_id")
+);
+--> statement-breakpoint
+CREATE TABLE "sealai_project"."project_delete_previews" (
+	"id" text NOT NULL,
+	"actor_uid" text NOT NULL,
+	"chat_id" text NOT NULL,
+	"namespace" text NOT NULL,
+	"project_id" text NOT NULL,
+	"display_name" text NOT NULL,
+	"resource_summary" jsonb NOT NULL,
+	"fingerprint" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"consumed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "project_delete_previews_pk" PRIMARY KEY("id")
+);
+--> statement-breakpoint
+CREATE TABLE "sealai_project"."project_management_audit_events" (
+	"id" text NOT NULL,
+	"action" text NOT NULL,
+	"status" text NOT NULL,
+	"source" text NOT NULL,
+	"actor_uid" text NOT NULL,
+	"chat_id" text NOT NULL,
+	"namespace" text NOT NULL,
+	"project_id" text NOT NULL,
+	"display_name" text NOT NULL,
+	"resource_summary" jsonb NOT NULL,
+	"failure_code" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "project_management_audit_events_pk" PRIMARY KEY("id")
+);
+--> statement-breakpoint
+CREATE INDEX "project_delete_operations_expires_at_idx" ON "sealai_project"."project_delete_operations" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX "project_delete_previews_expires_at_idx" ON "sealai_project"."project_delete_previews" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX "project_delete_previews_target_idx" ON "sealai_project"."project_delete_previews" USING btree ("namespace","project_id");--> statement-breakpoint
+CREATE INDEX "project_management_audit_events_target_idx" ON "sealai_project"."project_management_audit_events" USING btree ("namespace","project_id","created_at");

--- a/apps/ui/drizzle/meta/0010_snapshot.json
+++ b/apps/ui/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1839 @@
+{
+  "id": "77ccc87d-883f-4159-a4dc-7736b73fe782",
+  "prevId": "1c629245-56e9-45e2-8ba4-61972efcc478",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "sealai_assistant.assistant_chat_messages": {
+      "name": "assistant_chat_messages",
+      "schema": "sealai_assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assistant_chat_messages_chat_id_idx": {
+          "name": "assistant_chat_messages_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assistant_chat_messages_chat_id_created_idx": {
+          "name": "assistant_chat_messages_chat_id_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assistant_chat_messages_chat_id_assistant_chats_id_fk": {
+          "name": "assistant_chat_messages_chat_id_assistant_chats_id_fk",
+          "tableFrom": "assistant_chat_messages",
+          "tableTo": "assistant_chats",
+          "schemaTo": "sealai_assistant",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.assistant_chats": {
+      "name": "assistant_chats",
+      "schema": "sealai_assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_actor": {
+          "name": "workspace_actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Chat'"
+        },
+        "title_ai_generated": {
+          "name": "title_ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assistant_chats_updated_at_idx": {
+          "name": "assistant_chats_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assistant_chats_namespace_actor_updated_at_idx": {
+          "name": "assistant_chats_namespace_actor_updated_at_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_actor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.assistant_entitlements": {
+      "name": "assistant_entitlements",
+      "schema": "sealai_assistant",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "free_turns_used": {
+          "name": "free_turns_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assistant_entitlements_updated_at_idx": {
+          "name": "assistant_entitlements_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.github_app_install_sessions": {
+      "name": "github_app_install_sessions",
+      "schema": "sealai_assistant",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_actor": {
+          "name": "workspace_actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "owner_identity_version": {
+          "name": "owner_identity_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "return_path": {
+          "name": "return_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_app_install_sessions_expires_at_idx": {
+          "name": "github_app_install_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_app_install_sessions_namespace_idx": {
+          "name": "github_app_install_sessions_namespace_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.github_connections": {
+      "name": "github_connections",
+      "schema": "sealai_assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github_app'"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'User'"
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_connections_updated_at_idx": {
+          "name": "github_connections_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_namespace_updated_at_idx": {
+          "name": "github_connections_namespace_updated_at_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_namespace_unique_idx": {
+          "name": "github_connections_namespace_unique_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_installation_idx": {
+          "name": "github_connections_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.github_oauth_connections": {
+      "name": "github_oauth_connections",
+      "schema": "sealai_assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_actor": {
+          "name": "workspace_actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "owner_identity_version": {
+          "name": "owner_identity_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "github_login": {
+          "name": "github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bearer'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_oauth_connections_updated_at_idx": {
+          "name": "github_oauth_connections_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_oauth_connections_github_login_idx": {
+          "name": "github_oauth_connections_github_login_idx",
+          "columns": [
+            {
+              "expression": "github_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_oauth_connections_current_owner_unique_idx": {
+          "name": "github_oauth_connections_current_owner_unique_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_actor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sealai_assistant\".\"github_oauth_connections\".\"owner_identity_version\" = 2",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.identity_fingerprints": {
+      "name": "identity_fingerprints",
+      "schema": "sealai_assistant",
+      "columns": {
+        "cr_name": {
+          "name": "cr_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_uid": {
+          "name": "user_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minted_at": {
+          "name": "minted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_deployment.deploy_task_events": {
+      "name": "deploy_task_events",
+      "schema": "sealai_deployment",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nextval('sealai_deployment.deploy_task_events_seq'::regclass)"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deploy_task_events_task_created_at_idx": {
+          "name": "deploy_task_events_task_created_at_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deploy_task_events_task_id_deploy_tasks_id_fk": {
+          "name": "deploy_task_events_task_id_deploy_tasks_id_fk",
+          "tableFrom": "deploy_task_events",
+          "tableTo": "deploy_tasks",
+          "schemaTo": "sealai_deployment",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "deploy_task_events_pk": {
+          "name": "deploy_task_events_pk",
+          "columns": ["task_id", "seq"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_deployment.deploy_task_messages": {
+      "name": "deploy_task_messages",
+      "schema": "sealai_deployment",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deploy_task_messages_task_id_idx": {
+          "name": "deploy_task_messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_task_messages_task_created_idx": {
+          "name": "deploy_task_messages_task_created_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deploy_task_messages_task_id_deploy_tasks_id_fk": {
+          "name": "deploy_task_messages_task_id_deploy_tasks_id_fk",
+          "tableFrom": "deploy_task_messages",
+          "tableTo": "deploy_tasks",
+          "schemaTo": "sealai_deployment",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_deployment.deploy_tasks": {
+      "name": "deploy_tasks",
+      "schema": "sealai_deployment",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_uid": {
+          "name": "project_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creating_actor": {
+          "name": "creating_actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_binding": {
+          "name": "credential_binding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_connection_id": {
+          "name": "github_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_from": {
+          "name": "created_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_name": {
+          "name": "runtime_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_url": {
+          "name": "gateway_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_session_id": {
+          "name": "gateway_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_thread_id": {
+          "name": "gateway_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_turn_id": {
+          "name": "gateway_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_state_snapshot": {
+          "name": "gateway_state_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_details": {
+          "name": "failure_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_summary": {
+          "name": "artifact_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "canvas_projection": {
+          "name": "canvas_projection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "timeline_snapshot": {
+          "name": "timeline_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocking_inputs": {
+          "name": "blocking_inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "preview_url": {
+          "name": "preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_url": {
+          "name": "result_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_epoch": {
+          "name": "lease_epoch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_claimed_at": {
+          "name": "lease_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retried_from_task_id": {
+          "name": "retried_from_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deploy_tasks_namespace_updated_at_idx": {
+          "name": "deploy_tasks_namespace_updated_at_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_project_uid_updated_at_idx": {
+          "name": "deploy_tasks_project_uid_updated_at_idx",
+          "columns": [
+            {
+              "expression": "project_uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_status_updated_at_idx": {
+          "name": "deploy_tasks_status_updated_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_leased_expiry_idx": {
+          "name": "deploy_tasks_leased_expiry_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"status\" IN ('running', 'applying')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_queued_created_idx": {
+          "name": "deploy_tasks_queued_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_terminal_completed_idx": {
+          "name": "deploy_tasks_terminal_completed_idx",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"status\" IN ('completed', 'failed', 'cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_one_active_clone_idx": {
+          "name": "deploy_tasks_one_active_clone_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retried_from_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"retried_from_task_id\" IS NOT NULL AND \"sealai_deployment\".\"deploy_tasks\".\"status\" IN ('queued', 'running', 'blocked', 'applying')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_canvas_layouts": {
+      "name": "project_canvas_layouts",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_uid": {
+          "name": "project_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name_snapshot": {
+          "name": "project_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "nodes": {
+          "name": "nodes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_canvas_layouts_updated_at_idx": {
+          "name": "project_canvas_layouts_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_canvas_layouts_pk": {
+          "name": "project_canvas_layouts_pk",
+          "columns": ["namespace", "project_uid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_delete_operations": {
+      "name": "project_delete_operations",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_uid": {
+          "name": "actor_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_id": {
+          "name": "preview_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_delete_operations_expires_at_idx": {
+          "name": "project_delete_operations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_delete_operations_pk": {
+          "name": "project_delete_operations_pk",
+          "columns": ["namespace", "project_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_delete_previews": {
+      "name": "project_delete_previews",
+      "schema": "sealai_project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_uid": {
+          "name": "actor_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_summary": {
+          "name": "resource_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_delete_previews_expires_at_idx": {
+          "name": "project_delete_previews_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_delete_previews_target_idx": {
+          "name": "project_delete_previews_target_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_delete_previews_pk": {
+          "name": "project_delete_previews_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_management_audit_events": {
+      "name": "project_management_audit_events",
+      "schema": "sealai_project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_uid": {
+          "name": "actor_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_summary": {
+          "name": "resource_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_management_audit_events_target_idx": {
+          "name": "project_management_audit_events_target_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_management_audit_events_pk": {
+          "name": "project_management_audit_events_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_navigation_preferences": {
+      "name": "project_navigation_preferences",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_project_ids": {
+          "name": "pinned_project_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_navigation_preferences_updated_at_idx": {
+          "name": "project_navigation_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_navigation_preferences_pk": {
+          "name": "project_navigation_preferences_pk",
+          "columns": ["namespace"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.projects": {
+      "name": "projects",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_namespace_lower_display_name_idx": {
+          "name": "projects_namespace_lower_display_name_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"display_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "projects_pk": {
+          "name": "projects_pk",
+          "columns": ["namespace", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "sealai_assistant": "sealai_assistant",
+    "sealai_deployment": "sealai_deployment",
+    "sealai_project": "sealai_project"
+  },
+  "sequences": {
+    "sealai_deployment.deploy_task_events_seq": {
+      "name": "deploy_task_events_seq",
+      "schema": "sealai_deployment",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/ui/drizzle/meta/_journal.json
+++ b/apps/ui/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1785254479905,
       "tag": "0009_identity_fingerprints",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1785399621883,
+      "tag": "0010_tiny_cardiac",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/ui/src/app/api/chat/route.ts
+++ b/apps/ui/src/app/api/chat/route.ts
@@ -574,9 +574,11 @@ async function runChatPipeline(input: {
     // kubeconfig-verified identity (AIM-154 keeps them token-free).
     const { tools, systemPrompt } = await buildChatToolset({
       assistantContext,
+      chatId,
       kubeconfig,
       kubernetesNamespace: owner.namespace,
       workspaceActor: actor.legacyWorkspaceActor,
+      workspaceUserUid: owner.userUid,
     });
 
     const openAi = await resolveChatOpenAiConnection({

--- a/apps/ui/src/app/api/projects/route.ts
+++ b/apps/ui/src/app/api/projects/route.ts
@@ -8,6 +8,7 @@ import {
 import {
   createProject,
   deleteProject,
+  getProject,
   listProjects,
   ProjectPersistenceError,
   updateProject,
@@ -101,6 +102,13 @@ export async function GET(request: NextRequest) {
   }
 
   try {
+    const id = request.nextUrl.searchParams.get("id")?.trim();
+    if (id) {
+      const project = await getProject(namespace.data, id);
+      return project === null
+        ? jsonError("Project not found.", 404)
+        : NextResponse.json({ project });
+    }
     return NextResponse.json({ projects: await listProjects(namespace.data) });
   } catch {
     return jsonError("Project persistence is unavailable.", 503);

--- a/apps/ui/src/features/chat/chat.tool-group.test.ts
+++ b/apps/ui/src/features/chat/chat.tool-group.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { projectDeletionApprovalInput } from "./chat.tool-group";
+
+test("Project deletion approval exposes the exact preview target and resources", () => {
+  assert.deepEqual(
+    projectDeletionApprovalInput({
+      projectDisplayName: "Payments",
+      projectId: "project-1",
+      resourceSummary: { ap: ["api"], db: ["postgres"] },
+    }),
+    {
+      displayName: "Payments",
+      projectId: "project-1",
+      resources: [
+        ["ap", ["api"]],
+        ["db", ["postgres"]],
+      ],
+    }
+  );
+});
+
+test("Project deletion approval rejects malformed tool input", () => {
+  assert.equal(projectDeletionApprovalInput({ projectId: "project-1" }), null);
+  assert.equal(
+    projectDeletionApprovalInput({
+      projectDisplayName: "Payments",
+      projectId: "project-1",
+      resourceSummary: { ap: [1] },
+    }),
+    null
+  );
+});

--- a/apps/ui/src/features/chat/chat.tool-group.tsx
+++ b/apps/ui/src/features/chat/chat.tool-group.tsx
@@ -7,6 +7,7 @@ import {
   TaskTrigger,
 } from "@workspace/ui/components/ai-elements/task";
 import { AppButton } from "@workspace/ui/components/app-button";
+import { AppInput } from "@workspace/ui/components/app-input";
 import {
   Collapsible,
   CollapsibleContent,
@@ -275,8 +276,10 @@ const ChatToolGroupItem = memo(
 /** Approval id + human label for a tool part awaiting the user's decision. */
 interface PendingApproval {
   id: string;
+  input: unknown;
   key: string;
   label: string;
+  type: string;
 }
 
 function collectPendingApprovals(parts: ChatToolPart[]): PendingApproval[] {
@@ -291,11 +294,135 @@ function collectPendingApprovals(parts: ChatToolPart[]): PendingApproval[] {
     return [
       {
         id,
+        input: part.input,
         key: part.toolCallId,
         label: readIntention(part.input) ?? humanizeToolType(part.type),
+        type: part.type,
       },
     ];
   });
+}
+
+export function projectDeletionApprovalInput(input: unknown): {
+  displayName: string;
+  projectId: string;
+  resources: [string, string[]][];
+} | null {
+  if (input == null || typeof input !== "object") {
+    return null;
+  }
+  const value = input as {
+    projectDisplayName?: unknown;
+    projectId?: unknown;
+    resourceSummary?: unknown;
+  };
+  if (
+    typeof value.projectDisplayName !== "string" ||
+    typeof value.projectId !== "string" ||
+    value.resourceSummary == null ||
+    typeof value.resourceSummary !== "object" ||
+    Array.isArray(value.resourceSummary)
+  ) {
+    return null;
+  }
+  const resources: [string, string[]][] = [];
+  for (const [kind, names] of Object.entries(value.resourceSummary)) {
+    if (
+      !(Array.isArray(names) && names.every((name) => typeof name === "string"))
+    ) {
+      return null;
+    }
+    resources.push([kind, names]);
+  }
+  return {
+    displayName: value.projectDisplayName,
+    projectId: value.projectId,
+    resources,
+  };
+}
+
+function ProjectDeletionApprovalCard({
+  approval,
+  input,
+  onRespond,
+}: {
+  approval: PendingApproval;
+  input: NonNullable<ReturnType<typeof projectDeletionApprovalInput>>;
+  onRespond?: ChatAddToolApproveResponseFunction;
+}) {
+  const [confirmation, setConfirmation] = useState("");
+  const confirmed = confirmation.trim() === input.displayName;
+  const nonEmptyResources = input.resources.filter(
+    ([, names]) => names.length > 0
+  );
+
+  return (
+    <div
+      className="flex flex-col gap-3 rounded-lg border border-destructive/40 bg-background p-3"
+      data-slot="chat-project-delete-approval"
+    >
+      <div className="flex min-w-0 flex-col gap-1">
+        <p className="text-foreground text-sm">Delete project permanently?</p>
+        <p className="text-muted-foreground text-xs">{input.displayName}</p>
+        <p className="break-all font-mono text-muted-foreground text-xs">
+          {input.projectId}
+        </p>
+      </div>
+      <div className="max-h-40 overflow-y-auto rounded-md border border-border/60 bg-input/15 p-2 text-xs">
+        {nonEmptyResources.length === 0 ? (
+          <p className="text-muted-foreground">No managed resources found.</p>
+        ) : (
+          <ul className="space-y-1 text-muted-foreground">
+            {nonEmptyResources.map(([kind, names]) => (
+              <li key={kind}>
+                <span className="text-foreground">{kind}</span>:{" "}
+                {names.join(", ")}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <label
+        className="flex flex-col gap-1.5 text-muted-foreground text-xs"
+        htmlFor={`${approval.id}-project-name`}
+      >
+        Type{" "}
+        <span className="font-medium text-foreground">{input.displayName}</span>{" "}
+        to confirm
+        <AppInput
+          aria-label="Project name confirmation"
+          id={`${approval.id}-project-name`}
+          onChange={(event) => setConfirmation(event.target.value)}
+          value={confirmation}
+        />
+      </label>
+      <div className="flex flex-wrap gap-2">
+        <AppButton
+          disabled={!confirmed}
+          onClick={() => onRespond?.({ approved: true, id: approval.id })}
+          size="sm"
+          type="button"
+          variant="danger"
+        >
+          Delete project
+        </AppButton>
+        <AppButton
+          onClick={() =>
+            onRespond?.({
+              approved: false,
+              id: approval.id,
+              reason: "User declined Project deletion.",
+            })
+          }
+          size="sm"
+          type="button"
+          variant="quiet"
+        >
+          Cancel
+        </AppButton>
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -310,6 +437,19 @@ function ChatToolApprovalCard({
   approval: PendingApproval;
   onRespond?: ChatAddToolApproveResponseFunction;
 }) {
+  const projectDeletion =
+    approval.type === "tool-deleteProject"
+      ? projectDeletionApprovalInput(approval.input)
+      : null;
+  if (projectDeletion !== null) {
+    return (
+      <ProjectDeletionApprovalCard
+        approval={approval}
+        input={projectDeletion}
+        onRespond={onRespond}
+      />
+    );
+  }
   return (
     <div
       className="flex flex-col gap-2 rounded-lg border border-border bg-background p-3"

--- a/apps/ui/src/features/chat/runtime/model.ts
+++ b/apps/ui/src/features/chat/runtime/model.ts
@@ -17,6 +17,7 @@ export const CHAT_BASE_SYSTEM_PROMPT = [
   "You have sandbox tools `readFile`, `writeFile`, and `bash` for filesystem access, kubectl, and shell work against the user's connected Sealos cluster; context includes the relevant Kubernetes namespace when present.",
   "For normal Sealos Brain AP/DB workflows, prefer the Brain product tools (`readProductResource`, `draftProductResourceChange`, `writeProductResource`) over raw kubectl writes.",
   "Use `draftProductResourceChange` to preview AP/DB changes first. Use `writeProductResource` only after explicit user approval of the exact change; public address/domain changes belong to AP network intent.",
+  "For Project management, use `listProjects` and `getProject` before selecting a target. Project deletion must use `previewProjectDeletion` followed by `deleteProject` with the preview values copied verbatim; never use bash or kubectl to delete a Project or namespace. After a successful Project deletion, call `refreshFrontendSwrCaches` and navigate away from the deleted Project when it is the active workspace.",
   "Use bash/kubectl for diagnostics, emergency recovery, or evidence gathering when product tools are insufficient; do not use it as the default product write path.",
   "",
   "Stay helpful, concise, and proactive: suggest sensible next checks or edits so users can manage resources efficiently.",

--- a/apps/ui/src/features/chat/runtime/tools.ts
+++ b/apps/ui/src/features/chat/runtime/tools.ts
@@ -12,6 +12,7 @@ import { createDeployTaskTools } from "@/features/chat/tool/chat-deploy-task-too
 import { navigateAppTool } from "@/features/chat/tool/chat-navigate-app-tool";
 import { openProjectSurfaceTool } from "@/features/chat/tool/chat-open-project-surface-tool";
 import { createChatProductTools } from "@/features/chat/tool/chat-product-tools";
+import { createChatProjectTools } from "@/features/chat/tool/chat-project-tools";
 import { refreshFrontendSwrCachesTool } from "@/features/chat/tool/chat-refresh-frontend-swr-tool";
 import {
   buildChatSkillsDiscoveryPrompt,
@@ -56,12 +57,16 @@ export interface ChatToolset {
 export async function buildChatToolset({
   kubeconfig,
   kubernetesNamespace,
+  chatId,
   workspaceActor,
+  workspaceUserUid,
   assistantContext,
 }: {
+  chatId: string;
   kubeconfig: string;
   kubernetesNamespace: string;
   workspaceActor: string;
+  workspaceUserUid: string;
   assistantContext?: AssistantContextPayload;
 }): Promise<ChatToolset> {
   const [skillIndex, { tools: bashTools }] = await Promise.all([
@@ -78,10 +83,17 @@ export async function buildChatToolset({
     kubeconfig,
     kubernetesNamespace,
   });
+  const projectTools = createChatProjectTools({
+    chatId,
+    kubeconfig,
+    kubernetesNamespace,
+    workspaceUserUid,
+  });
 
   const tools = {
     ...deployTaskTools,
     ...productTools,
+    ...projectTools,
     emitGenUISpec,
     navigateApp: navigateAppTool,
     openProjectSurface: openProjectSurfaceTool,

--- a/apps/ui/src/features/chat/tool/chat-project-tools.test.ts
+++ b/apps/ui/src/features/chat/tool/chat-project-tools.test.ts
@@ -1,0 +1,45 @@
+import { mock } from "bun:test";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+mock.module("server-only", () => ({}));
+
+const { createChatProjectTools, deleteProjectInputSchema } = await import(
+  "./chat-project-tools"
+);
+
+test("Project delete tool requires AI SDK approval", () => {
+  const tools = createChatProjectTools({
+    chatId: "chat-1",
+    kubeconfig: "kubeconfig",
+    kubernetesNamespace: "ns-a",
+    workspaceUserUid: "user-1",
+  });
+
+  assert.equal(Reflect.get(tools.deleteProject, "needsApproval"), true);
+  assert.ok("listProjects" in tools);
+  assert.ok("getProject" in tools);
+  assert.ok("previewProjectDeletion" in tools);
+});
+
+test("Project deletion input binds the server preview summary to the approval", () => {
+  assert.equal(
+    deleteProjectInputSchema.safeParse({
+      intention: "delete the selected Project after review",
+      previewId: "preview-1",
+      projectDisplayName: "Payments",
+      projectId: "project-1",
+      resourceSummary: { ap: ["api"] },
+    }).success,
+    true
+  );
+  assert.equal(
+    deleteProjectInputSchema.safeParse({
+      intention: "delete the selected Project after review",
+      previewId: "preview-1",
+      projectDisplayName: "Payments",
+      projectId: "project-1",
+    }).success,
+    false
+  );
+});

--- a/apps/ui/src/features/chat/tool/chat-project-tools.ts
+++ b/apps/ui/src/features/chat/tool/chat-project-tools.ts
@@ -1,0 +1,142 @@
+import { tool } from "ai";
+import { z } from "zod";
+import type { ProjectChildResourceSummary } from "@/lib/project-persistence/delete-guard";
+import {
+  deleteManagedProject,
+  getManagedProject,
+  listManagedProjects,
+  previewManagedProjectDeletion,
+} from "@/lib/project-persistence/project-management";
+
+import {
+  chatToolIntentionField,
+  logChatToolIntention,
+} from "./chat-tool-intention";
+
+const projectIdSchema = z.string().trim().min(1).max(256);
+const resourceSummarySchema = z.record(
+  z.string().min(1).max(80),
+  z.array(z.string().min(1).max(253)).max(10_000)
+);
+
+const listProjectsInputSchema = z.object({
+  intention: chatToolIntentionField,
+});
+
+const getProjectInputSchema = z.object({
+  intention: chatToolIntentionField,
+  projectId: projectIdSchema,
+});
+
+const previewProjectDeletionInputSchema = z.object({
+  intention: chatToolIntentionField,
+  projectId: projectIdSchema,
+});
+
+export const deleteProjectInputSchema = z.object({
+  intention: chatToolIntentionField,
+  previewId: projectIdSchema,
+  projectDisplayName: z.string().trim().min(1).max(256),
+  projectId: projectIdSchema,
+  resourceSummary: resourceSummarySchema,
+});
+
+export function createChatProjectTools(options: {
+  chatId: string;
+  kubeconfig: string;
+  kubernetesNamespace: string;
+  workspaceUserUid: string;
+}) {
+  const actor = {
+    actorUid: options.workspaceUserUid,
+    chatId: options.chatId,
+    encodedKubeconfig: encodeURIComponent(options.kubeconfig),
+    namespace: options.kubernetesNamespace,
+  };
+
+  const listProjectsTool = tool({
+    description: [
+      "List the Projects accessible in the current authorized namespace.",
+      "Use this before selecting a Project by name. Return IDs are the only valid targets for subsequent Project tools.",
+      "Never assume a Project name maps to a target without first listing or reading it.",
+    ].join(" "),
+    inputSchema: listProjectsInputSchema,
+    execute: async (input) => {
+      logChatToolIntention("listProjects", input.intention);
+      return { ok: true, projects: await listManagedProjects(actor) };
+    },
+  });
+
+  const getProjectTool = tool({
+    description: [
+      "Read one Project by stable Project ID in the current authorized namespace.",
+      "Use before previewing or managing a Project. A missing result means the ID is not available in this namespace.",
+    ].join(" "),
+    inputSchema: getProjectInputSchema,
+    execute: async (input) => {
+      logChatToolIntention("getProject", input.intention);
+      const project = await getManagedProject({
+        namespace: actor.namespace,
+        projectId: input.projectId,
+      });
+      return project === null
+        ? { error: "Project not found in the current namespace.", ok: false }
+        : { ok: true, project };
+    },
+  });
+
+  const previewProjectDeletionTool = tool({
+    description: [
+      "Create a live deletion preview for one Project ID.",
+      "Use only after getProject. The output names every managed resource that deletion would remove and is valid for 10 minutes.",
+      "Show the Project display name and complete resource summary to the user before calling deleteProject.",
+    ].join(" "),
+    inputSchema: previewProjectDeletionInputSchema,
+    execute: async (input) => {
+      logChatToolIntention("previewProjectDeletion", input.intention);
+      const preview = await previewManagedProjectDeletion(
+        actor,
+        input.projectId
+      );
+      return preview === null
+        ? { error: "Project not found in the current namespace.", ok: false }
+        : { ok: true, preview };
+    },
+  });
+
+  const deleteProjectTool = tool({
+    description: [
+      "Delete exactly the Project represented by a current deletion preview.",
+      "Call only after previewProjectDeletion and after the user has requested deletion of that exact Project.",
+      "Copy previewId, projectId, projectDisplayName, and resourceSummary verbatim from the preview output.",
+      "Execution requires a final browser approval and rechecks the Project and resource summary before any deletion.",
+    ].join(" "),
+    inputSchema: deleteProjectInputSchema,
+    needsApproval: true,
+    execute: async (input) => {
+      logChatToolIntention("deleteProject", input.intention);
+      const result = await deleteManagedProject({
+        actor,
+        expectedDisplayName: input.projectDisplayName,
+        expectedResourceSummary:
+          input.resourceSummary as unknown as ProjectChildResourceSummary,
+        previewId: input.previewId,
+        projectId: input.projectId,
+      });
+      if (!result.ok) {
+        return result;
+      }
+      return {
+        ...result,
+        refreshRequired: true,
+      };
+    },
+  });
+
+  return {
+    deleteProject: deleteProjectTool,
+    getProject: getProjectTool,
+    listProjects: listProjectsTool,
+    previewProjectDeletion: previewProjectDeletionTool,
+  };
+}

--- a/apps/ui/src/lib/project-persistence/db.ts
+++ b/apps/ui/src/lib/project-persistence/db.ts
@@ -6,11 +6,17 @@ import { getAppPostgresPool } from "@/lib/app-postgres/db";
 
 import {
   projectCanvasLayouts,
+  projectDeleteOperations,
+  projectDeletePreviews,
+  projectManagementAuditEvents,
   projectNavigationPreferences,
   projects,
 } from "./schema";
 
 const projectSchema = {
+  projectDeleteOperations,
+  projectDeletePreviews,
+  projectManagementAuditEvents,
   projectCanvasLayouts,
   projectNavigationPreferences,
   projects,

--- a/apps/ui/src/lib/project-persistence/delete-guard.test.ts
+++ b/apps/ui/src/lib/project-persistence/delete-guard.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import {
   assertProjectHasNoManagedResources,
   deleteProjectManagedResources,
+  inspectProjectManagedResources,
   ProjectDeleteBlockedError,
   type ProjectDeleteFetch,
   ProjectManagedResourceCleanupError,
@@ -128,6 +129,31 @@ test("project delete guard allows deletion when no managed resources exist", asy
     id: "project-a",
     namespace: "ns-a",
   });
+});
+
+test("project deletion inspection returns the complete scope without deleting", async () => {
+  const calls: string[] = [];
+  const summary = await inspectProjectManagedResources({
+    apiBaseUrl: "https://brain.test",
+    encodedKubeconfig: "kubeconfig",
+    fetchImpl: (url, init) => {
+      calls.push(`${init?.method ?? "GET"} ${String(url)}`);
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ items: managedResourceItems(new URL(String(url))) }),
+          { status: 200 }
+        )
+      );
+    },
+    id: "project-a",
+    namespace: "ns-a",
+  });
+
+  assert.equal(calls.length, 16);
+  assert.ok(calls.every((call) => call.startsWith("GET ")));
+  assert.deepEqual(summary.ap, ["api"]);
+  assert.deepEqual(summary.db, ["postgres"]);
+  assert.deepEqual(summary.template, ["template-memos"]);
 });
 
 test("project delete guard does not double encode kubeconfig authorization", async () => {

--- a/apps/ui/src/lib/project-persistence/delete-guard.ts
+++ b/apps/ui/src/lib/project-persistence/delete-guard.ts
@@ -340,70 +340,14 @@ function directDbProjectLabelSelector(projectId: string): string {
 export async function assertProjectHasNoManagedResources(
   input: ProjectDeleteGuardInput
 ): Promise<void> {
-  const templateSelector = templateProjectLabelSelector(input.id);
-  const [
-    ap,
-    db,
-    template,
-    templateCertificates,
-    templateClusters,
-    templateConfigMaps,
-    templateDeployments,
-    templateIngresses,
-    templateIssuers,
-    templateJobs,
-    templateOpsRequests,
-    templatePods,
-    templatePersistentVolumeClaims,
-    templateSecrets,
-    templateServices,
-    templateStatefulSets,
-  ] = await Promise.all([
-    listProjectResources(input, API_ROUTES.ap.root, {
-      "label-selector": directApProjectLabelSelector(input.id),
-    }),
-    listProjectResources(input, API_ROUTES.db.root, {
-      "label-selector": directDbProjectLabelSelector(input.id),
-    }),
-    listProjectK8sResources(input, "instances", templateSelector),
-    listProjectK8sResources(input, "certificates", templateSelector),
-    listProjectK8sResources(input, "clusters", templateSelector),
-    listProjectK8sResources(input, "configmaps", templateSelector),
-    listProjectK8sResources(input, "deployments", templateSelector),
-    listProjectK8sResources(input, "ingresses", templateSelector),
-    listProjectK8sResources(input, "issuers", templateSelector),
-    listProjectK8sResources(input, "jobs", templateSelector),
-    listProjectK8sResources(input, "opsrequests", templateSelector),
-    listProjectK8sResources(input, "pods", templateSelector),
-    listProjectK8sResources(input, "persistentvolumeclaims", templateSelector),
-    listProjectK8sResources(input, "secrets", templateSelector),
-    listProjectK8sResources(input, "services", templateSelector),
-    listProjectK8sResources(input, "statefulsets", templateSelector),
-  ]);
-  const resources = {
-    ap,
-    db,
-    template,
-    templateCertificates,
-    templateClusters,
-    templateConfigMaps,
-    templateDeployments,
-    templateIngresses,
-    templateIssuers,
-    templateJobs,
-    templateOpsRequests,
-    templatePods,
-    templatePersistentVolumeClaims,
-    templateSecrets,
-    templateServices,
-    templateStatefulSets,
-  };
+  const resources = await inspectProjectManagedResources(input);
   if (Object.values(resources).some((items) => items.length > 0)) {
     throw new ProjectDeleteBlockedError(resources);
   }
 }
 
-export async function deleteProjectManagedResources(
+/** Read the complete managed-resource scope before displaying or deleting it. */
+export async function inspectProjectManagedResources(
   input: ProjectDeleteGuardInput
 ): Promise<ProjectChildResourceSummary> {
   const templateSelector = templateProjectLabelSelector(input.id);
@@ -446,13 +390,38 @@ export async function deleteProjectManagedResources(
     listProjectK8sResources(input, "services", templateSelector),
     listProjectK8sResources(input, "statefulsets", templateSelector),
   ]);
-  for (const name of db) {
+  return {
+    ap,
+    db,
+    template,
+    templateCertificates,
+    templateClusters,
+    templateConfigMaps,
+    templateDeployments,
+    templateIngresses,
+    templateIssuers,
+    templateJobs,
+    templateOpsRequests,
+    templatePods,
+    templatePersistentVolumeClaims,
+    templateSecrets,
+    templateServices,
+    templateStatefulSets,
+  };
+}
+
+export async function deleteProjectManagedResources(
+  input: ProjectDeleteGuardInput
+): Promise<ProjectChildResourceSummary> {
+  const resources = await inspectProjectManagedResources(input);
+  const templateSelector = templateProjectLabelSelector(input.id);
+  for (const name of resources.db) {
     await deleteProjectResource(input, API_ROUTES.db.root, name);
   }
-  for (const name of ap) {
+  for (const name of resources.ap) {
     await deleteProjectResource(input, API_ROUTES.ap.root, name);
   }
-  for (const name of template) {
+  for (const name of resources.template) {
     await deleteProjectK8sResource(input, "instances", name);
   }
   const selectorCleanupKinds = [
@@ -473,22 +442,5 @@ export async function deleteProjectManagedResources(
   for (const kind of selectorCleanupKinds) {
     await deleteProjectK8sResourcesBySelector(input, kind, templateSelector);
   }
-  return {
-    ap,
-    db,
-    template,
-    templateCertificates,
-    templateClusters,
-    templateConfigMaps,
-    templateDeployments,
-    templateIngresses,
-    templateIssuers,
-    templateJobs,
-    templateOpsRequests,
-    templatePods,
-    templatePersistentVolumeClaims,
-    templateSecrets,
-    templateServices,
-    templateStatefulSets,
-  };
+  return resources;
 }

--- a/apps/ui/src/lib/project-persistence/project-management.ts
+++ b/apps/ui/src/lib/project-persistence/project-management.ts
@@ -1,0 +1,466 @@
+import "server-only";
+
+import { createHash, randomUUID } from "node:crypto";
+import { API_ROUTES } from "@workspace/api/constants";
+import { and, eq, gt, isNull, lt } from "drizzle-orm";
+
+import { BRAIN_PROJECT_ID_LABEL } from "@/lib/brain-labels";
+import { kubeconfigBearerHeader } from "@/lib/kubeconfig-header";
+
+import { getProjectDb } from "./db";
+import {
+  deleteProjectManagedResources,
+  inspectProjectManagedResources,
+  type ProjectChildResourceSummary,
+  type ProjectDeleteFetch,
+} from "./delete-guard";
+import {
+  type BrainProject,
+  deleteProject,
+  getProject,
+  listProjects,
+} from "./projects";
+import {
+  projectDeleteOperations,
+  projectDeletePreviews,
+  projectManagementAuditEvents,
+} from "./schema";
+
+const PREVIEW_TTL_MS = 10 * 60 * 1000;
+const OPERATION_TTL_MS = 10 * 60 * 1000;
+
+export type ProjectAggregateStatus =
+  | "negative"
+  | "neutral"
+  | "positive"
+  | "progress"
+  | "unknown"
+  | "warning";
+
+export interface ProjectManagementActor {
+  actorUid: string;
+  chatId: string;
+  encodedKubeconfig: string;
+  namespace: string;
+}
+
+export interface ManagedProject extends BrainProject {
+  aggregateStatus: ProjectAggregateStatus;
+}
+
+export interface ProjectDeletionPreview {
+  expiresAt: string;
+  fingerprint: string;
+  previewId: string;
+  project: BrainProject;
+  resourceSummary: ProjectChildResourceSummary;
+}
+
+export type DeleteManagedProjectResult =
+  | {
+      ok: true;
+      project: BrainProject;
+      resourceSummary: ProjectChildResourceSummary;
+    }
+  | {
+      code: "deletion_in_progress" | "invalid_preview" | "stale_preview";
+      ok: false;
+    };
+
+function sortedSummary(
+  resources: ProjectChildResourceSummary
+): ProjectChildResourceSummary {
+  return Object.fromEntries(
+    Object.entries(resources).map(([key, names]) => [key, [...names].sort()])
+  ) as unknown as ProjectChildResourceSummary;
+}
+
+function summaryFingerprint(resources: ProjectChildResourceSummary): string {
+  return createHash("sha256")
+    .update(JSON.stringify(sortedSummary(resources)))
+    .digest("hex");
+}
+
+function auditEvent(input: {
+  actor: ProjectManagementActor;
+  displayName: string;
+  failureCode?: string;
+  projectId: string;
+  resourceSummary: ProjectChildResourceSummary;
+  status: "completed" | "failed" | "previewed" | "started" | "stale";
+}): Promise<unknown> {
+  return getProjectDb()
+    .insert(projectManagementAuditEvents)
+    .values({
+      action: "delete",
+      actorUid: input.actor.actorUid,
+      chatId: input.actor.chatId,
+      displayName: input.displayName,
+      ...(input.failureCode === undefined
+        ? {}
+        : { failureCode: input.failureCode }),
+      id: randomUUID(),
+      namespace: input.actor.namespace,
+      projectId: input.projectId,
+      resourceSummary: sortedSummary(input.resourceSummary),
+      source: "chat",
+      status: input.status,
+    });
+}
+
+function apiUrl(path: string, params: Record<string, string>): URL | null {
+  const base = process.env.API_URL?.trim() ?? "";
+  if (base === "") {
+    return null;
+  }
+  const url = new URL(path, base);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return url;
+}
+
+function listItems(payload: unknown): unknown[] {
+  if (payload == null || typeof payload !== "object") {
+    return [];
+  }
+  const root = payload as { data?: { items?: unknown }; items?: unknown };
+  if (Array.isArray(root.items)) {
+    return root.items;
+  }
+  return Array.isArray(root.data?.items) ? root.data.items : [];
+}
+
+const TONE_SEVERITY: Record<
+  Exclude<ProjectAggregateStatus, "unknown">,
+  number
+> = {
+  negative: 4,
+  neutral: 0,
+  positive: 1,
+  progress: 2,
+  warning: 3,
+};
+
+function phaseStatus(
+  phase: unknown,
+  paused: boolean
+): Exclude<ProjectAggregateStatus, "unknown"> {
+  if (paused) {
+    return "neutral";
+  }
+  switch (typeof phase === "string" ? phase.trim().toLowerCase() : "") {
+    case "running":
+    case "succeeded":
+    case "ready":
+    case "available":
+    case "bound":
+      return "positive";
+    case "pending":
+    case "creating":
+    case "progressing":
+    case "binding":
+    case "restarting":
+    case "starting":
+    case "stopping":
+    case "updating":
+    case "unknown":
+      return "progress";
+    case "failed":
+    case "error":
+    case "degraded":
+    case "deleting":
+    case "unavailable":
+      return "negative";
+    default:
+      return "neutral";
+  }
+}
+
+async function listProjectStatuses(
+  actor: ProjectManagementActor
+): Promise<ReadonlyMap<string, ProjectAggregateStatus> | null> {
+  const fetchImpl: ProjectDeleteFetch = fetch;
+  const request = async (path: string) => {
+    const url = apiUrl(path, {
+      "label-selector": BRAIN_PROJECT_ID_LABEL,
+      namespace: actor.namespace,
+    });
+    if (url === null) {
+      return null;
+    }
+    const response = await fetchImpl(url, {
+      cache: "no-store",
+      headers: {
+        Authorization: kubeconfigBearerHeader(actor.encodedKubeconfig),
+      },
+    });
+    if (!response.ok) {
+      return null;
+    }
+    return listItems(await response.json());
+  };
+  const [aps, dbs] = await Promise.all([
+    request(API_ROUTES.ap.root),
+    request(API_ROUTES.db.root),
+  ]);
+  if (aps === null && dbs === null) {
+    return null;
+  }
+  const statuses = new Map<
+    string,
+    Exclude<ProjectAggregateStatus, "unknown">
+  >();
+  for (const resource of [...(aps ?? []), ...(dbs ?? [])]) {
+    if (resource == null || typeof resource !== "object") {
+      continue;
+    }
+    const value = resource as {
+      metadata?: { labels?: Record<string, unknown> };
+      spec?: { paused?: unknown };
+      status?: { phase?: unknown };
+    };
+    const projectId = value.metadata?.labels?.[BRAIN_PROJECT_ID_LABEL];
+    if (typeof projectId !== "string" || projectId === "") {
+      continue;
+    }
+    const next = phaseStatus(value.status?.phase, value.spec?.paused === true);
+    const current = statuses.get(projectId);
+    if (current === undefined || TONE_SEVERITY[next] > TONE_SEVERITY[current]) {
+      statuses.set(projectId, next);
+    }
+  }
+  return statuses;
+}
+
+export async function listManagedProjects(
+  actor: ProjectManagementActor
+): Promise<ManagedProject[]> {
+  const [projects, statuses] = await Promise.all([
+    listProjects(actor.namespace),
+    listProjectStatuses(actor).catch(() => null),
+  ]);
+  return projects.map((project) => ({
+    ...project,
+    aggregateStatus: statuses?.get(project.id) ?? "unknown",
+  }));
+}
+
+export function getManagedProject(input: {
+  namespace: string;
+  projectId: string;
+}): Promise<BrainProject | null> {
+  return getProject(input.namespace, input.projectId);
+}
+
+export async function previewManagedProjectDeletion(
+  actor: ProjectManagementActor,
+  projectId: string
+): Promise<ProjectDeletionPreview | null> {
+  const project = await getProject(actor.namespace, projectId);
+  if (project === null) {
+    return null;
+  }
+  const resourceSummary = sortedSummary(
+    await inspectProjectManagedResources({
+      encodedKubeconfig: actor.encodedKubeconfig,
+      id: projectId,
+      namespace: actor.namespace,
+    })
+  );
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + PREVIEW_TTL_MS);
+  const previewId = randomUUID();
+  await getProjectDb()
+    .delete(projectDeletePreviews)
+    .where(lt(projectDeletePreviews.expiresAt, now));
+  await getProjectDb()
+    .insert(projectDeletePreviews)
+    .values({
+      actorUid: actor.actorUid,
+      chatId: actor.chatId,
+      createdAt: now,
+      displayName: project.displayName,
+      expiresAt,
+      fingerprint: summaryFingerprint(resourceSummary),
+      id: previewId,
+      namespace: actor.namespace,
+      projectId,
+      resourceSummary,
+    });
+  await auditEvent({
+    actor,
+    displayName: project.displayName,
+    projectId,
+    resourceSummary,
+    status: "previewed",
+  });
+  return {
+    expiresAt: expiresAt.toISOString(),
+    fingerprint: summaryFingerprint(resourceSummary),
+    previewId,
+    project,
+    resourceSummary,
+  };
+}
+
+async function claimDeletionOperation(input: {
+  actor: ProjectManagementActor;
+  previewId: string;
+  projectId: string;
+}): Promise<boolean> {
+  const now = new Date();
+  await getProjectDb()
+    .delete(projectDeleteOperations)
+    .where(
+      and(
+        eq(projectDeleteOperations.namespace, input.actor.namespace),
+        eq(projectDeleteOperations.projectId, input.projectId),
+        lt(projectDeleteOperations.expiresAt, now)
+      )
+    );
+  const [operation] = await getProjectDb()
+    .insert(projectDeleteOperations)
+    .values({
+      actorUid: input.actor.actorUid,
+      createdAt: now,
+      expiresAt: new Date(now.getTime() + OPERATION_TTL_MS),
+      namespace: input.actor.namespace,
+      previewId: input.previewId,
+      projectId: input.projectId,
+    })
+    .onConflictDoNothing()
+    .returning();
+  return operation !== undefined;
+}
+
+async function releaseDeletionOperation(
+  actor: ProjectManagementActor,
+  projectId: string,
+  previewId: string
+) {
+  await getProjectDb()
+    .delete(projectDeleteOperations)
+    .where(
+      and(
+        eq(projectDeleteOperations.namespace, actor.namespace),
+        eq(projectDeleteOperations.projectId, projectId),
+        eq(projectDeleteOperations.actorUid, actor.actorUid),
+        eq(projectDeleteOperations.previewId, previewId)
+      )
+    );
+}
+
+export async function deleteManagedProject(input: {
+  actor: ProjectManagementActor;
+  expectedDisplayName: string;
+  expectedResourceSummary: ProjectChildResourceSummary;
+  previewId: string;
+  projectId: string;
+}): Promise<DeleteManagedProjectResult> {
+  const now = new Date();
+  const [preview] = await getProjectDb()
+    .update(projectDeletePreviews)
+    .set({ consumedAt: now })
+    .where(
+      and(
+        eq(projectDeletePreviews.id, input.previewId),
+        eq(projectDeletePreviews.actorUid, input.actor.actorUid),
+        eq(projectDeletePreviews.chatId, input.actor.chatId),
+        eq(projectDeletePreviews.namespace, input.actor.namespace),
+        eq(projectDeletePreviews.projectId, input.projectId),
+        gt(projectDeletePreviews.expiresAt, now),
+        isNull(projectDeletePreviews.consumedAt)
+      )
+    )
+    .returning();
+  if (preview === undefined) {
+    return { code: "invalid_preview", ok: false };
+  }
+  if (
+    preview.displayName !== input.expectedDisplayName ||
+    preview.fingerprint !== summaryFingerprint(input.expectedResourceSummary)
+  ) {
+    return { code: "invalid_preview", ok: false };
+  }
+  const project = await getProject(input.actor.namespace, input.projectId);
+  if (project === null) {
+    await auditEvent({
+      actor: input.actor,
+      displayName: preview.displayName,
+      failureCode: "project_not_found",
+      projectId: input.projectId,
+      resourceSummary: preview.resourceSummary,
+      status: "stale",
+    });
+    return { code: "stale_preview", ok: false };
+  }
+  const currentSummary = sortedSummary(
+    await inspectProjectManagedResources({
+      encodedKubeconfig: input.actor.encodedKubeconfig,
+      id: input.projectId,
+      namespace: input.actor.namespace,
+    })
+  );
+  if (
+    project.displayName !== preview.displayName ||
+    summaryFingerprint(currentSummary) !== preview.fingerprint
+  ) {
+    await auditEvent({
+      actor: input.actor,
+      displayName: project.displayName,
+      failureCode: "preview_stale",
+      projectId: input.projectId,
+      resourceSummary: currentSummary,
+      status: "stale",
+    });
+    return { code: "stale_preview", ok: false };
+  }
+  if (!(await claimDeletionOperation(input))) {
+    return { code: "deletion_in_progress", ok: false };
+  }
+  await auditEvent({
+    actor: input.actor,
+    displayName: project.displayName,
+    projectId: input.projectId,
+    resourceSummary: currentSummary,
+    status: "started",
+  });
+  try {
+    const deletedSummary = await deleteProjectManagedResources({
+      encodedKubeconfig: input.actor.encodedKubeconfig,
+      id: input.projectId,
+      namespace: input.actor.namespace,
+    });
+    await deleteProject({
+      id: input.projectId,
+      namespace: input.actor.namespace,
+    });
+    await auditEvent({
+      actor: input.actor,
+      displayName: project.displayName,
+      projectId: input.projectId,
+      resourceSummary: deletedSummary,
+      status: "completed",
+    });
+    return { ok: true, project, resourceSummary: deletedSummary };
+  } catch {
+    await auditEvent({
+      actor: input.actor,
+      displayName: project.displayName,
+      failureCode: "cleanup_failed",
+      projectId: input.projectId,
+      resourceSummary: currentSummary,
+      status: "failed",
+    });
+    throw new Error(
+      "Project cleanup failed. Re-preview the Project and retry."
+    );
+  } finally {
+    await releaseDeletionOperation(
+      input.actor,
+      input.projectId,
+      input.previewId
+    );
+  }
+}

--- a/apps/ui/src/lib/project-persistence/projects.ts
+++ b/apps/ui/src/lib/project-persistence/projects.ts
@@ -10,7 +10,12 @@ import {
 } from "@/features/projects/derived-project-display-name";
 
 import { getProjectDb } from "./db";
-import { type ProjectRow, projects } from "./schema";
+import {
+  type ProjectRow,
+  projectCanvasLayouts,
+  projectNavigationPreferences,
+  projects,
+} from "./schema";
 
 /** Bounded so a crowded namespace ends on a fallback name instead of spinning. */
 const DISPLAY_NAME_SUFFIX_ATTEMPTS = 20;
@@ -266,11 +271,37 @@ export async function updateProject(
 }
 
 export async function deleteProject(input: DeleteProjectInput): Promise<void> {
-  const [row] = await getProjectDb()
-    .delete(projects)
-    .where(whereProject(input.namespace, input.id))
-    .returning();
-  if (row === undefined) {
-    throw new ProjectPersistenceError("not_found", "Project not found.");
-  }
+  await getProjectDb().transaction(async (tx) => {
+    const [row] = await tx
+      .delete(projects)
+      .where(whereProject(input.namespace, input.id))
+      .returning();
+    if (row === undefined) {
+      throw new ProjectPersistenceError("not_found", "Project not found.");
+    }
+    await tx
+      .delete(projectCanvasLayouts)
+      .where(
+        and(
+          eq(projectCanvasLayouts.namespace, input.namespace),
+          eq(projectCanvasLayouts.projectId, input.id)
+        )
+      );
+    const [preferences] = await tx
+      .select()
+      .from(projectNavigationPreferences)
+      .where(eq(projectNavigationPreferences.namespace, input.namespace))
+      .limit(1);
+    if (preferences !== undefined) {
+      await tx
+        .update(projectNavigationPreferences)
+        .set({
+          pinnedProjectIds: preferences.pinnedProjectIds.filter(
+            (projectId) => projectId !== input.id
+          ),
+          updatedAt: new Date(),
+        })
+        .where(eq(projectNavigationPreferences.namespace, input.namespace));
+    }
+  });
 }

--- a/apps/ui/src/lib/project-persistence/schema.ts
+++ b/apps/ui/src/lib/project-persistence/schema.ts
@@ -12,6 +12,7 @@ import {
 
 import type { CanvasLayoutNode } from "@/features/project-canvas/layout/types";
 
+import type { ProjectChildResourceSummary } from "./delete-guard";
 import { PROJECT_DB_SCHEMA } from "./types";
 
 export const ns = pgSchema(PROJECT_DB_SCHEMA);
@@ -101,6 +102,101 @@ export const projectNavigationPreferences = ns.table(
   ]
 );
 
+/** One-time, actor-bound evidence for an Agent-requested Project deletion. */
+export const projectDeletePreviews = ns.table(
+  "project_delete_previews",
+  {
+    id: text("id").notNull(),
+    actorUid: text("actor_uid").notNull(),
+    chatId: text("chat_id").notNull(),
+    namespace: text("namespace").notNull(),
+    projectId: text("project_id").notNull(),
+    displayName: text("display_name").notNull(),
+    resourceSummary: jsonb("resource_summary")
+      .notNull()
+      .$type<ProjectChildResourceSummary>(),
+    fingerprint: text("fingerprint").notNull(),
+    expiresAt: timestamp("expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
+    consumedAt: timestamp("consumed_at", { mode: "date", withTimezone: true }),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.id],
+      name: "project_delete_previews_pk",
+    }),
+    index("project_delete_previews_expires_at_idx").on(table.expiresAt),
+    index("project_delete_previews_target_idx").on(
+      table.namespace,
+      table.projectId
+    ),
+  ]
+);
+
+/** Short-lived mutual exclusion for external Project resource cleanup. */
+export const projectDeleteOperations = ns.table(
+  "project_delete_operations",
+  {
+    namespace: text("namespace").notNull(),
+    projectId: text("project_id").notNull(),
+    actorUid: text("actor_uid").notNull(),
+    previewId: text("preview_id").notNull(),
+    expiresAt: timestamp("expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.namespace, table.projectId],
+      name: "project_delete_operations_pk",
+    }),
+    index("project_delete_operations_expires_at_idx").on(table.expiresAt),
+  ]
+);
+
+/** Durable Agent Project-management audit trail; deliberately independent of Project deletion. */
+export const projectManagementAuditEvents = ns.table(
+  "project_management_audit_events",
+  {
+    id: text("id").notNull(),
+    action: text("action").notNull(),
+    status: text("status").notNull(),
+    source: text("source").notNull(),
+    actorUid: text("actor_uid").notNull(),
+    chatId: text("chat_id").notNull(),
+    namespace: text("namespace").notNull(),
+    projectId: text("project_id").notNull(),
+    displayName: text("display_name").notNull(),
+    resourceSummary: jsonb("resource_summary")
+      .notNull()
+      .$type<ProjectChildResourceSummary>(),
+    failureCode: text("failure_code"),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.id],
+      name: "project_management_audit_events_pk",
+    }),
+    index("project_management_audit_events_target_idx").on(
+      table.namespace,
+      table.projectId,
+      table.createdAt
+    ),
+  ]
+);
+
 // `sealai_project.ap_image_versions` is intentionally NOT declared here: the Go
 // API owns that table end-to-end (DDL + retention pruning) in
 // `apps/api/service/apversion/store.go`; the UI only reads it over HTTP.
@@ -109,3 +205,4 @@ export type ProjectRow = typeof projects.$inferSelect;
 export type ProjectCanvasLayoutRow = typeof projectCanvasLayouts.$inferSelect;
 export type ProjectNavigationPreferencesRow =
   typeof projectNavigationPreferences.$inferSelect;
+export type ProjectDeletePreviewRow = typeof projectDeletePreviews.$inferSelect;


### PR DESCRIPTION
## Summary
- add AI chat tools to list, inspect, preview, and delete projects
- protect deletions with expiring actor- and chat-bound previews, approval UI, and display-name confirmation
- persist deletion operations and audit events, and clean related layout and pinned-project state

## Validation
- bun test src/lib/project-persistence/delete-guard.test.ts src/features/chat/tool/chat-project-tools.test.ts src/features/chat/chat.tool-group.test.ts src/app/api/chat/route.test.ts
- bun typecheck
- bun check