### PR TITLE
fix(ui): satisfy react compiler lint in side pane and top bar slot

### DIFF
--- a/apps/ui/src/features/shell/project-top-bar-slot.tsx
+++ b/apps/ui/src/features/shell/project-top-bar-slot.tsx
@@ -49,12 +49,9 @@ export function ProjectTopBarSlotHost({ className }: { className?: string }) {
   if (attachment == null) {
     return null;
   }
+  const { setHost } = attachment;
   return (
-    <div
-      className={className}
-      data-slot="project-top-bar-slot"
-      ref={attachment.setHost}
-    />
+    <div className={className} data-slot="project-top-bar-slot" ref={setHost} />
   );
 }
 

--- a/packages/ui/src/components/side-pane.tsx
+++ b/packages/ui/src/components/side-pane.tsx
@@ -73,6 +73,13 @@ export function SidePane({
   const glowPhase = useContext(SidePaneGlowPhaseContext);
   const [footerContributors, setFooterContributors] = useState(0);
   const [footerHost, setFooterHost] = useState<HTMLDivElement | null>(null);
+  // The same node, held in a ref: the footer's lift flag is written straight to
+  // the DOM, and only a ref may be mutated outside render.
+  const footerHostRef = useRef<HTMLDivElement | null>(null);
+  const attachFooterHost = useCallback((node: HTMLDivElement | null) => {
+    footerHostRef.current = node;
+    setFooterHost(node);
+  }, []);
   const registerFooter = useCallback(() => {
     setFooterContributors((count) => count + 1);
     return () => setFooterContributors((count) => Math.max(0, count - 1));
@@ -96,7 +103,10 @@ export function SidePane({
     const sync = () => {
       const scrolledToEnd =
         scrollEl.scrollTop + scrollEl.clientHeight >= scrollEl.scrollHeight - 1;
-      footerHost.dataset.lifted = String(!scrolledToEnd);
+      const hostEl = footerHostRef.current;
+      if (hostEl != null) {
+        hostEl.dataset.lifted = String(!scrolledToEnd);
+      }
     };
     sync();
     scrollEl.addEventListener("scroll", sync, { passive: true });
@@ -194,7 +204,7 @@ export function SidePane({
           <div
             className="side-pane-footer-lift flex min-w-0 shrink-0 flex-wrap items-center justify-end gap-2.5 px-5 py-3"
             data-slot="side-pane-footer"
-            ref={setFooterHost}
+            ref={attachFooterHost}
           />
         ) : null}
         <div


### PR DESCRIPTION
`bun lint` was failing on two React Compiler rules.

## `packages/ui/src/components/side-pane.tsx` — `react-hooks/immutability`

The footer-lift effect wrote `data-lifted` onto a host element held in `useState`, and the compiler forbids mutating a `useState` value. The state stays (the footer portal needs the mount re-render); the element is now also held in a parallel ref, and the scroll handler mutates that. Behavior is unchanged — the lift flag still goes straight to the DOM so scroll ticks never repaint the pane shell.

## `apps/ui/src/features/shell/project-top-bar-slot.tsx` — `react-hooks/refs`

`ref={attachment.setHost}` read the callback off the context object in the `ref` position, which the compiler treats as a ref access during render. Destructured `setHost` before the JSX — same setter, same identity, no re-attach.

## Verification

`bun lint`, `bun check`, and `bun typecheck` all pass.

Note: the first `bun lint` run stops after the `@workspace/ui` failure, so the `apps/ui` error only surfaces once that one is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)