### PR TITLE
fix(ui): let project list pin button inherit the quiet hover accent

### DIFF
--- a/apps/ui/src/features/projects/explorer/project-explorer.list-item.tsx
+++ b/apps/ui/src/features/projects/explorer/project-explorer.list-item.tsx
@@ -95,7 +95,6 @@ function ProjectExplorerPinAction({
           <AppIconButton
             aria-label={projectPinActionLabel(projectName, pinned)}
             aria-pressed={pinned}
-            className="text-muted-foreground hover:text-foreground"
             disabled={limitReached}
             onClick={(event) => {
               event.stopPropagation();


### PR DESCRIPTION
350cffa5 made hover itself the blue accent on AppIconButton, but the project list pin button kept a local 'text-muted-foreground hover:text-foreground' override that twMerge let win, so it still hovered white while the sibling row-menu trigger hovered blue.

Drop the whole override rather than just the hover half: the row's two icon buttons now behave identically, and future variant changes propagate with no local class to fight them. Compared on-page against keeping a muted rest tint (and against dimming both buttons) via the throwaway prototype on branch prototype/pin-hover-variants (952bf96f).

Other AppIconButton hover:text-foreground overrides are left alone on purpose — they carry real coupling (copied-state feedback color, progressive-disclosure rows, group-hover rows) the pin button never had.