### PR TITLE
fix(ui): paint log viewer live control at system icon-button size

### DIFF
--- a/packages/ui/src/components/log-viewer/log-viewer.live-control.tsx
+++ b/packages/ui/src/components/log-viewer/log-viewer.live-control.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { AppIconButton } from "@workspace/ui/components/app-icon-button";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@workspace/ui/components/tooltip";
-import { cn } from "@workspace/ui/lib/utils";
 import { Pause, Play } from "lucide-react";
 import { useLogViewerContext } from "./log-viewer.context";
 
@@ -21,19 +21,24 @@ export function LogViewerLiveControl() {
   return (
     <Tooltip>
       <TooltipTrigger
-        aria-label={isLive ? "Pause live logs" : "Start live logs"}
-        aria-pressed={isLive}
-        className={cn(
-          "flex size-9 shrink-0 cursor-pointer items-center justify-center rounded-lg border border-transparent shadow-none transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30",
-          isLive
-            ? "bg-input text-blue-400 hover:bg-input/80"
-            : "bg-input/30 text-brand-primary-foreground hover:bg-input"
-        )}
-        onClick={isLive ? freeze : resumeLive}
-        type="button"
-      >
-        {isLive ? <Pause className="size-4" /> : <Play className="size-4" />}
-      </TooltipTrigger>
+        render={
+          <AppIconButton
+            aria-label={isLive ? "Pause live logs" : "Start live logs"}
+            aria-pressed={isLive}
+            data-active={isLive || undefined}
+            onClick={isLive ? freeze : resumeLive}
+            size="lg"
+            type="button"
+            variant="secondary"
+          >
+            {isLive ? (
+              <Pause className="size-4" />
+            ) : (
+              <Play className="size-4" />
+            )}
+          </AppIconButton>
+        }
+      />
       <TooltipContent side="bottom">
         {isLive ? "Pause live logs" : "Start live logs"}
       </TooltipContent>


### PR DESCRIPTION
## Problem

The two leftmost buttons on the log view toolbar (pause / download) inspect as identical 36×36 boxes, yet visibly render at different sizes — measured 36px vs 34px painted.

## Root cause

`Button`'s base cva includes `border border-transparent bg-clip-padding`, so every Button-based control clips its background to the padding box and paints a 34×34 square inside the 36×36 border box. `LogViewerLiveControl` hand-rolled its styles on a raw `TooltipTrigger`, copied the transparent border but missed `bg-clip-padding` — its background painted under the border, a full 36×36. Same box model, 2px painted difference.

## Fix

Rebuild the live control on `AppIconButton` (`size="lg" variant="secondary"`, same `TooltipTrigger render` pattern as `TableView.Toolbar`) instead of patching the copy:

- live state rides the existing `data-[active=true]:bg-input` / `text-blue-400` convention via `data-active`
- `aria-pressed`, `aria-label`, icon switching, and freeze/resume semantics unchanged
- inherits `bg-clip-padding`, focus ring, and press feedback from the system button

Intentional follow-on shifts: frozen-state hover now tints the icon blue (matching the adjacent download button), and live-state hover no longer dims the background (active state already saturates it).

## Verification

- `bun typecheck` — 5/5 packages pass
- `bun check` — clean
- Pixel-measured both screenshots: painted squares now share geometry via the same component path

🤖 Generated with [Claude Code](https://claude.com/claude-code)