### PR TITLE
feat(ui): move deployment task dock into the top bar and fold by width

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -532,6 +532,8 @@ A Project Canvas affordance that presents the current Project's visible Deployme
 
 A dock chip carries no inline lifecycle actions: it shows a source summary and status, opens the Deployment Task Timeline pane on click, and — for terminal tasks only — offers a dismiss control. Cancel and Redeploy are performed in the Deployment Task Timeline pane the chip opens, not on the chip itself.
 
+The dock shows as many of the highest-priority tasks as fit the space available to it — never a fixed count — and keeps the remainder reachable behind a single overflow control. Visible chips stay readable rather than shrinking without bound; a chip that cannot stay readable folds into the overflow, and on the narrowest surfaces the dock may degrade to the overflow control alone. The open pane's task gets no special claim on a visible chip.
+
 _Avoid_: canvas task list, deployment history list, task center, chat task status.
 
 ### Deployment Task Dock Dismissal

--- a/apps/ui/src/features/project-canvas/workbench/deployment-task-timeline-reentry-affordance.test.tsx
+++ b/apps/ui/src/features/project-canvas/workbench/deployment-task-timeline-reentry-affordance.test.tsx
@@ -3,10 +3,16 @@ import { test } from "node:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type { DeploymentTaskProjection } from "@/features/deploy/task/projection";
-import type { DeploymentTaskDockModel } from "./deployment-task-timeline-reentry";
-import { ProjectCanvasDeploymentTaskDock } from "./deployment-task-timeline-reentry-affordance";
+import type { DeploymentTaskDockItem } from "./deployment-task-timeline-reentry";
+import {
+  DeploymentTaskDockOverflowList,
+  DeploymentTaskDockRow,
+  ProjectCanvasDeploymentTaskDock,
+} from "./deployment-task-timeline-reentry-affordance";
 
 const DOCK_SLOT_RE = /data-slot="deployment-task-dock"/;
+const ROW_SLOT_RE = /data-slot="deployment-task-dock-row"/;
+const TASK_SLOT_GLOBAL_RE = /data-slot="deployment-task-dock-task"/g;
 const OPEN_BUTTON_RE = /Open timeline/;
 const DISMISS_LABEL_RE = /Dismiss deployment task reminder/;
 const DISMISS_LABEL_GLOBAL_RE = /Dismiss deployment task reminder/g;
@@ -14,10 +20,11 @@ const CANCEL_ACTION_RE = /Cancel deployment/;
 const REDEPLOY_ACTION_RE = /Redeploy/;
 const SOURCE_RE = /nginx:latest/;
 const RESULT_RE = /AP api/;
