### PR TITLE
fix(ui): recolor icon buttons blue on hover instead of tooltip open

### DIFF
--- a/packages/ui/src/components/app-icon-button.tsx
+++ b/packages/ui/src/components/app-icon-button.tsx
@@ -11,10 +11,10 @@ const appIconButtonVariants = cva(
         primary:
           "bg-brand-primary text-brand-primary-foreground hover:bg-brand-primary-hover data-popup-open:bg-brand-primary-hover",
         secondary:
-          "bg-input/30 text-brand-primary-foreground hover:bg-input aria-[current=page]:bg-input aria-[current=page]:text-blue-400 data-[active=true]:bg-input data-popup-open:bg-input data-[active=true]:text-blue-400 data-popup-open:text-blue-400",
+          "bg-input/30 text-brand-primary-foreground hover:bg-input hover:text-blue-400 aria-[current=page]:bg-input aria-[current=page]:text-blue-400 data-[active=true]:bg-input data-popup-open:bg-input data-[active=true]:text-blue-400 data-popup-open:text-blue-400",
         quiet:
-          "bg-transparent text-brand-primary-foreground hover:bg-input/30 aria-[current=page]:bg-input aria-[current=page]:text-blue-400 data-[active=true]:bg-input data-popup-open:bg-input/30 data-[active=true]:text-blue-400 data-popup-open:text-blue-400",
-        node: "bg-zinc-950/20 text-brand-primary-foreground hover:bg-input data-popup-open:bg-input data-popup-open:text-blue-400",
+          "bg-transparent text-brand-primary-foreground hover:bg-input/30 hover:text-blue-400 aria-[current=page]:bg-input aria-[current=page]:text-blue-400 data-[active=true]:bg-input data-popup-open:bg-input/30 data-[active=true]:text-blue-400 data-popup-open:text-blue-400",
+        node: "bg-zinc-950/20 text-brand-primary-foreground hover:bg-input hover:text-blue-400 data-popup-open:bg-input data-popup-open:text-blue-400",
         danger:
           "bg-input/30 text-foreground hover:bg-input hover:text-red-500 focus-visible:border-destructive/40 focus-visible:ring-destructive/25 data-popup-open:bg-input data-popup-open:text-red-500",
       },

--- a/packages/ui/src/components/canvas-node/canvas-node.actions.tsx
+++ b/packages/ui/src/components/canvas-node/canvas-node.actions.tsx
@@ -92,7 +92,10 @@ export function CanvasNodeActionButton({
       className={cn(
         RF_CONTROL_CLASS,
         "canvas-node-action-button shrink-0 cursor-pointer border-0",
-        disabledReason && "cursor-not-allowed opacity-50",
+        // Reason-disabled buttons stay interactive for their tooltip; keep the
+        // hover/open accent off them so blue keeps meaning "will act".
+        disabledReason &&
+          "cursor-not-allowed opacity-50 hover:text-brand-primary-foreground data-popup-open:text-brand-primary-foreground",
         className
       )}
       disabled={disabled && disabledReason == null}

--- a/packages/ui/src/components/canvas-node/canvas-node.css
+++ b/packages/ui/src/components/canvas-node/canvas-node.css
@@ -344,10 +344,6 @@
   background: color-mix(in oklab, var(--color-white) 4.5%, transparent);
 }
 
-.canvas-node-action-button:is([data-state="open"], [data-popup-open]) {
-  color: var(--sealai-brand-primary-foreground);
-}
-
 .canvas-node-action-button:is([data-state="open"], [data-popup-open]):not(
     :hover,
     :focus-visible

--- a/packages/ui/src/components/canvas/canvas.controls.tsx
+++ b/packages/ui/src/components/canvas/canvas.controls.tsx
@@ -200,7 +200,7 @@ function CanvasControlButton({
             aria-label={label}
             aria-pressed={active || undefined}
             className={cn(
-              "text-muted-foreground hover:bg-input/30 hover:text-foreground data-[active=true]:bg-input data-[active=true]:text-brand-primary-foreground"
+              "text-muted-foreground hover:bg-input/30 data-[active=true]:bg-input data-[active=true]:text-brand-primary-foreground"
             )}
             data-active={active || undefined}
             onClick={onClick}


### PR DESCRIPTION
## Summary

The blue accent on `AppIconButton` was only wired to `data-popup-open`, so it appeared 420ms into a hover — when the Base UI tooltip opened — and read as a tooltip side effect. This makes hover itself carry the accent, mirroring the `danger` variant's existing `hover:text-red-500`.

- `app-icon-button.tsx`: add `hover:text-blue-400` to the `secondary` / `quiet` / `node` variants
- `canvas-node.css`: drop the unlayered rule that forced popup-open quick actions back to neutral (it papered over the missing hover rule; the popup-open background rules stay)
- `canvas-node.actions.tsx`: reason-disabled quick actions keep neutral hover/popup-open text so blue still means "will act"
- `canvas.controls.tsx`: remove the local `hover:text-foreground` override so canvas controls inherit the variant accent instead of the old "hover white → tooltip blue" mix

Behavior after the change: hover recolors immediately (150ms transition), the tooltip still opens at 420ms with no color jump, menu triggers keep their highlight while open, and `aria-current` / `data-active` states are untouched.

## Testing

- `bun typecheck` (all packages) and `bun check` clean
- `bun test` for `canvas-node.actions` and `container-node.content` (8 pass)
- Verified interactively on a real-canvas fixture (container nodes, controls, menus, disabled-with-reason buttons) in the registry app; the throwaway fixture page was removed before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)