### PR TITLE
fix(chat): make project deletion preview server-authoritative

### DIFF
--- a/apps/ui/src/features/chat/chat.tool-group.test.ts
+++ b/apps/ui/src/features/chat/chat.tool-group.test.ts
@@ -3,32 +3,18 @@ import { test } from "node:test";
 
 import { projectDeletionApprovalInput } from "./chat.tool-group";
 
-test("Project deletion approval exposes the exact preview target and resources", () => {
+test("Project deletion approval exposes the exact preview target", () => {
   assert.deepEqual(
     projectDeletionApprovalInput({
       projectDisplayName: "Payments",
       projectId: "project-1",
       resourceSummary: { ap: ["api"], db: ["postgres"] },
     }),
-    {
-      displayName: "Payments",
-      projectId: "project-1",
-      resources: [
-        ["ap", ["api"]],
-        ["db", ["postgres"]],
-      ],
-    }
+    { projectId: "project-1" }
   );
 });
 
 test("Project deletion approval rejects malformed tool input", () => {
-  assert.equal(projectDeletionApprovalInput({ projectId: "project-1" }), null);
-  assert.equal(
-    projectDeletionApprovalInput({
-      projectDisplayName: "Payments",
-      projectId: "project-1",
-      resourceSummary: { ap: [1] },
-    }),
-    null
-  );
+  assert.equal(projectDeletionApprovalInput({}), null);
+  assert.equal(projectDeletionApprovalInput({ projectId: "" }), null);
 });

--- a/apps/ui/src/features/chat/chat.tool-group.tsx
+++ b/apps/ui/src/features/chat/chat.tool-group.tsx
@@ -357,15 +357,6 @@ function ProjectDeletionApprovalCard({
       </label>
       <div className="flex flex-wrap gap-2">
         <AppButton
-          disabled={!confirmed}
-          onClick={() => onRespond?.({ approved: true, id: approval.id })}
-          size="sm"
-          type="button"
-          variant="danger"
-        >
-          Delete project
-        </AppButton>
-        <AppButton
           onClick={() =>
             onRespond?.({
               approved: false,
@@ -378,6 +369,15 @@ function ProjectDeletionApprovalCard({
           variant="quiet"
         >
           Cancel
+        </AppButton>
+        <AppButton
+          disabled={!confirmed}
+          onClick={() => onRespond?.({ approved: true, id: approval.id })}
+          size="sm"
+          type="button"
+          variant="danger"
+        >
+          Delete project
         </AppButton>
       </div>
     </div>

--- a/apps/ui/src/features/chat/chat.tool-group.tsx
+++ b/apps/ui/src/features/chat/chat.tool-group.tsx
@@ -304,41 +304,18 @@ function collectPendingApprovals(parts: ChatToolPart[]): PendingApproval[] {
 }
 
 export function projectDeletionApprovalInput(input: unknown): {
-  displayName: string;
   projectId: string;
-  resources: [string, string[]][];
 } | null {
   if (input == null || typeof input !== "object") {
     return null;
   }
   const value = input as {
-    projectDisplayName?: unknown;
     projectId?: unknown;
-    resourceSummary?: unknown;
   };
-  if (
-    typeof value.projectDisplayName !== "string" ||
-    typeof value.projectId !== "string" ||
-    value.resourceSummary == null ||
-    typeof value.resourceSummary !== "object" ||
-    Array.isArray(value.resourceSummary)
-  ) {
+  if (typeof value.projectId !== "string" || value.projectId.trim() === "") {
     return null;
   }
-  const resources: [string, string[]][] = [];
-  for (const [kind, names] of Object.entries(value.resourceSummary)) {
-    if (
-      !(Array.isArray(names) && names.every((name) => typeof name === "string"))
-    ) {
-      return null;
-    }
-    resources.push([kind, names]);
-  }
-  return {
-    displayName: value.projectDisplayName,
-    projectId: value.projectId,
-    resources,
-  };
+  return { projectId: value.projectId };
 }
 
 function ProjectDeletionApprovalCard({
@@ -351,10 +328,7 @@ function ProjectDeletionApprovalCard({
   onRespond?: ChatAddToolApproveResponseFunction;
 }) {
   const [confirmation, setConfirmation] = useState("");
-  const confirmed = confirmation.trim() === input.displayName;
-  const nonEmptyResources = input.resources.filter(
-    ([, names]) => names.length > 0
-  );
+  const confirmed = confirmation.trim() === input.projectId;
 
   return (
     <div
@@ -363,35 +337,20 @@ function ProjectDeletionApprovalCard({
     >
       <div className="flex min-w-0 flex-col gap-1">
         <p className="text-foreground text-sm">Delete project permanently?</p>
-        <p className="text-muted-foreground text-xs">{input.displayName}</p>
         <p className="break-all font-mono text-muted-foreground text-xs">
           {input.projectId}
         </p>
       </div>
-      <div className="max-h-40 overflow-y-auto rounded-md border border-border/60 bg-input/15 p-2 text-xs">
-        {nonEmptyResources.length === 0 ? (
-          <p className="text-muted-foreground">No managed resources found.</p>
-        ) : (
-          <ul className="space-y-1 text-muted-foreground">
-            {nonEmptyResources.map(([kind, names]) => (
-              <li key={kind}>
-                <span className="text-foreground">{kind}</span>:{" "}
-                {names.join(", ")}
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
       <label
         className="flex flex-col gap-1.5 text-muted-foreground text-xs"
-        htmlFor={`${approval.id}-project-name`}
+        htmlFor={`${approval.id}-project-id`}
       >
         Type{" "}
-        <span className="font-medium text-foreground">{input.displayName}</span>{" "}
+        <span className="font-medium text-foreground">{input.projectId}</span>{" "}
         to confirm
         <AppInput
-          aria-label="Project name confirmation"
-          id={`${approval.id}-project-name`}
+          aria-label="Project ID confirmation"
+          id={`${approval.id}-project-id`}
           onChange={(event) => setConfirmation(event.target.value)}
           value={confirmation}
         />

--- a/apps/ui/src/features/chat/tool/chat-project-tools.test.ts
+++ b/apps/ui/src/features/chat/tool/chat-project-tools.test.ts
@@ -8,25 +8,6 @@ const { createChatProjectTools, deleteProjectInputSchema } = await import(
   "./chat-project-tools"
 );
 
-const COMPLETE_RESOURCE_SUMMARY = {
-  ap: ["api"],
-  db: [],
-  template: [],
-  templateCertificates: [],
-  templateClusters: [],
-  templateConfigMaps: [],
-  templateDeployments: [],
-  templateIngresses: [],
-  templateIssuers: [],
-  templateJobs: [],
-  templateOpsRequests: [],
-  templatePersistentVolumeClaims: [],
-  templatePods: [],
-  templateSecrets: [],
-  templateServices: [],
-  templateStatefulSets: [],
-} as const;
-
 test("Project delete tool requires AI SDK approval", () => {
   const tools = createChatProjectTools({
     chatId: "chat-1",
@@ -41,14 +22,12 @@ test("Project delete tool requires AI SDK approval", () => {
   assert.ok("previewProjectDeletion" in tools);
 });
 
-test("Project deletion input binds the server preview summary to the approval", () => {
+test("Project deletion input uses the opaque preview and Project IDs", () => {
   assert.equal(
     deleteProjectInputSchema.safeParse({
       intention: "delete the selected Project after review",
       previewId: "preview-1",
-      projectDisplayName: "Payments",
       projectId: "project-1",
-      resourceSummary: COMPLETE_RESOURCE_SUMMARY,
     }).success,
     true
   );
@@ -56,9 +35,14 @@ test("Project deletion input binds the server preview summary to the approval", 
     deleteProjectInputSchema.safeParse({
       intention: "delete the selected Project after review",
       previewId: "preview-1",
-      projectDisplayName: "Payments",
       projectId: "project-1",
-      resourceSummary: { ap: ["api"] },
+    }).success,
+    true
+  );
+  assert.equal(
+    deleteProjectInputSchema.safeParse({
+      intention: "delete the selected Project after review",
+      projectId: "project-1",
     }).success,
     false
   );

--- a/apps/ui/src/features/chat/tool/chat-project-tools.ts
+++ b/apps/ui/src/features/chat/tool/chat-project-tools.ts
@@ -1,6 +1,5 @@
 import { tool } from "ai";
 import { z } from "zod";
-import type { ProjectChildResourceSummary } from "@/lib/project-persistence/delete-guard";
 import {
   deleteManagedProject,
   getManagedProject,
@@ -14,27 +13,6 @@ import {
 } from "./chat-tool-intention";
 
 const projectIdSchema = z.string().trim().min(1).max(256);
-const resourceNamesSchema = z.array(z.string().min(1).max(253)).max(10_000);
-const resourceSummarySchema = z
-  .object({
-    ap: resourceNamesSchema,
-    db: resourceNamesSchema,
-    template: resourceNamesSchema,
-    templateCertificates: resourceNamesSchema,
-    templateClusters: resourceNamesSchema,
-    templateConfigMaps: resourceNamesSchema,
-    templateDeployments: resourceNamesSchema,
-    templateIngresses: resourceNamesSchema,
-    templateIssuers: resourceNamesSchema,
-    templateJobs: resourceNamesSchema,
-    templateOpsRequests: resourceNamesSchema,
-    templatePersistentVolumeClaims: resourceNamesSchema,
-    templatePods: resourceNamesSchema,
-    templateSecrets: resourceNamesSchema,
-    templateServices: resourceNamesSchema,
-    templateStatefulSets: resourceNamesSchema,
-  })
-  .strict();
 
 const listProjectsInputSchema = z.object({
   intention: chatToolIntentionField,
@@ -53,9 +31,7 @@ const previewProjectDeletionInputSchema = z.object({
 export const deleteProjectInputSchema = z.object({
   intention: chatToolIntentionField,
   previewId: projectIdSchema,
-  projectDisplayName: z.string().trim().min(1).max(256),
   projectId: projectIdSchema,
-  resourceSummary: resourceSummarySchema,
 });
 
 export function createChatProjectTools(options: {
@@ -125,7 +101,7 @@ export function createChatProjectTools(options: {
     description: [
       "Delete exactly the Project represented by a current deletion preview.",
       "Call only after previewProjectDeletion and after the user has requested deletion of that exact Project.",
-      "Copy previewId, projectId, projectDisplayName, and resourceSummary verbatim from the preview output.",
+      "Copy previewId and projectId from the preview output; the server owns the display name and resource summary.",
       "Execution requires a final browser approval and rechecks the Project and resource summary before any deletion.",
     ].join(" "),
     inputSchema: deleteProjectInputSchema,
@@ -134,9 +110,6 @@ export function createChatProjectTools(options: {
       logChatToolIntention("deleteProject", input.intention);
       const result = await deleteManagedProject({
         actor,
-        expectedDisplayName: input.projectDisplayName,
-        expectedResourceSummary:
-          input.resourceSummary as unknown as ProjectChildResourceSummary,
         previewId: input.previewId,
         projectId: input.projectId,
       });

--- a/apps/ui/src/lib/project-persistence/project-management.test.ts
+++ b/apps/ui/src/lib/project-persistence/project-management.test.ts
@@ -24,9 +24,11 @@ mock.module(fileURLToPath(new URL("./db.ts", import.meta.url)), () => ({
   },
 }));
 
-const { deleteManagedProject, previewManagedProjectDeletion } = await import(
-  "./project-management"
-);
+const {
+  deleteManagedProject,
+  previewManagedProjectDeletion,
+  resourceSummaryFingerprint,
+} = await import("./project-management");
 
 before(async () => {
   harness = await createDeployTaskTestHarness();
@@ -37,7 +39,35 @@ after(async () => {
   await harness.close();
 });
 
-test("invalid deletion input does not consume a valid preview", async () => {
+test("resource summary fingerprints ignore object key order", () => {
+  const summary = {
+    ap: ["api"],
+    db: [],
+    template: ["template"],
+    templateCertificates: [],
+    templateClusters: [],
+    templateConfigMaps: [],
+    templateDeployments: [],
+    templateIngresses: [],
+    templateIssuers: [],
+    templateJobs: [],
+    templateOpsRequests: [],
+    templatePersistentVolumeClaims: [],
+    templatePods: [],
+    templateSecrets: [],
+    templateServices: [],
+    templateStatefulSets: [],
+  };
+  const reordered = Object.fromEntries(
+    Object.entries(summary).reverse()
+  ) as typeof summary;
+  assert.equal(
+    resourceSummaryFingerprint(summary),
+    resourceSummaryFingerprint(reordered)
+  );
+});
+
+test("valid preview deletes without model-provided resource details", async () => {
   assert.ok(projectDb);
   const namespace = "ns-preview";
   const projectId = "project-preview";
@@ -70,9 +100,7 @@ test("invalid deletion input does not consume a valid preview", async () => {
     assert.ok(preview);
 
     const invalid = await deleteManagedProject({
-      actor,
-      expectedDisplayName: preview.project.displayName,
-      expectedResourceSummary: {} as typeof preview.resourceSummary,
+      actor: { ...actor, chatId: "other-chat" },
       previewId: preview.previewId,
       projectId,
     });
@@ -86,8 +114,6 @@ test("invalid deletion input does not consume a valid preview", async () => {
 
     const deleted = await deleteManagedProject({
       actor,
-      expectedDisplayName: preview.project.displayName,
-      expectedResourceSummary: preview.resourceSummary,
       previewId: preview.previewId,
       projectId,
     });

--- a/apps/ui/src/lib/project-persistence/project-management.ts
+++ b/apps/ui/src/lib/project-persistence/project-management.ts
@@ -67,15 +67,36 @@ export type DeleteManagedProjectResult =
       ok: false;
     };
 
+const RESOURCE_SUMMARY_KEYS = [
+  "ap",
+  "db",
+  "template",
+  "templateCertificates",
+  "templateClusters",
+  "templateConfigMaps",
+  "templateDeployments",
+  "templateIngresses",
+  "templateIssuers",
+  "templateJobs",
+  "templateOpsRequests",
+  "templatePersistentVolumeClaims",
+  "templatePods",
+  "templateSecrets",
+  "templateServices",
+  "templateStatefulSets",
+] as const satisfies readonly (keyof ProjectChildResourceSummary)[];
+
 function sortedSummary(
   resources: ProjectChildResourceSummary
 ): ProjectChildResourceSummary {
   return Object.fromEntries(
-    Object.entries(resources).map(([key, names]) => [key, [...names].sort()])
+    RESOURCE_SUMMARY_KEYS.map((key) => [key, [...resources[key]].sort()])
   ) as unknown as ProjectChildResourceSummary;
 }
 
-function summaryFingerprint(resources: ProjectChildResourceSummary): string {
+export function resourceSummaryFingerprint(
+  resources: ProjectChildResourceSummary
+): string {
   return createHash("sha256")
     .update(JSON.stringify(sortedSummary(resources)))
     .digest("hex");
@@ -282,7 +303,7 @@ export async function previewManagedProjectDeletion(
       createdAt: now,
       displayName: project.displayName,
       expiresAt,
-      fingerprint: summaryFingerprint(resourceSummary),
+      fingerprint: resourceSummaryFingerprint(resourceSummary),
       id: previewId,
       namespace: actor.namespace,
       projectId,
@@ -297,7 +318,7 @@ export async function previewManagedProjectDeletion(
   });
   return {
     expiresAt: expiresAt.toISOString(),
-    fingerprint: summaryFingerprint(resourceSummary),
+    fingerprint: resourceSummaryFingerprint(resourceSummary),
     previewId,
     project,
     resourceSummary,
@@ -353,8 +374,6 @@ async function releaseDeletionOperation(
 
 export async function deleteManagedProject(input: {
   actor: ProjectManagementActor;
-  expectedDisplayName: string;
-  expectedResourceSummary: ProjectChildResourceSummary;
   previewId: string;
   projectId: string;
 }): Promise<DeleteManagedProjectResult> {
@@ -375,12 +394,6 @@ export async function deleteManagedProject(input: {
     )
     .limit(1);
   if (preview === undefined) {
-    return { code: "invalid_preview", ok: false };
-  }
-  if (
-    preview.displayName !== input.expectedDisplayName ||
-    preview.fingerprint !== summaryFingerprint(input.expectedResourceSummary)
-  ) {
     return { code: "invalid_preview", ok: false };
   }
   const [consumedPreview] = await getProjectDb()
@@ -422,7 +435,8 @@ export async function deleteManagedProject(input: {
   );
   if (
     project.displayName !== preview.displayName ||
-    summaryFingerprint(currentSummary) !== preview.fingerprint
+    resourceSummaryFingerprint(currentSummary) !==
+      resourceSummaryFingerprint(preview.resourceSummary)
   ) {
     await auditEvent({
       actor: input.actor,


### PR DESCRIPTION
## Summary

- Make Chat project deletion submit only the opaque `previewId` and `projectId`.
- Load the authoritative display name and resource summary from the stored deletion preview on the server.
- Confirm the exact Project ID in the approval card and keep resource-change rechecks before deletion.
- Stabilize resource-summary fingerprints with fixed key and array ordering.

## Root cause

The Chat tool required the model to echo the preview display name and full resource summary. The echoed payload could differ in ordering or shape from the stored preview, causing the deletion API to reject an otherwise valid preview with `invalid_preview`.

## Validation

- `bun typecheck`
- `bun check`
- Focused Chat/Project tests: 6 passing