-const DESKTOP_MORE_RE = /\+1/;
-const DESKTOP_MORE_LABEL_RE = /Show 1 more deployment tasks/;
-const EXPANDED_LIST_SLOT_RE = /data-slot="deployment-task-dock-list"/;
-const EXPANDED_LIST_HEADING_RE = />Deployment tasks</;
+const MORE_RE = /\+1/;
+const MORE_ALL_FOLDED_RE = /\+4/;
+const MORE_LABEL_RE = /Show 1 more deployment tasks/;
+const LIST_SLOT_RE = /data-slot="deployment-task-dock-list"/;
+const LIST_HEADING_RE = />Deployment tasks</;
 
 function task(overrides: Partial<DeploymentTaskProjection>) {
   return {
@@ -43,111 +50,95 @@ function countMatches(html: string, pattern: RegExp): number {
   return html.match(pattern)?.length ?? 0;
 }
 
-const dock: DeploymentTaskDockModel = {
-  desktopHiddenCount: 1,
-  desktopTasks: [
-    { active: true, task: task({ id: "task-active", status: "applying" }) },
-    { active: false, task: task({ id: "task-blocked", status: "blocked" }) },
-    { active: false, task: task({ id: "task-failed", status: "failed" }) },
-  ],
-  mobileHiddenCount: 3,
-  mobileTasks: [
-    { active: true, task: task({ id: "task-active", status: "applying" }) },
-  ],
-  tasks: [
-    { active: true, task: task({ id: "task-active", status: "applying" }) },
-    { active: false, task: task({ id: "task-blocked", status: "blocked" }) },
-    { active: false, task: task({ id: "task-failed", status: "failed" }) },
-    { active: false, task: task({ id: "task-queued", status: "queued" }) },
-  ],
-};
+const items: DeploymentTaskDockItem[] = [
+  { active: true, task: task({ id: "task-active", status: "applying" }) },
+  { active: false, task: task({ id: "task-blocked", status: "blocked" }) },
+  { active: false, task: task({ id: "task-failed", status: "failed" }) },
+  { active: false, task: task({ id: "task-queued", status: "queued" }) },
+];
 
-test("deployment task dock renders tasks as direct timeline entries", () => {
+test("deployment task dock row renders visible chips and folds the rest", () => {
   const html = renderToStaticMarkup(
-    <ProjectCanvasDeploymentTaskDock
-      dock={dock}
+    <DeploymentTaskDockRow
+      items={items}
       onDismiss={() => undefined}
       onOpen={() => undefined}
+      visibleCount={3}
     />
   );
 
-  assert.match(html, DOCK_SLOT_RE);
+  assert.match(html, ROW_SLOT_RE);
   assert.match(html, SOURCE_RE);
   assert.match(html, RESULT_RE);
-  assert.match(html, DISMISS_LABEL_RE);
-  assert.match(html, DESKTOP_MORE_RE);
-  assert.match(html, DESKTOP_MORE_LABEL_RE);
+  assert.equal(countMatches(html, TASK_SLOT_GLOBAL_RE), 3);
+  assert.match(html, MORE_RE);
+  assert.match(html, MORE_LABEL_RE);
   assert.doesNotMatch(html, OPEN_BUTTON_RE);
-  assert.doesNotMatch(html, EXPANDED_LIST_SLOT_RE);
-  assert.doesNotMatch(html, EXPANDED_LIST_HEADING_RE);
+  assert.doesNotMatch(html, LIST_SLOT_RE);
+  assert.doesNotMatch(html, LIST_HEADING_RE);
   // Only the terminal (failed) task is dismissible; the in-progress
-  // applying/blocked/queued chips render no ✕ (ADR 0038).
+  // applying/blocked chips render no ✕ (ADR 0038).
   assert.equal(countMatches(html, DISMISS_LABEL_GLOBAL_RE), 1);
 });
 
-test("deployment task dock shows no dismiss for in-progress tasks", () => {
-  const inProgress: DeploymentTaskDockModel = {
-    desktopHiddenCount: 0,
-    desktopTasks: [
-      { active: true, task: task({ id: "task-active", status: "applying" }) },
-      { active: false, task: task({ id: "task-blocked", status: "blocked" }) },
-    ],
-    mobileHiddenCount: 1,
-    mobileTasks: [
-      { active: true, task: task({ id: "task-active", status: "applying" }) },
-    ],
-    tasks: [
-      { active: true, task: task({ id: "task-active", status: "applying" }) },
-      { active: false, task: task({ id: "task-blocked", status: "blocked" }) },
-    ],
-  };
+test("deployment task dock row degrades to the overflow trigger alone", () => {
   const html = renderToStaticMarkup(
-    <ProjectCanvasDeploymentTaskDock
-      dock={inProgress}
+    <DeploymentTaskDockRow
+      items={items}
       onDismiss={() => undefined}
       onOpen={() => undefined}
+      visibleCount={0}
     />
   );
 
-  assert.match(html, DOCK_SLOT_RE);
+  assert.equal(countMatches(html, TASK_SLOT_GLOBAL_RE), 0);
+  assert.match(html, MORE_ALL_FOLDED_RE);
+});
+
+test("deployment task dock row shows no dismiss for in-progress tasks", () => {
+  const inProgress: DeploymentTaskDockItem[] = [
+    { active: true, task: task({ id: "task-active", status: "applying" }) },
+    { active: false, task: task({ id: "task-blocked", status: "blocked" }) },
+  ];
+  const html = renderToStaticMarkup(
+    <DeploymentTaskDockRow
+      items={inProgress}
+      onDismiss={() => undefined}
+      onOpen={() => undefined}
+      visibleCount={2}
+    />
+  );
+
+  assert.match(html, ROW_SLOT_RE);
   assert.doesNotMatch(html, DISMISS_LABEL_RE);
 });
 
-test("deployment task dock keeps the dismiss control on the active terminal chip", () => {
-  const activeFailed: DeploymentTaskDockModel = {
-    desktopHiddenCount: 0,
-    desktopTasks: [
-      { active: true, task: task({ id: "task-failed", status: "failed" }) },
-    ],
-    mobileHiddenCount: 0,
-    mobileTasks: [
-      { active: true, task: task({ id: "task-failed", status: "failed" }) },
-    ],
-    tasks: [
-      { active: true, task: task({ id: "task-failed", status: "failed" }) },
-    ],
-  };
+test("deployment task dock row keeps the dismiss control on the active terminal chip", () => {
+  const activeFailed: DeploymentTaskDockItem[] = [
+    { active: true, task: task({ id: "task-failed", status: "failed" }) },
+  ];
   const html = renderToStaticMarkup(
-    <ProjectCanvasDeploymentTaskDock
-      dock={activeFailed}
+    <DeploymentTaskDockRow
+      items={activeFailed}
       onDismiss={() => undefined}
       onOpen={() => undefined}
+      visibleCount={1}
     />
   );
 
   // Dismissing the open pane's chip records the dismissal and closes the
   // pane, so the control must stay available while the pane is open
-  // (CONTEXT.md: Deployment Task Dock Dismissal). Desktop + mobile trees
-  // both render, hence two matches.
-  assert.equal(countMatches(html, DISMISS_LABEL_GLOBAL_RE), 2);
+  // (CONTEXT.md: Deployment Task Dock Dismissal).
+  assert.equal(countMatches(html, DISMISS_LABEL_GLOBAL_RE), 1);
 });
 
-test("deployment task dock never renders cancel or redeploy actions", () => {
+test("deployment task dock row never renders cancel or redeploy actions", () => {
   const html = renderToStaticMarkup(
-    <ProjectCanvasDeploymentTaskDock
-      dock={dock}
+    <DeploymentTaskDockRow
+      items={items}
       onDismiss={() => undefined}
       onOpen={() => undefined}
+      visibleCount={3}
     />
   );
 
@@ -155,20 +146,49 @@ test("deployment task dock never renders cancel or redeploy actions", () => {
   assert.doesNotMatch(html, REDEPLOY_ACTION_RE);
 });
 
+test("dock overflow panel lists every task with dock chip semantics", () => {
+  const html = renderToStaticMarkup(
+    <DeploymentTaskDockOverflowList
+      onDismiss={() => undefined}
+      onOpen={() => undefined}
+      tasks={items}
+    />
+  );
+
+  assert.match(html, LIST_SLOT_RE);
+  assert.match(html, LIST_HEADING_RE);
+  // The panel is the full task list, not just the hidden tail.
+  assert.equal(countMatches(html, TASK_SLOT_GLOBAL_RE), items.length);
+  // Chip rules carry over: dismiss only on the terminal (failed) row,
+  // never cancel or redeploy (ADR 0038).
+  assert.equal(countMatches(html, DISMISS_LABEL_GLOBAL_RE), 1);
+  assert.doesNotMatch(html, CANCEL_ACTION_RE);
+  assert.doesNotMatch(html, REDEPLOY_ACTION_RE);
+});
+
 test("deployment task dock is absent without tasks", () => {
   const html = renderToStaticMarkup(
     <ProjectCanvasDeploymentTaskDock
-      dock={{
-        desktopHiddenCount: 0,
-        desktopTasks: [],
-        mobileHiddenCount: 0,
-        mobileTasks: [],
-        tasks: [],
-      }}
+      dock={{ tasks: [] }}
       onDismiss={() => undefined}
       onOpen={() => undefined}
     />
   );
 
   assert.equal(html, "");
+});
+
+test("deployment task dock renders only the measuring host before layout", () => {
+  const html = renderToStaticMarkup(
+    <ProjectCanvasDeploymentTaskDock
+      dock={{ tasks: items }}
+      onDismiss={() => undefined}
+      onOpen={() => undefined}
+    />
+  );
+
+  // The visible count needs a real measured width; server markup carries
+  // just the host so hydration never paints an unfitted row.
+  assert.match(html, DOCK_SLOT_RE);
+  assert.doesNotMatch(html, ROW_SLOT_RE);
 });

--- a/apps/ui/src/features/project-canvas/workbench/deployment-task-timeline-reentry-affordance.tsx
+++ b/apps/ui/src/features/project-canvas/workbench/deployment-task-timeline-reentry-affordance.tsx
@@ -3,6 +3,11 @@
 import { ProjectSourceDockerIcon } from "@workspace/ui/assets/project-source-icons";
 import { AppIconButton } from "@workspace/ui/components/app-icon-button";
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@workspace/ui/components/popover";
+import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -16,7 +21,7 @@ import {
   MessageSquareText,
   X,
 } from "lucide-react";
-import { Fragment, useState } from "react";
+import { Fragment, useLayoutEffect, useRef, useState } from "react";
 import {
   type DeploymentTaskDisplaySummary,
   type DeploymentTaskProjection,
@@ -27,9 +32,10 @@ import {
   deployTaskStatusDotClass,
   deployTaskStatusLabel,
 } from "@/features/deploy/task/status-presentation";
-import type {
-  DeploymentTaskDockItem,
-  DeploymentTaskDockModel,
+import {
+  type DeploymentTaskDockItem,
+  type DeploymentTaskDockModel,
+  fitDeploymentTaskDockChipCount,
 } from "./deployment-task-timeline-reentry";
 
 function taskDisplay(
@@ -155,7 +161,6 @@ function DeploymentTaskDockTask({
     <div
       className={cn(
         "group/dock-task flex min-w-0 items-center gap-[6px] overflow-hidden rounded-md bg-white/[0.05] px-4 py-2 transition-colors hover:bg-white/[0.08]",
-        "max-sm:w-full max-sm:max-w-full",
         item.active && "bg-white/10"
       )}
       data-active={item.active ? "true" : "false"}
@@ -210,48 +215,162 @@ function DeploymentTaskDockDivider() {
   );
 }
 
-function ExpandButton({
-  className,
-  expanded,
-  hiddenCount,
-  onToggle,
+/**
+ * The overflow panel's body: the full visible task list with the same chip
+ * semantics as the inline row (open on click, dismiss only when terminal).
+ * Kept free of popover context so tests can render it directly.
+ */
+export function DeploymentTaskDockOverflowList({
+  onDismiss,
+  onOpen,
+  tasks,
 }: {
-  className?: string;
-  expanded: boolean;
-  hiddenCount: number;
-  onToggle: () => void;
+  onDismiss: (taskId: string) => void;
+  onOpen: (taskId: string) => void;
+  tasks: DeploymentTaskDockItem[];
 }) {
+  return (
+    <div
+      className="flex min-w-0 flex-col gap-1"
+      data-slot="deployment-task-dock-list"
+    >
+      <p className="px-2 pt-1 font-medium text-muted-foreground text-xs">
+        Deployment tasks
+      </p>
+      <div className="flex max-h-[60vh] min-h-0 flex-col gap-1 overflow-y-auto">
+        {tasks.map((item) => (
+          <DeploymentTaskDockTask
+            item={item}
+            key={item.task.id}
+            onDismiss={onDismiss}
+            onOpen={onOpen}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The dock's overflow affordance: a "+N" trigger that opens a popover panel
+ * listing every visible task. The panel grows downward as an overlay, so the
+ * top bar row keeps its fixed height no matter how many tasks are queued.
+ */
+function DeploymentTaskDockOverflow({
+  hiddenCount,
+  onDismiss,
+  onOpen,
+  tasks,
+}: {
+  hiddenCount: number;
+  onDismiss: (taskId: string) => void;
+  onOpen: (taskId: string) => void;
+  tasks: DeploymentTaskDockItem[];
+}) {
+  const [open, setOpen] = useState(false);
+
   if (hiddenCount <= 0) {
     return null;
   }
 
+  const openTask = (taskId: string) => {
+    setOpen(false);
+    onOpen(taskId);
+  };
+
   return (
-    <button
-      aria-expanded={expanded}
-      aria-label={
-        expanded
-          ? "Show fewer deployment tasks"
-          : `Show ${hiddenCount} more deployment tasks`
-      }
-      className={cn(
-        "inline-flex shrink-0 items-center gap-[6px] rounded-md bg-white/[0.08] px-4 py-2 font-medium text-foreground text-sm outline-none transition-colors hover:bg-white/[0.12] focus-visible:ring-2 focus-visible:ring-blue-300/45",
-        className
-      )}
-      onClick={onToggle}
-      type="button"
-    >
-      <span>{expanded ? "Show less" : `+${hiddenCount}`}</span>
-      <ChevronDown
-        aria-hidden
-        className={cn(
-          "size-3.5 transition-transform",
-          expanded && "rotate-180"
-        )}
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverTrigger
+        render={
+          <button
+            aria-label={`Show ${hiddenCount} more deployment tasks`}
+            className="inline-flex shrink-0 items-center gap-[6px] rounded-md bg-white/[0.08] px-4 py-2 font-medium text-foreground text-sm outline-none transition-colors hover:bg-white/[0.12] focus-visible:ring-2 focus-visible:ring-blue-300/45"
+            type="button"
+          >
+            <span>+{hiddenCount}</span>
+            <ChevronDown
+              aria-hidden
+              className={cn(
+                "size-3.5 transition-transform",
+                open && "rotate-180"
+              )}
+            />
+          </button>
+        }
       />
-    </button>
+      <PopoverContent
+        align="start"
+        aria-label="Deployment tasks"
+        className="w-80 p-2"
+        sideOffset={8}
+      >
+        <DeploymentTaskDockOverflowList
+          onDismiss={onDismiss}
+          onOpen={openTask}
+          tasks={tasks}
+        />
+      </PopoverContent>
+    </Popover>
   );
 }
 
+/**
+ * The dock row at a decided visible count: the first `visibleCount` chips
+ * inline, each elastic between the chip floor and `max-w-64`, the rest
+ * behind the "+N" popover. Kept free of measurement so tests can render it
+ * with an explicit count.
+ */
+export function DeploymentTaskDockRow({
+  items,
+  onDismiss,
+  onOpen,
+  visibleCount,
+}: {
+  items: DeploymentTaskDockItem[];
+  onDismiss: (taskId: string) => void;
+  onOpen: (taskId: string) => void;
+  visibleCount: number;
+}) {
+  const visible = items.slice(0, visibleCount);
+  const hiddenCount = items.length - visible.length;
+
+  return (
+    <div
+      className="flex min-w-0 items-center gap-1"
+      data-slot="deployment-task-dock-row"
+    >
+      {visible.map((item, index) => (
+        <Fragment key={item.task.id}>
+          {index > 0 ? <DeploymentTaskDockDivider /> : null}
+          {/* min-w-32 must stay in sync with DEPLOYMENT_TASK_DOCK_CHIP_MIN_PX. */}
+          <div className="flex min-w-32 max-w-64 *:w-full">
+            <DeploymentTaskDockTask
+              item={item}
+              onDismiss={onDismiss}
+              onOpen={onOpen}
+            />
+          </div>
+        </Fragment>
+      ))}
+      {hiddenCount > 0 && visible.length > 0 ? (
+        <DeploymentTaskDockDivider />
+      ) : null}
+      <DeploymentTaskDockOverflow
+        hiddenCount={hiddenCount}
+        onDismiss={onDismiss}
+        onOpen={onOpen}
+        tasks={items}
+      />
+    </div>
+  );
+}
+
+/**
+ * Measuring shell: observes the slot's width and lets the pure fit
+ * arithmetic decide how many chips the row shows. Nothing renders until the
+ * first measurement lands (pre-paint, via layout effect), so the bar never
+ * flashes an unfitted row.
+ */
 export function ProjectCanvasDeploymentTaskDock({
   className,
   dock,
@@ -263,61 +382,49 @@ export function ProjectCanvasDeploymentTaskDock({
   onDismiss: (taskId: string) => void;
   onOpen: (taskId: string) => void;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const [slotWidth, setSlotWidth] = useState<number | null>(null);
+  const hasTasks = dock.tasks.length > 0;
 
-  if (dock.tasks.length === 0) {
+  useLayoutEffect(() => {
+    if (!hasTasks) {
+      return;
+    }
+    const host = hostRef.current;
+    if (!host) {
+      return;
+    }
+    const measure = () => setSlotWidth(host.clientWidth);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(host);
+    return () => observer.disconnect();
+  }, [hasTasks]);
+
+  if (!hasTasks) {
     return null;
   }
-
-  const toggleExpanded = () => setExpanded((current) => !current);
-  const desktopTasks = expanded ? dock.tasks : dock.desktopTasks;
-  const mobileTasks = expanded ? dock.tasks : dock.mobileTasks;
 
   return (
     <div
       className={cn(
-        "pointer-events-auto w-[calc(100vw-13rem)] max-w-[calc(100vw-13rem)] overflow-hidden rounded-lg sm:w-fit",
+        "pointer-events-auto flex min-w-0 flex-1 items-center overflow-hidden",
         className
       )}
       data-slot="deployment-task-dock"
+      ref={hostRef}
     >
-      <div className="flex min-w-0 items-start sm:hidden">
-        <div className={cn("min-w-0 flex-1", expanded && "flex flex-col")}>
-          {mobileTasks.map((item) => (
-            <DeploymentTaskDockTask
-              item={item}
-              key={item.task.id}
-              onDismiss={onDismiss}
-              onOpen={onOpen}
-            />
-          ))}
-        </div>
-        <ExpandButton
-          expanded={expanded}
-          hiddenCount={dock.mobileHiddenCount}
-          onToggle={toggleExpanded}
+      {slotWidth == null ? null : (
+        <DeploymentTaskDockRow
+          items={dock.tasks}
+          onDismiss={onDismiss}
+          onOpen={onOpen}
+          visibleCount={fitDeploymentTaskDockChipCount(
+            slotWidth,
+            dock.tasks.length
+          )}
         />
-      </div>
-      <div className="hidden min-w-0 flex-nowrap items-center gap-1 sm:flex">
-        {desktopTasks.map((item, index) => (
-          <Fragment key={item.task.id}>
-            {index > 0 ? <DeploymentTaskDockDivider /> : null}
-            <DeploymentTaskDockTask
-              item={item}
-              onDismiss={onDismiss}
-              onOpen={onOpen}
-            />
-          </Fragment>
-        ))}
-        {dock.desktopHiddenCount > 0 && desktopTasks.length > 0 ? (
-          <DeploymentTaskDockDivider />
-        ) : null}
-        <ExpandButton
-          expanded={expanded}
-          hiddenCount={dock.desktopHiddenCount}
-          onToggle={toggleExpanded}
-        />
-      </div>
+      )}
     </div>
   );
 }

--- a/apps/ui/src/features/project-canvas/workbench/deployment-task-timeline-reentry.test.ts
+++ b/apps/ui/src/features/project-canvas/workbench/deployment-task-timeline-reentry.test.ts
@@ -2,7 +2,13 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import type { DeploymentTaskProjection } from "@/features/deploy/task/projection";
-import { selectDeploymentTaskDock } from "./deployment-task-timeline-reentry";
+import {
+  DEPLOYMENT_TASK_DOCK_CHIP_GAP_PX,
+  DEPLOYMENT_TASK_DOCK_CHIP_MIN_PX,
+  DEPLOYMENT_TASK_DOCK_OVERFLOW_RESERVE_PX,
+  fitDeploymentTaskDockChipCount,
+  selectDeploymentTaskDock,
+} from "./deployment-task-timeline-reentry";
 
 const NOW = new Date("2026-06-17T10:04:00.000Z");
 
@@ -111,7 +117,7 @@ test("deployment task dock hides dismissed task only for the dismissed update", 
   assert.equal(visibleAfterUpdate.tasks.length, 1);
 });
 
-test("deployment task dock exposes desktop and mobile collapsed counts", () => {
+test("deployment task dock keeps the full ordered task list without pre-split views", () => {
   const dock = selectDeploymentTaskDock({
     activeTaskId: null,
     dismissedTaskUpdatedAtById: new Map(),
@@ -124,10 +130,37 @@ test("deployment task dock exposes desktop and mobile collapsed counts", () => {
     ],
   });
 
-  assert.equal(dock.desktopTasks.length, 3);
-  assert.equal(dock.desktopHiddenCount, 1);
-  assert.equal(dock.mobileTasks.length, 1);
-  assert.equal(dock.mobileHiddenCount, 3);
+  assert.equal(dock.tasks.length, 4);
+});
+
+test("dock chip fit shows every task when all fit at the chip floor", () => {
+  const chip = DEPLOYMENT_TASK_DOCK_CHIP_MIN_PX;
+  const gap = DEPLOYMENT_TASK_DOCK_CHIP_GAP_PX;
+  const exactWidth = 3 * chip + 2 * gap;
+
+  assert.equal(fitDeploymentTaskDockChipCount(exactWidth, 3), 3);
+  // One pixel short of "all fit" folds into the overflow instead, and the
+  // overflow reserve now competes with the chips for room.
+  assert.equal(fitDeploymentTaskDockChipCount(exactWidth - 1, 3), 2);
+});
+
+test("dock chip fit reserves room for the overflow trigger when folding", () => {
+  const unit =
+    DEPLOYMENT_TASK_DOCK_CHIP_MIN_PX + DEPLOYMENT_TASK_DOCK_CHIP_GAP_PX;
+  const reserve = DEPLOYMENT_TASK_DOCK_OVERFLOW_RESERVE_PX;
+  const twoChipsWithTrigger = 2 * unit + reserve;
+
+  assert.equal(fitDeploymentTaskDockChipCount(twoChipsWithTrigger, 5), 2);
+  assert.equal(fitDeploymentTaskDockChipCount(twoChipsWithTrigger - 1, 5), 1);
+});
+
+test("dock chip fit degrades to the overflow trigger alone in a tiny slot", () => {
+  assert.equal(fitDeploymentTaskDockChipCount(90, 4), 0);
+  assert.equal(fitDeploymentTaskDockChipCount(0, 4), 0);
+});
+
+test("dock chip fit is zero for an empty dock", () => {
+  assert.equal(fitDeploymentTaskDockChipCount(1000, 0), 0);
 });
 
 test("deployment task dock does not show completed tasks during projection grace", () => {

--- a/apps/ui/src/features/project-canvas/workbench/deployment-task-timeline-reentry.ts
+++ b/apps/ui/src/features/project-canvas/workbench/deployment-task-timeline-reentry.ts
@@ -3,9 +3,51 @@ import {
   deploymentTaskProjectionIsVisible,
 } from "@/features/deploy/task/projection";
 
-export const DEPLOYMENT_TASK_DOCK_DESKTOP_LIMIT = 3;
-export const DEPLOYMENT_TASK_DOCK_MOBILE_LIMIT = 1;
 export const DEPLOYMENT_TASK_DOCK_COMPLETION_NOTICE_MS = 6000;
+
+/**
+ * Dock chip slot geometry (px). The chip floor mirrors the row's `min-w-32`
+ * class (a chip narrower than this stops being readable, so it folds into
+ * the overflow instead); the gap is one chip → divider → chip span
+ * (gap-1 + 1px divider + gap-1); the reserve holds room for the widest
+ * realistic "+N" trigger plus the divider before it.
+ */
+export const DEPLOYMENT_TASK_DOCK_CHIP_MIN_PX = 128;
+export const DEPLOYMENT_TASK_DOCK_CHIP_GAP_PX = 9;
+export const DEPLOYMENT_TASK_DOCK_OVERFLOW_RESERVE_PX = 84;
+
+/**
+ * How many chips (highest-priority first) fit the measured slot width.
+ * Every task is shown only when each chip can take at least its floor width
+ * with no overflow trigger; otherwise each visible chip must fit at its
+ * floor alongside the "+N" reserve. Pure arithmetic so the fold decision
+ * stays unit-testable — the DOM contributes only the measured width.
+ */
+export function fitDeploymentTaskDockChipCount(
+  slotWidth: number,
+  taskCount: number
+): number {
+  if (taskCount === 0) {
+    return 0;
+  }
+  const allChipsWidth =
+    taskCount * DEPLOYMENT_TASK_DOCK_CHIP_MIN_PX +
+    (taskCount - 1) * DEPLOYMENT_TASK_DOCK_CHIP_GAP_PX;
+  if (allChipsWidth <= slotWidth) {
+    return taskCount;
+  }
+  let count = 0;
+  while (
+    count < taskCount &&
+    (count + 1) *
+      (DEPLOYMENT_TASK_DOCK_CHIP_MIN_PX + DEPLOYMENT_TASK_DOCK_CHIP_GAP_PX) +
+      DEPLOYMENT_TASK_DOCK_OVERFLOW_RESERVE_PX <=
+      slotWidth
+  ) {
+    count += 1;
+  }
+  return count;
+}
 
 export interface DeploymentTaskDockItem {
   active: boolean;
@@ -13,10 +55,6 @@ export interface DeploymentTaskDockItem {
 }
 
 export interface DeploymentTaskDockModel {
-  desktopHiddenCount: number;
-  desktopTasks: DeploymentTaskDockItem[];
-  mobileHiddenCount: number;
-  mobileTasks: DeploymentTaskDockItem[];
   tasks: DeploymentTaskDockItem[];
 }
 
@@ -127,20 +165,5 @@ export function selectDeploymentTaskDock(input: {
     })
   );
 
-  const desktopTasks = tasks.slice(0, DEPLOYMENT_TASK_DOCK_DESKTOP_LIMIT);
-  const mobileTasks = tasks.slice(0, DEPLOYMENT_TASK_DOCK_MOBILE_LIMIT);
-
-  return {
-    desktopHiddenCount: Math.max(
-      0,
-      tasks.length - DEPLOYMENT_TASK_DOCK_DESKTOP_LIMIT
-    ),
-    desktopTasks,
-    mobileHiddenCount: Math.max(
-      0,
-      tasks.length - DEPLOYMENT_TASK_DOCK_MOBILE_LIMIT
-    ),
-    mobileTasks,
-    tasks,
-  };
+  return { tasks };
 }

--- a/apps/ui/src/features/project-canvas/workbench/project-canvas-page-shell.tsx
+++ b/apps/ui/src/features/project-canvas/workbench/project-canvas-page-shell.tsx
@@ -20,6 +20,7 @@ import {
   type ProjectCanvasNodeCommands,
   ProjectCanvasNodeCommandsProvider,
 } from "@/features/project-canvas/workbench/node-commands-react";
+import { ProjectTopBarSlot } from "@/features/shell/project-top-bar-slot";
 
 const PROJECT_CANVAS_LOADING_TOAST_ID = "project-canvas-loading-workloads";
 const PROJECT_CANVAS_NO_WORKLOADS_TOAST_ID = "project-canvas-no-workloads";
@@ -159,12 +160,16 @@ export function ProjectCanvasOverlayLayer({
 }: ProjectCanvasOverlayLayerProps) {
   return (
     <>
-      <ProjectCanvasDeploymentTaskDock
-        className="absolute top-2 left-48 z-20"
-        dock={deploymentTaskDock}
-        onDismiss={onDismissDeploymentTask}
-        onOpen={onOpenDeploymentTask}
-      />
+      {/* The dock's DOM mounts into the shell top bar's slot; its model and
+          callbacks stay canvas-owned, so nothing crosses the shell boundary
+          but the rendered output. */}
+      <ProjectTopBarSlot>
+        <ProjectCanvasDeploymentTaskDock
+          dock={deploymentTaskDock}
+          onDismiss={onDismissDeploymentTask}
+          onOpen={onOpenDeploymentTask}
+        />
+      </ProjectTopBarSlot>
       <ProjectCanvasLoadingToast active={frameState.overlay === "loading"} />
       <ProjectCanvasFrameStateToast overlay={frameState.overlay} />
     </>

--- a/apps/ui/src/features/shell/project-top-bar-slot.test.tsx
+++ b/apps/ui/src/features/shell/project-top-bar-slot.test.tsx
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { render } from "@testing-library/react/pure";
+
+import {
+  actAndDrain,
+  installTestDom,
+  restoreActEnvironment,
+  setActEnvironment,
+} from "@/features/project-canvas/react-test-harness";
+import {
+  ProjectTopBarSlot,
+  ProjectTopBarSlotHost,
+  ProjectTopBarSlotProvider,
+} from "./project-top-bar-slot";
+
+async function withDom(run: () => Promise<void>): Promise<void> {
+  const dom = installTestDom();
+  const previousActEnvironment = setActEnvironment(true);
+  try {
+    await run();
+  } finally {
+    restoreActEnvironment(previousActEnvironment);
+    await dom.restore();
+  }
+}
+
+test("slot content mounts into the top bar host, not in place", async () => {
+  await withDom(async () => {
+    let rendered: ReturnType<typeof render> | undefined;
+    await actAndDrain(() => {
+      rendered = render(
+        <ProjectTopBarSlotProvider>
+          <header>
+            <ProjectTopBarSlotHost />
+          </header>
+          <main>
+            <ProjectTopBarSlot>
+              <span data-testid="slot-content">dock</span>
+            </ProjectTopBarSlot>
+          </main>
+        </ProjectTopBarSlotProvider>
+      );
+    });
+
+    const host = document.querySelector('[data-slot="project-top-bar-slot"]');
+    const content = document.querySelector('[data-testid="slot-content"]');
+    assert.notEqual(host, null);
+    assert.notEqual(content, null);
+    assert.equal(host?.contains(content), true);
+    assert.equal(document.querySelector("main")?.contains(content), false);
+    await actAndDrain(() => {
+      rendered?.unmount();
+    });
+  });
+});
+
+test("slot content unmounts from the host with its owner", async () => {
+  await withDom(async () => {
+    function Tree({ withContent }: { withContent: boolean }) {
+      return (
+        <ProjectTopBarSlotProvider>
+          <header>
+            <ProjectTopBarSlotHost />
+          </header>
+          {withContent ? (
+            <ProjectTopBarSlot>
+              <span data-testid="slot-content">dock</span>
+            </ProjectTopBarSlot>
+          ) : null}
+        </ProjectTopBarSlotProvider>
+      );
+    }
+    let rendered: ReturnType<typeof render> | undefined;
+    await actAndDrain(() => {
+      rendered = render(<Tree withContent />);
+    });
+    assert.notEqual(
+      document.querySelector('[data-testid="slot-content"]'),
+      null
+    );
+
+    await actAndDrain(() => {
+      rendered?.rerender(<Tree withContent={false} />);
+    });
+    assert.equal(document.querySelector('[data-testid="slot-content"]'), null);
+    await actAndDrain(() => {
+      rendered?.unmount();
+    });
+  });
+});
+
+test("slot renders children in place outside a provider", async () => {
+  await withDom(async () => {
+    let rendered: ReturnType<typeof render> | undefined;
+    await actAndDrain(() => {
+      rendered = render(
+        <main>
+          <ProjectTopBarSlot>
+            <span data-testid="slot-content">dock</span>
+          </ProjectTopBarSlot>
+        </main>
+      );
+    });
+
+    const content = document.querySelector('[data-testid="slot-content"]');
+    assert.notEqual(content, null);
+    assert.equal(document.querySelector("main")?.contains(content), true);
+    await actAndDrain(() => {
+      rendered?.unmount();
+    });
+  });
+});
+
+test("slot renders nothing while the provider has no host", async () => {
+  await withDom(async () => {
+    let rendered: ReturnType<typeof render> | undefined;
+    await actAndDrain(() => {
+      rendered = render(
+        <ProjectTopBarSlotProvider>
+          <ProjectTopBarSlot>
+            <span data-testid="slot-content">dock</span>
+          </ProjectTopBarSlot>
+        </ProjectTopBarSlotProvider>
+      );
+    });
+
+    assert.equal(document.querySelector('[data-testid="slot-content"]'), null);
+    await actAndDrain(() => {
+      rendered?.unmount();
+    });
+  });
+});

--- a/apps/ui/src/features/shell/project-top-bar-slot.tsx
+++ b/apps/ui/src/features/shell/project-top-bar-slot.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+interface ProjectTopBarSlotAttachment {
+  host: HTMLElement | null;
+  setHost: (host: HTMLElement | null) => void;
+}
+
+const ProjectTopBarSlotContext =
+  createContext<ProjectTopBarSlotAttachment | null>(null);
+
+/**
+ * Slot contract between the project top bar and page modules: the top bar
+ * rents out a region of its row without knowing what fills it, and a page
+ * module (today: the Project Canvas workbench's Deployment Task Dock) mounts
+ * content there while keeping ownership — data, callbacks, and state stay in
+ * the contributing module's React tree; only the DOM output travels.
+ */
+export function ProjectTopBarSlotProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  // useState (not useRef) so the host element's mount re-renders consumers,
+  // giving the portal a target to attach to.
+  const [host, setHost] = useState<HTMLElement | null>(null);
+  const attachment = useMemo<ProjectTopBarSlotAttachment>(
+    () => ({ host, setHost }),
+    [host]
+  );
+  return (
+    <ProjectTopBarSlotContext.Provider value={attachment}>
+      {children}
+    </ProjectTopBarSlotContext.Provider>
+  );
+}
+
+/** The top bar's rented region: an empty element slot content portals into. */
+export function ProjectTopBarSlotHost({ className }: { className?: string }) {
+  const attachment = useContext(ProjectTopBarSlotContext);
+  if (attachment == null) {
+    return null;
+  }
+  return (
+    <div
+      className={className}
+      data-slot="project-top-bar-slot"
+      ref={attachment.setHost}
+    />
+  );
+}
+
+/**
+ * Mounts its children into the project top bar's slot from anywhere under the
+ * provider. Outside a provider (chrome-less hosts, tests) children render in
+ * place, mirroring SidePaneFooter's fallback.
+ */
+export function ProjectTopBarSlot({ children }: { children: ReactNode }) {
+  const attachment = useContext(ProjectTopBarSlotContext);
+  if (attachment == null) {
+    return <>{children}</>;
+  }
+  if (attachment.host == null) {
+    return null;
+  }
+  return createPortal(children, attachment.host);
+}

--- a/apps/ui/src/features/shell/project-workspace-layout.tsx
+++ b/apps/ui/src/features/shell/project-workspace-layout.tsx
@@ -107,6 +107,10 @@ import {
   type ProjectEditDialogValues,
 } from "@/features/projects/project-edit-dialog";
 import { isAssistantChatNamespaceReady } from "@/features/shell/project-assistant-chat-readiness";
+import {
+  ProjectTopBarSlotHost,
+  ProjectTopBarSlotProvider,
+} from "@/features/shell/project-top-bar-slot";
 import { appTokenRequestHeaders } from "@/lib/app-token-header";
 import { appTokenAtom, kubeconfigAtom, namespaceAtom } from "@/lib/auth-store";
 import { kubeconfigBearerHeader } from "@/lib/kubeconfig-header";
@@ -999,7 +1003,11 @@ function ProjectRouteTopBar({
           !assistantPaneOpen && "pr-12"
         )}
       >
-        <div className="pointer-events-auto flex min-w-0 shrink-0 basis-40 items-center">
+        {/* Content-hugging with a cap: the name keeps priority over the dock
+            up to the cap, then truncates; the dock flows right after it. The
+            cap tightens on mobile so the dock's chip and overflow trigger
+            always keep room. */}
+        <div className="pointer-events-auto flex min-w-0 max-w-40 shrink-0 items-center sm:max-w-64">
           {showProjectName ? (
             <div className="flex min-w-0 items-center gap-1 rounded-lg bg-background/10 backdrop-blur-lg">
               {currentProject.isLoading ? (
@@ -1008,7 +1016,7 @@ function ProjectRouteTopBar({
                 <>
                   <button
                     aria-label={`Edit project name: ${projectName}`}
-                    className="flex min-w-0 shrink-0 cursor-pointer items-center gap-[6px] overflow-hidden rounded-md p-2 text-left transition-colors hover:bg-input/30 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30"
+                    className="flex min-w-0 cursor-pointer items-center gap-[6px] overflow-hidden rounded-md p-2 text-left transition-colors hover:bg-input/30 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30"
                     onClick={() => setEditOpen(true)}
                     type="button"
                   >
@@ -1031,6 +1039,10 @@ function ProjectRouteTopBar({
             </div>
           ) : null}
         </div>
+        {/* Rented to page modules (Deployment Task Dock); slot content
+            centers in the bar, and overflow opens as a popover panel, so
+            the row keeps its fixed height. */}
+        <ProjectTopBarSlotHost className="flex min-w-0 flex-1 items-center" />
       </header>
       <ProjectEditDialog
         currentDescription={projectDescription}
@@ -1443,9 +1455,11 @@ export default function ProjectWorkspaceLayout({
   return (
     <ProjectSidePaneProvider>
       <ProjectIdProvider>
-        <ProjectWorkspaceLayoutContent>
-          {children}
-        </ProjectWorkspaceLayoutContent>
+        <ProjectTopBarSlotProvider>
+          <ProjectWorkspaceLayoutContent>
+            {children}
+          </ProjectWorkspaceLayoutContent>
+        </ProjectTopBarSlotProvider>
       </ProjectIdProvider>
     </ProjectSidePaneProvider>
   );


### PR DESCRIPTION
## What

The Deployment Task Dock moves off the canvas overlay into the shell top bar (through a rented `ProjectTopBarSlot`), and its collapse behavior becomes width-driven instead of constant-driven:

- **Slot mount** — the dock's DOM renders in the top bar; its model and callbacks stay canvas-owned, so only rendered output crosses the shell boundary.
- **Width-driven fold** — the fixed desktop/mobile visible-count constants (3/1) are gone. A single ResizeObserver measures the slot, and a pure function (`fitDeploymentTaskDockChipCount`) decides how many chips fit; desktop and mobile share one mechanism.
- **Elastic chips** — each chip hugs its content between a readable floor (`min-w-32`) and a cap (`max-w-64`); when the row tightens, chips shrink to the floor before the next one folds.
- **"+N" popover** — folded tasks live behind an overflow popover listing every task with full chip semantics (open on click, dismiss on terminal only), so the bar keeps a fixed height. On the narrowest slots the dock degrades to the overflow control alone.
- The dock model slims to the ordered task list; the row renders from an explicit visible count so tests drive it without layout. CONTEXT.md's Deployment Task Dock entry records the resolved behavior.

## Test plan

- `deployment-task-timeline-reentry.test.ts` — ordering + fit arithmetic boundaries (exact fit, 1px short, overflow reserve, zero-width, empty dock)
- `deployment-task-timeline-reentry-affordance.test.tsx` — row at explicit counts (fold, trigger-only degrade, dismiss rules per ADR 0038, no cancel/redeploy), overflow panel completeness, measuring-host SSR contract
- Verified in-browser across 320/390/768/1100px: fold ladder, popover open/dismiss, K=0 degrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)