### PR TITLE
feat(settings): restyle elastic scaling controls to match design

### DIFF
--- a/apps/ui/src/features/resource-settings/ap/ap-replica-strategy-section.tsx
+++ b/apps/ui/src/features/resource-settings/ap/ap-replica-strategy-section.tsx
@@ -81,8 +81,8 @@ const SCALING_TARGET_TOGGLE_OPTIONS = [
   {
     ariaLabel: "CPU utilization target",
     label: (
-      <span className="inline-flex items-center gap-1.5">
-        <Cpu aria-hidden className="size-3.5" />
+      <span className="inline-flex items-center gap-2">
+        <Cpu aria-hidden className="size-4" />
         Target CPU
       </span>
     ),
@@ -91,8 +91,8 @@ const SCALING_TARGET_TOGGLE_OPTIONS = [
   {
     ariaLabel: "Memory average target",
     label: (
-      <span className="inline-flex items-center gap-1.5">
-        <MemoryStick aria-hidden className="size-3.5" />
+      <span className="inline-flex items-center gap-2">
+        <MemoryStick aria-hidden className="size-4" />
         Target Memory
       </span>
     ),
@@ -533,7 +533,6 @@ function ScalingTargetSlider({
   memoryTargetMib,
   onCpuTargetChange,
   onMemoryTargetChange,
-  onTargetMetricChange,
   targetMetric,
 }: {
   cpuTargetPercent: number;
@@ -541,7 +540,6 @@ function ScalingTargetSlider({
   memoryTargetMib: number;
   onCpuTargetChange: (value: number) => void;
   onMemoryTargetChange: (value: number) => void;
-  onTargetMetricChange: (metric: ElasticTargetMetric) => void;
   targetMetric: ElasticTargetMetric;
 }) {
   const config =
@@ -550,6 +548,7 @@ function ScalingTargetSlider({
           ariaLabel: "Memory average target",
           displayValue: memoryMibDisplayValue(memoryTargetMib),
           format: formatMemoryMibValue,
+          label: "Target Memory",
           max: MEMORY_AVERAGE_TARGET_LIMITS.max,
           maxDecimals: 2,
           min: MEMORY_AVERAGE_TARGET_LIMITS.min,
@@ -561,6 +560,7 @@ function ScalingTargetSlider({
           ariaLabel: "CPU utilization target",
           displayValue: cpuTargetPercent,
           format: (next: number) => `${formatPlainNumber(next, 0)}%`,
+          label: "Target CPU",
           max: CPU_UTILIZATION_TARGET_LIMITS.max,
           maxDecimals: 0,
           min: CPU_UTILIZATION_TARGET_LIMITS.min,
@@ -571,10 +571,12 @@ function ScalingTargetSlider({
 
   return (
     <ResourceSettingsInset>
-      <SettingsSlider.Root
+      <SettingsSlider
+        ariaLabel={config.ariaLabel}
         disabled={disabled}
         displayValue={config.displayValue}
         formatBound={config.format}
+        label={config.label}
         max={config.max}
         maxDecimals={config.maxDecimals}
         min={config.min}
@@ -582,29 +584,7 @@ function ScalingTargetSlider({
         step={1}
         value={config.value}
         valueSuffix={config.valueSuffix}
-      >
-        <SettingsSlider.Stack>
-          <SettingsSlider.Header>
-            <SlidingToggle
-              ariaLabel="Scaling target"
-              disabled={disabled}
-              onValueChange={onTargetMetricChange}
-              options={SCALING_TARGET_TOGGLE_OPTIONS}
-              size="sm"
-              value={targetMetric}
-              width="auto"
-            />
-            <SettingsSlider.Value />
-          </SettingsSlider.Header>
-          <SettingsSlider.Control aria-label={config.ariaLabel}>
-            <SettingsSlider.Track>
-              <SettingsSlider.Range />
-            </SettingsSlider.Track>
-            <SettingsSlider.Thumb />
-          </SettingsSlider.Control>
-          <SettingsSlider.Bounds />
-        </SettingsSlider.Stack>
-      </SettingsSlider.Root>
+      />
     </ResourceSettingsInset>
   );
 }
@@ -708,13 +688,21 @@ export function ReplicaStrategyContent({
             />
           </ResourceSettingsInset>
 
+          <SlidingToggle
+            ariaLabel="Scaling target"
+            disabled={readOnly}
+            indicatorClassName="dark:bg-input/30"
+            onValueChange={onElasticTargetMetricChange}
+            options={SCALING_TARGET_TOGGLE_OPTIONS}
+            value={targetMetric}
+          />
+
           <ScalingTargetSlider
             cpuTargetPercent={cpuTargetPercent}
             disabled={readOnly}
             memoryTargetMib={memoryTargetMib}
             onCpuTargetChange={onElasticCpuTargetChange}
             onMemoryTargetChange={onElasticMemoryTargetChange}
-            onTargetMetricChange={onElasticTargetMetricChange}
             targetMetric={targetMetric}
           />
         </div>

--- a/packages/ui/src/components/sliding-toggle.tsx
+++ b/packages/ui/src/components/sliding-toggle.tsx
@@ -115,7 +115,7 @@ export function SlidingToggle<TValue extends string = string>({
         <ToggleGroupItem
           aria-label={option.ariaLabel}
           className={cn(
-            "relative z-10 min-w-0 cursor-pointer border-0 bg-transparent hover:bg-transparent aria-pressed:bg-transparent data-[state=on]:bg-transparent",
+            "relative z-10 min-w-0 cursor-pointer border-0 bg-transparent font-normal hover:bg-transparent aria-pressed:bg-transparent aria-pressed:font-medium data-[state=on]:bg-transparent [&[aria-pressed=true]_svg]:text-blue-400",
             sizeClasses.item,
             itemClassName
           )}


### PR DESCRIPTION
## Summary

Implements the updated Figma design for the Elastic Scaling section of AP settings (edit mode, styles/layout only — no behavior changes):

- Lift the Target CPU / Target Memory toggle out of the target slider card into a standalone full-width control between the Maximum Replicas card and the target card.
- The target card becomes a regular labeled slider card ("Target CPU" / "Target Memory" following the selected metric), matching the min/max replica cards.
- The metric toggle uses a subtler `input/30` selected indicator (scoped override; the shared default is unchanged).
- Shared `SlidingToggle`: selected options now render medium-weight text and a `blue-400` icon; unselected options fall back to regular weight.

Replica limits, defaults, normalization, commit flow, read-only rows, and the fixed-replicas branch are untouched.

## Test plan

- `bun typecheck`, `bun check` pass.
- `apps/ui` `ap-settings-sections.test.tsx`: 53 pass; the 1 failure ("Launchpad-backed command config and storage fields") pre-exists on `main` (verified against a clean tree).
- Verified live in dev: selected toggle option renders weight 500 + blue-400 icon; unselected 400 + white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)