### PR TITLE
feat(devbox): delete paused runtimes after 24 hours

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -262,9 +262,9 @@ The immutable selection on a GitHub Deployment Task identifying the credential-o
 
 ### Deployment Task Retention
 
-The automatic cleanup boundary for Deployment Task records: terminal tasks, their events, transcripts, and per-task runtimes are purged after a fixed window. Active and blocked tasks are never purged, and there is no user-facing task deletion.
+The split lifecycle boundary between permanent Deployment Task history and its ephemeral execution runtime. Deployment Task rows, events, runner transcripts, and deployment results have no application-level retention deletion. A per-task Deploy Devbox is paused at a terminal outcome and deleted after 24 confirmed paused hours; the task then records `runtimeState=deleted`. There is no user-facing task deletion.
 
-_Avoid_: delete task, clear history.
+_Avoid_: task purge, clear history, archive task, Devbox retention as task retention.
 
 ### GitHub Connection
 

--- a/apps/ui/.env.example
+++ b/apps/ui/.env.example
@@ -30,7 +30,6 @@ TEMPLATE_PROVIDER_URL=
 
 DEVBOX_JWT_SIGNING_KEY=
 DEVBOX_RUNTIME_IMAGE=ghcr.io/labring-actions/devbox-base-images/sandbox-v1:2026-6-stable-zh-cn-amd64
-DEVBOX_ARCHIVE_AFTER_PAUSE_TIME=24h
 DEVBOX_JWT_TTL_SECONDS=14400
 # Optional. Defaults to the production brain-deploy skill source.
 DEPLOY_SKILL_SOURCE=

--- a/apps/ui/drizzle/0012_young_menace.sql
+++ b/apps/ui/drizzle/0012_young_menace.sql
@@ -1,0 +1,24 @@
+CREATE TABLE "sealai_assistant"."assistant_devbox_runtimes" (
+	"upstream_id" text PRIMARY KEY NOT NULL,
+	"namespace" text NOT NULL,
+	"runtime_name" text NOT NULL,
+	"pause_due_at" timestamp with time zone NOT NULL,
+	"paused_at" timestamp with time zone,
+	"delete_due_at" timestamp with time zone,
+	"cleanup_lease_owner" text,
+	"cleanup_lease_expires_at" timestamp with time zone,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "sealai_deployment"."deploy_tasks" ADD COLUMN "runtime_paused_at" timestamp with time zone;--> statement-breakpoint
+UPDATE "sealai_deployment"."deploy_tasks"
+SET "runtime_paused_at" = coalesce("updated_at", "completed_at", "created_at")
+WHERE "runtime_provider" = 'devbox'
+	AND lower(coalesce("runtime_state", '')) IN ('paused', 'archived')
+	AND "runtime_paused_at" IS NULL;--> statement-breakpoint
+ALTER TABLE "sealai_deployment"."deploy_tasks" ADD COLUMN "runtime_cleanup_lease_owner" text;--> statement-breakpoint
+ALTER TABLE "sealai_deployment"."deploy_tasks" ADD COLUMN "runtime_cleanup_lease_expires_at" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX "assistant_devbox_runtimes_pause_due_idx" ON "sealai_assistant"."assistant_devbox_runtimes" USING btree ("pause_due_at") WHERE "sealai_assistant"."assistant_devbox_runtimes"."paused_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "assistant_devbox_runtimes_delete_due_idx" ON "sealai_assistant"."assistant_devbox_runtimes" USING btree ("delete_due_at") WHERE "sealai_assistant"."assistant_devbox_runtimes"."delete_due_at" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "deploy_tasks_runtime_paused_idx" ON "sealai_deployment"."deploy_tasks" USING btree ("runtime_paused_at") WHERE "sealai_deployment"."deploy_tasks"."runtime_provider" = 'devbox' AND lower(coalesce("sealai_deployment"."deploy_tasks"."runtime_state", '')) IN ('paused', 'archived');

--- a/apps/ui/drizzle/meta/0012_snapshot.json
+++ b/apps/ui/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,2075 @@
+{
+  "id": "77542120-84d9-4b1b-8443-74f1cd7f5fc9",
+  "prevId": "cf4cbc1d-01b6-4fa3-936c-70d9d816091a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "sealai_assistant.assistant_chat_messages": {
+      "name": "assistant_chat_messages",
+      "schema": "sealai_assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assistant_chat_messages_chat_id_idx": {
+          "name": "assistant_chat_messages_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assistant_chat_messages_chat_id_created_idx": {
+          "name": "assistant_chat_messages_chat_id_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assistant_chat_messages_chat_id_assistant_chats_id_fk": {
+          "name": "assistant_chat_messages_chat_id_assistant_chats_id_fk",
+          "tableFrom": "assistant_chat_messages",
+          "tableTo": "assistant_chats",
+          "schemaTo": "sealai_assistant",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.assistant_chats": {
+      "name": "assistant_chats",
+      "schema": "sealai_assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_actor": {
+          "name": "workspace_actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Chat'"
+        },
+        "title_ai_generated": {
+          "name": "title_ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assistant_chats_updated_at_idx": {
+          "name": "assistant_chats_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assistant_chats_namespace_actor_updated_at_idx": {
+          "name": "assistant_chats_namespace_actor_updated_at_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_actor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.assistant_devbox_runtimes": {
+      "name": "assistant_devbox_runtimes",
+      "schema": "sealai_assistant",
+      "columns": {
+        "upstream_id": {
+          "name": "upstream_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_name": {
+          "name": "runtime_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pause_due_at": {
+          "name": "pause_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_due_at": {
+          "name": "delete_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_lease_owner": {
+          "name": "cleanup_lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_lease_expires_at": {
+          "name": "cleanup_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assistant_devbox_runtimes_pause_due_idx": {
+          "name": "assistant_devbox_runtimes_pause_due_idx",
+          "columns": [
+            {
+              "expression": "pause_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_assistant\".\"assistant_devbox_runtimes\".\"paused_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assistant_devbox_runtimes_delete_due_idx": {
+          "name": "assistant_devbox_runtimes_delete_due_idx",
+          "columns": [
+            {
+              "expression": "delete_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_assistant\".\"assistant_devbox_runtimes\".\"delete_due_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.assistant_entitlements": {
+      "name": "assistant_entitlements",
+      "schema": "sealai_assistant",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "free_turns_used": {
+          "name": "free_turns_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assistant_entitlements_updated_at_idx": {
+          "name": "assistant_entitlements_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.github_app_install_sessions": {
+      "name": "github_app_install_sessions",
+      "schema": "sealai_assistant",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_actor": {
+          "name": "workspace_actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "owner_identity_version": {
+          "name": "owner_identity_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "return_path": {
+          "name": "return_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_app_install_sessions_expires_at_idx": {
+          "name": "github_app_install_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_app_install_sessions_namespace_idx": {
+          "name": "github_app_install_sessions_namespace_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.github_connections": {
+      "name": "github_connections",
+      "schema": "sealai_assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github_app'"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'User'"
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_connections_updated_at_idx": {
+          "name": "github_connections_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_namespace_updated_at_idx": {
+          "name": "github_connections_namespace_updated_at_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_namespace_unique_idx": {
+          "name": "github_connections_namespace_unique_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_installation_idx": {
+          "name": "github_connections_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.github_oauth_connections": {
+      "name": "github_oauth_connections",
+      "schema": "sealai_assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_actor": {
+          "name": "workspace_actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "owner_identity_version": {
+          "name": "owner_identity_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "github_login": {
+          "name": "github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bearer'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_oauth_connections_updated_at_idx": {
+          "name": "github_oauth_connections_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_oauth_connections_github_login_idx": {
+          "name": "github_oauth_connections_github_login_idx",
+          "columns": [
+            {
+              "expression": "github_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_oauth_connections_current_owner_unique_idx": {
+          "name": "github_oauth_connections_current_owner_unique_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_actor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sealai_assistant\".\"github_oauth_connections\".\"owner_identity_version\" = 2",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.identity_fingerprints": {
+      "name": "identity_fingerprints",
+      "schema": "sealai_assistant",
+      "columns": {
+        "cr_name": {
+          "name": "cr_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_uid": {
+          "name": "user_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minted_at": {
+          "name": "minted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_deployment.deploy_task_events": {
+      "name": "deploy_task_events",
+      "schema": "sealai_deployment",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nextval('sealai_deployment.deploy_task_events_seq'::regclass)"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deploy_task_events_task_created_at_idx": {
+          "name": "deploy_task_events_task_created_at_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deploy_task_events_task_id_deploy_tasks_id_fk": {
+          "name": "deploy_task_events_task_id_deploy_tasks_id_fk",
+          "tableFrom": "deploy_task_events",
+          "tableTo": "deploy_tasks",
+          "schemaTo": "sealai_deployment",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "deploy_task_events_pk": {
+          "name": "deploy_task_events_pk",
+          "columns": ["task_id", "seq"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_deployment.deploy_task_messages": {
+      "name": "deploy_task_messages",
+      "schema": "sealai_deployment",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deploy_task_messages_task_id_idx": {
+          "name": "deploy_task_messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_task_messages_task_created_idx": {
+          "name": "deploy_task_messages_task_created_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deploy_task_messages_task_id_deploy_tasks_id_fk": {
+          "name": "deploy_task_messages_task_id_deploy_tasks_id_fk",
+          "tableFrom": "deploy_task_messages",
+          "tableTo": "deploy_tasks",
+          "schemaTo": "sealai_deployment",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_deployment.deploy_tasks": {
+      "name": "deploy_tasks",
+      "schema": "sealai_deployment",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_uid": {
+          "name": "project_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creating_actor": {
+          "name": "creating_actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_binding": {
+          "name": "credential_binding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_connection_id": {
+          "name": "github_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_from": {
+          "name": "created_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_name": {
+          "name": "runtime_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_paused_at": {
+          "name": "runtime_paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_cleanup_lease_owner": {
+          "name": "runtime_cleanup_lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_cleanup_lease_expires_at": {
+          "name": "runtime_cleanup_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_url": {
+          "name": "gateway_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_session_id": {
+          "name": "gateway_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_thread_id": {
+          "name": "gateway_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_turn_id": {
+          "name": "gateway_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_state_snapshot": {
+          "name": "gateway_state_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_details": {
+          "name": "failure_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_summary": {
+          "name": "artifact_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "canvas_projection": {
+          "name": "canvas_projection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "timeline_snapshot": {
+          "name": "timeline_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocking_inputs": {
+          "name": "blocking_inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "preview_url": {
+          "name": "preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_url": {
+          "name": "result_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_epoch": {
+          "name": "lease_epoch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_claimed_at": {
+          "name": "lease_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retried_from_task_id": {
+          "name": "retried_from_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deploy_tasks_namespace_updated_at_idx": {
+          "name": "deploy_tasks_namespace_updated_at_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_project_uid_updated_at_idx": {
+          "name": "deploy_tasks_project_uid_updated_at_idx",
+          "columns": [
+            {
+              "expression": "project_uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_status_updated_at_idx": {
+          "name": "deploy_tasks_status_updated_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_leased_expiry_idx": {
+          "name": "deploy_tasks_leased_expiry_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"status\" IN ('running', 'applying')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_queued_created_idx": {
+          "name": "deploy_tasks_queued_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_terminal_completed_idx": {
+          "name": "deploy_tasks_terminal_completed_idx",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"status\" IN ('completed', 'failed', 'cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_runtime_paused_idx": {
+          "name": "deploy_tasks_runtime_paused_idx",
+          "columns": [
+            {
+              "expression": "runtime_paused_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"runtime_provider\" = 'devbox' AND lower(coalesce(\"sealai_deployment\".\"deploy_tasks\".\"runtime_state\", '')) IN ('paused', 'archived')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_one_active_clone_idx": {
+          "name": "deploy_tasks_one_active_clone_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retried_from_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"retried_from_task_id\" IS NOT NULL AND \"sealai_deployment\".\"deploy_tasks\".\"status\" IN ('queued', 'running', 'blocked', 'applying')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_onboarding.onboarding_profiles": {
+      "name": "onboarding_profiles",
+      "schema": "sealai_onboarding",
+      "columns": {
+        "user_uid": {
+          "name": "user_uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dismissed_at_step": {
+          "name": "dismissed_at_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_type": {
+          "name": "role_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_other_text": {
+          "name": "role_other_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_context": {
+          "name": "usage_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_other_text": {
+          "name": "usage_other_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_tags": {
+          "name": "priority_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_display_order": {
+          "name": "priority_display_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_other_text": {
+          "name": "priority_other_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_goal_text": {
+          "name": "open_goal_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_canvas_layouts": {
+      "name": "project_canvas_layouts",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_uid": {
+          "name": "project_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name_snapshot": {
+          "name": "project_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "nodes": {
+          "name": "nodes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_canvas_layouts_updated_at_idx": {
+          "name": "project_canvas_layouts_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_canvas_layouts_pk": {
+          "name": "project_canvas_layouts_pk",
+          "columns": ["namespace", "project_uid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_delete_operations": {
+      "name": "project_delete_operations",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_uid": {
+          "name": "actor_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_id": {
+          "name": "preview_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_delete_operations_expires_at_idx": {
+          "name": "project_delete_operations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_delete_operations_pk": {
+          "name": "project_delete_operations_pk",
+          "columns": ["namespace", "project_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_delete_previews": {
+      "name": "project_delete_previews",
+      "schema": "sealai_project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_uid": {
+          "name": "actor_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_summary": {
+          "name": "resource_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_delete_previews_expires_at_idx": {
+          "name": "project_delete_previews_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_delete_previews_target_idx": {
+          "name": "project_delete_previews_target_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_delete_previews_pk": {
+          "name": "project_delete_previews_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_management_audit_events": {
+      "name": "project_management_audit_events",
+      "schema": "sealai_project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_uid": {
+          "name": "actor_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_summary": {
+          "name": "resource_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_management_audit_events_target_idx": {
+          "name": "project_management_audit_events_target_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_management_audit_events_pk": {
+          "name": "project_management_audit_events_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_navigation_preferences": {
+      "name": "project_navigation_preferences",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_project_ids": {
+          "name": "pinned_project_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_navigation_preferences_updated_at_idx": {
+          "name": "project_navigation_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_navigation_preferences_pk": {
+          "name": "project_navigation_preferences_pk",
+          "columns": ["namespace"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.projects": {
+      "name": "projects",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_namespace_lower_display_name_idx": {
+          "name": "projects_namespace_lower_display_name_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"display_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "projects_pk": {
+          "name": "projects_pk",
+          "columns": ["namespace", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "sealai_assistant": "sealai_assistant",
+    "sealai_deployment": "sealai_deployment",
+    "sealai_onboarding": "sealai_onboarding",
+    "sealai_project": "sealai_project"
+  },
+  "sequences": {
+    "sealai_deployment.deploy_task_events_seq": {
+      "name": "deploy_task_events_seq",
+      "schema": "sealai_deployment",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/ui/drizzle/meta/_journal.json
+++ b/apps/ui/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1785920126051,
       "tag": "0011_onboarding_profiles",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1786429769165,
+      "tag": "0012_young_menace",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/ui/scripts/devbox-api-smoke.mjs
+++ b/apps/ui/scripts/devbox-api-smoke.mjs
@@ -51,7 +51,6 @@ const token = await new SignJWT({ namespace })
 const name = `sealai-curl-${Date.now()}`;
 const url = `${devboxApiBaseUrl}/api/v1/devbox`;
 const body = {
-  archiveAfterPauseTime: env.DEVBOX_ARCHIVE_AFTER_PAUSE_TIME || "24h",
   env: { SEALAI_ASSISTANT_NAMESPACE: namespace },
   kubeAccess: { enabled: true, roleTemplate: "edit" },
   labels: [

--- a/apps/ui/src/features/chat/devbox/chat-runtime.test.ts
+++ b/apps/ui/src/features/chat/devbox/chat-runtime.test.ts
@@ -2,6 +2,9 @@ import { mock, test } from "bun:test";
 import assert from "node:assert/strict";
 
 mock.module("server-only", () => ({}));
+mock.module("./lifecycle-registration", () => ({
+  recordChatDevboxActivity: () => Promise.resolve(),
+}));
 
 const { bootstrapChatDevboxIfNeeded } = await import("./chat-runtime");
 

--- a/apps/ui/src/features/chat/devbox/chat-runtime.ts
+++ b/apps/ui/src/features/chat/devbox/chat-runtime.ts
@@ -258,12 +258,15 @@ async function ensureChatDevbox(
   const upstreamID = runtimeUpstreamId(runtimeHash);
   const pauseAt = getPauseAt();
 
-  await recordChatDevboxActivity({
-    namespace: authNamespace,
-    pauseDueAt: new Date(pauseAt),
-    runtimeName: name,
-    upstreamId: upstreamID,
-  });
+  await recordChatDevboxActivity(
+    {
+      namespace: authNamespace,
+      pauseDueAt: new Date(pauseAt),
+      runtimeName: name,
+      upstreamId: upstreamID,
+    },
+    signal
+  );
 
   const existing = (await listDevboxes(authNamespace, upstreamID, signal)).data
     .items[0];

--- a/apps/ui/src/features/chat/devbox/chat-runtime.ts
+++ b/apps/ui/src/features/chat/devbox/chat-runtime.ts
@@ -12,11 +12,9 @@ import {
   refreshDevboxPause,
   resumeDevbox,
 } from "@/lib/devbox/client";
-import {
-  getDevboxArchiveAfterPauseTime,
-  getDevboxDefaultImage,
-} from "@/lib/devbox/config";
+import { getDevboxDefaultImage } from "@/lib/devbox/config";
 import type { DevboxInfo } from "@/lib/devbox/types";
+import { recordChatDevboxActivity } from "./lifecycle-registration";
 
 const DEVBOX_NAME_PREFIX = "sealai-chat";
 const DEVBOX_RUNTIME_READY_TIMEOUT_MS = 60_000;
@@ -172,15 +170,11 @@ async function ensureRunningDevbox(
 async function refreshLease(
   authNamespace: string,
   name: string,
+  pauseAt: string,
   signal?: AbortSignal
 ): Promise<void> {
   signal?.throwIfAborted();
-  await refreshDevboxPause(
-    authNamespace,
-    name,
-    { pauseAt: getPauseAt() },
-    signal
-  );
+  await refreshDevboxPause(authNamespace, name, { pauseAt }, signal);
 }
 
 function shellQuote(value: string): string {
@@ -262,12 +256,20 @@ async function ensureChatDevbox(
   const runtimeHash = hashRuntimeIdentity(kubeconfig, options.namespace);
   const name = runtimeName(runtimeHash);
   const upstreamID = runtimeUpstreamId(runtimeHash);
+  const pauseAt = getPauseAt();
+
+  await recordChatDevboxActivity({
+    namespace: authNamespace,
+    pauseDueAt: new Date(pauseAt),
+    runtimeName: name,
+    upstreamId: upstreamID,
+  });
 
   const existing = (await listDevboxes(authNamespace, upstreamID, signal)).data
     .items[0];
   if (existing != null) {
     await ensureRunningDevbox(authNamespace, existing.name, signal);
-    await refreshLease(authNamespace, existing.name, signal);
+    await refreshLease(authNamespace, existing.name, pauseAt, signal);
     await assertDevboxKubectlReady(
       authNamespace,
       existing.name,
@@ -281,7 +283,6 @@ async function ensureChatDevbox(
   await createDevbox(
     authNamespace,
     {
-      archiveAfterPauseTime: getDevboxArchiveAfterPauseTime(),
       env: {
         SEALAI_ASSISTANT_NAMESPACE: options.namespace,
       },
@@ -295,7 +296,7 @@ async function ensureChatDevbox(
         { key: "app.kubernetes.io/component", value: "assistant-runtime" },
       ],
       name,
-      pauseAt: getPauseAt(),
+      pauseAt,
       upstreamID,
     },
     signal

--- a/apps/ui/src/features/chat/devbox/lifecycle-registration.ts
+++ b/apps/ui/src/features/chat/devbox/lifecycle-registration.ts
@@ -2,11 +2,14 @@ import "server-only";
 
 import { recordChatDevboxActivity as recordLifecycleActivity } from "./lifecycle";
 
-export async function recordChatDevboxActivity(input: {
-  namespace: string;
-  pauseDueAt: Date;
-  runtimeName: string;
-  upstreamId: string;
-}): Promise<void> {
-  await recordLifecycleActivity(input);
+export async function recordChatDevboxActivity(
+  input: {
+    namespace: string;
+    pauseDueAt: Date;
+    runtimeName: string;
+    upstreamId: string;
+  },
+  signal?: AbortSignal
+): Promise<void> {
+  await recordLifecycleActivity(input, undefined, signal);
 }

--- a/apps/ui/src/features/chat/devbox/lifecycle-registration.ts
+++ b/apps/ui/src/features/chat/devbox/lifecycle-registration.ts
@@ -1,0 +1,12 @@
+import "server-only";
+
+import { recordChatDevboxActivity as recordLifecycleActivity } from "./lifecycle";
+
+export async function recordChatDevboxActivity(input: {
+  namespace: string;
+  pauseDueAt: Date;
+  runtimeName: string;
+  upstreamId: string;
+}): Promise<void> {
+  await recordLifecycleActivity(input);
+}

--- a/apps/ui/src/features/chat/devbox/lifecycle.test.ts
+++ b/apps/ui/src/features/chat/devbox/lifecycle.test.ts
@@ -1,0 +1,271 @@
+import { afterAll, beforeAll, mock, test } from "bun:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+import { migrate } from "drizzle-orm/pglite/migrator";
+
+import type { AssistantPgDatabase } from "../persistence/db";
+import { assistantDevboxRuntimes } from "../persistence/schema";
+
+mock.module("server-only", () => ({}));
+
+const { recordChatDevboxActivity, runChatDevboxLifecycleSweep } = await import(
+  "./lifecycle"
+);
+
+const DAY_MS = 24 * 60 * 60_000;
+const NOW = new Date("2026-08-05T00:00:00.000Z");
+let pglite: PGlite;
+let db: AssistantPgDatabase;
+const lifecycleSchema = { assistantDevboxRuntimes };
+let testDb: ReturnType<typeof drizzle<typeof lifecycleSchema>>;
+
+beforeAll(async () => {
+  pglite = new PGlite();
+  testDb = drizzle(pglite, { schema: lifecycleSchema });
+  db = testDb as unknown as AssistantPgDatabase;
+  const migrationsFolder = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../../drizzle"
+  );
+  await migrate(testDb, { migrationsFolder });
+});
+
+afterAll(async () => {
+  await pglite.close();
+});
+
+async function clearRuntimes() {
+  await db.delete(assistantDevboxRuntimes);
+}
+
+test("activity resets a paused runtime before external resume", async () => {
+  await clearRuntimes();
+  await db.insert(assistantDevboxRuntimes).values({
+    deleteDueAt: NOW,
+    namespace: "ns-test",
+    pausedAt: new Date(NOW.getTime() - DAY_MS),
+    pauseDueAt: new Date(NOW.getTime() - 2 * DAY_MS),
+    runtimeName: "runtime-a",
+    upstreamId: "upstream-a",
+  });
+  const nextPause = new Date(NOW.getTime() + 5 * 60 * 60_000);
+
+  await recordChatDevboxActivity(
+    {
+      namespace: "ns-test",
+      pauseDueAt: nextPause,
+      runtimeName: "runtime-a",
+      upstreamId: "upstream-a",
+    },
+    db
+  );
+
+  const [runtime] = await db
+    .select()
+    .from(assistantDevboxRuntimes)
+    .where(eq(assistantDevboxRuntimes.upstreamId, "upstream-a"));
+  assert.equal(runtime?.pausedAt, null);
+  assert.equal(runtime?.deleteDueAt, null);
+  assert.equal(runtime?.pauseDueAt.toISOString(), nextPause.toISOString());
+});
+
+test("a chat Devbox is deleted only after 24 confirmed paused hours", async () => {
+  await clearRuntimes();
+  await db.insert(assistantDevboxRuntimes).values({
+    namespace: "ns-test",
+    pauseDueAt: new Date(NOW.getTime() - 1),
+    runtimeName: "runtime-b",
+    upstreamId: "upstream-b",
+  });
+  const paused: string[] = [];
+  const deleted: string[] = [];
+  const api = {
+    delete(namespace: string, runtimeName: string) {
+      deleted.push(`${namespace}/${runtimeName}`);
+      return Promise.resolve("deleted" as const);
+    },
+    pause(namespace: string, runtimeName: string) {
+      paused.push(`${namespace}/${runtimeName}`);
+      return Promise.resolve("paused" as const);
+    },
+  };
+
+  const first = await runChatDevboxLifecycleSweep({ api, db, now: () => NOW });
+  assert.equal(first.paused, 1);
+  assert.equal(first.deleted, 0);
+  assert.deepEqual(paused, ["ns-test/runtime-b"]);
+
+  const beforeDue = await runChatDevboxLifecycleSweep({
+    api,
+    db,
+    now: () => new Date(NOW.getTime() + DAY_MS - 1),
+  });
+  assert.equal(beforeDue.deleted, 0);
+
+  const afterDue = await runChatDevboxLifecycleSweep({
+    api,
+    db,
+    now: () => new Date(NOW.getTime() + DAY_MS + 1),
+  });
+  assert.equal(afterDue.deleted, 1);
+  assert.deepEqual(deleted, ["ns-test/runtime-b"]);
+  const [runtime] = await db
+    .select()
+    .from(assistantDevboxRuntimes)
+    .where(eq(assistantDevboxRuntimes.upstreamId, "upstream-b"));
+  assert.equal(runtime, undefined);
+});
+
+test("delete failures retain lifecycle state for the next sweep", async () => {
+  await clearRuntimes();
+  await db.insert(assistantDevboxRuntimes).values({
+    deleteDueAt: new Date(NOW.getTime() - 1),
+    namespace: "ns-test",
+    pausedAt: new Date(NOW.getTime() - DAY_MS - 1),
+    pauseDueAt: new Date(NOW.getTime() - 2 * DAY_MS),
+    runtimeName: "runtime-c",
+    upstreamId: "upstream-c",
+  });
+  let failDelete = true;
+  const api = {
+    delete() {
+      if (failDelete) {
+        failDelete = false;
+        return Promise.reject(new Error("delete unavailable"));
+      }
+      return Promise.resolve("deleted" as const);
+    },
+    pause: () => Promise.resolve("paused" as const),
+  };
+
+  const first = await runChatDevboxLifecycleSweep({ api, db, now: () => NOW });
+  assert.equal(first.deleteFailed, 1);
+  assert.equal(
+    (
+      await db
+        .select()
+        .from(assistantDevboxRuntimes)
+        .where(eq(assistantDevboxRuntimes.upstreamId, "upstream-c"))
+    ).length,
+    1
+  );
+
+  await db
+    .update(assistantDevboxRuntimes)
+    .set({ cleanupLeaseExpiresAt: new Date(0) })
+    .where(eq(assistantDevboxRuntimes.upstreamId, "upstream-c"));
+  const second = await runChatDevboxLifecycleSweep({ api, db, now: () => NOW });
+  assert.equal(second.deleted, 1);
+});
+
+test("concurrent chat lifecycle sweeps claim a runtime only once", async () => {
+  await clearRuntimes();
+  const currentNow = new Date();
+  await db.insert(assistantDevboxRuntimes).values({
+    namespace: "ns-test",
+    pauseDueAt: new Date(currentNow.getTime() - 1),
+    runtimeName: "runtime-d",
+    upstreamId: "upstream-d",
+  });
+  let pauseCalls = 0;
+  let releasePause!: () => void;
+  let markPauseStarted!: () => void;
+  const pauseStarted = new Promise<void>((resolve) => {
+    markPauseStarted = resolve;
+  });
+  const pauseBlocked = new Promise<void>((resolve) => {
+    releasePause = resolve;
+  });
+  const api = {
+    delete: () => Promise.resolve("deleted" as const),
+    async pause() {
+      pauseCalls += 1;
+      markPauseStarted();
+      await pauseBlocked;
+      return "paused" as const;
+    },
+  };
+
+  const first = runChatDevboxLifecycleSweep({
+    api,
+    db,
+    now: () => currentNow,
+  });
+  await pauseStarted;
+  const second = await runChatDevboxLifecycleSweep({
+    api,
+    db,
+    now: () => currentNow,
+  });
+
+  assert.equal(second.paused, 0);
+  assert.equal(pauseCalls, 1);
+  releasePause();
+  assert.equal((await first).paused, 1);
+});
+
+test("activity waits for an in-flight delete claim before recreating the ledger", async () => {
+  await clearRuntimes();
+  const currentNow = new Date();
+  await db.insert(assistantDevboxRuntimes).values({
+    deleteDueAt: new Date(currentNow.getTime() - 1),
+    namespace: "ns-test",
+    pausedAt: new Date(currentNow.getTime() - DAY_MS - 1),
+    pauseDueAt: new Date(currentNow.getTime() - 2 * DAY_MS),
+    runtimeName: "runtime-e",
+    upstreamId: "upstream-e",
+  });
+  let releaseDelete!: () => void;
+  let markDeleteStarted!: () => void;
+  const deleteStarted = new Promise<void>((resolve) => {
+    markDeleteStarted = resolve;
+  });
+  const deleteBlocked = new Promise<void>((resolve) => {
+    releaseDelete = resolve;
+  });
+  const api = {
+    async delete() {
+      markDeleteStarted();
+      await deleteBlocked;
+      return "deleted" as const;
+    },
+    pause: () => Promise.resolve("paused" as const),
+  };
+
+  const sweep = runChatDevboxLifecycleSweep({
+    api,
+    db,
+    now: () => currentNow,
+  });
+  await deleteStarted;
+  const nextPause = new Date(currentNow.getTime() + 5 * 60 * 60_000);
+  let activityFinished = false;
+  const activity = recordChatDevboxActivity(
+    {
+      namespace: "ns-test",
+      pauseDueAt: nextPause,
+      runtimeName: "runtime-e",
+      upstreamId: "upstream-e",
+    },
+    db
+  ).then(() => {
+    activityFinished = true;
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(activityFinished, false);
+  releaseDelete();
+  await Promise.all([sweep, activity]);
+
+  const [runtime] = await db
+    .select()
+    .from(assistantDevboxRuntimes)
+    .where(eq(assistantDevboxRuntimes.upstreamId, "upstream-e"));
+  assert.equal(runtime?.pausedAt, null);
+  assert.equal(runtime?.deleteDueAt, null);
+  assert.equal(runtime?.pauseDueAt.toISOString(), nextPause.toISOString());
+});

--- a/apps/ui/src/features/chat/devbox/lifecycle.test.ts
+++ b/apps/ui/src/features/chat/devbox/lifecycle.test.ts
@@ -269,3 +269,32 @@ test("activity waits for an in-flight delete claim before recreating the ledger"
   assert.equal(runtime?.deleteDueAt, null);
   assert.equal(runtime?.pauseDueAt.toISOString(), nextPause.toISOString());
 });
+
+test("activity cleanup wait honors request cancellation", async () => {
+  await clearRuntimes();
+  const currentNow = new Date();
+  await db.insert(assistantDevboxRuntimes).values({
+    cleanupLeaseExpiresAt: new Date(currentNow.getTime() + DAY_MS),
+    cleanupLeaseOwner: "active-cleanup",
+    namespace: "ns-test",
+    pauseDueAt: new Date(currentNow.getTime() - 1),
+    runtimeName: "runtime-f",
+    upstreamId: "upstream-f",
+  });
+  const controller = new AbortController();
+  const activity = recordChatDevboxActivity(
+    {
+      namespace: "ns-test",
+      pauseDueAt: new Date(currentNow.getTime() + 5 * 60 * 60_000),
+      runtimeName: "runtime-f",
+      upstreamId: "upstream-f",
+    },
+    db,
+    controller.signal
+  );
+
+  setTimeout(() => controller.abort(), 10);
+  await assert.rejects(activity, (error: unknown) => {
+    return error instanceof DOMException && error.name === "AbortError";
+  });
+});

--- a/apps/ui/src/features/chat/devbox/lifecycle.test.ts
+++ b/apps/ui/src/features/chat/devbox/lifecycle.test.ts
@@ -208,6 +208,146 @@ test("concurrent chat lifecycle sweeps claim a runtime only once", async () => {
   assert.equal((await first).paused, 1);
 });
 
+test("chat lifecycle claims only the concurrency wave being processed", async () => {
+  await clearRuntimes();
+  const currentNow = new Date();
+  await db.insert(assistantDevboxRuntimes).values(
+    Array.from({ length: 5 }, (_, index) => ({
+      namespace: "ns-test",
+      pauseDueAt: new Date(currentNow.getTime() - 5 + index),
+      runtimeName: `runtime-wave-${index}`,
+      upstreamId: `upstream-wave-${index}`,
+    }))
+  );
+  const started: string[] = [];
+  let active = 0;
+  let maxActive = 0;
+  let releaseFirstWave!: () => void;
+  let markFirstWaveStarted!: () => void;
+  const firstWaveStarted = new Promise<void>((resolve) => {
+    markFirstWaveStarted = resolve;
+  });
+  const firstWaveBlocked = new Promise<void>((resolve) => {
+    releaseFirstWave = resolve;
+  });
+  const api = {
+    delete: () => Promise.resolve("deleted" as const),
+    async pause(_namespace: string, runtimeName: string) {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      started.push(runtimeName);
+      if (started.length === 4) {
+        markFirstWaveStarted();
+      }
+      if (runtimeName !== "runtime-wave-4") {
+        await firstWaveBlocked;
+      }
+      active -= 1;
+      return "paused" as const;
+    },
+  };
+
+  const sweep = runChatDevboxLifecycleSweep({
+    api,
+    db,
+    now: () => currentNow,
+  });
+  await firstWaveStarted;
+
+  const [queuedRuntime] = await db
+    .select()
+    .from(assistantDevboxRuntimes)
+    .where(eq(assistantDevboxRuntimes.upstreamId, "upstream-wave-4"));
+  assert.equal(queuedRuntime?.cleanupLeaseOwner, null);
+  assert.equal(started.length, 4);
+
+  releaseFirstWave();
+  const summary = await sweep;
+  assert.equal(summary.paused, 5);
+  assert.equal(maxActive, 4);
+  assert.equal(started.length, 5);
+});
+
+test("chat lifecycle skips an external operation after losing its claim", async () => {
+  await clearRuntimes();
+  const currentNow = new Date();
+  await db.insert(assistantDevboxRuntimes).values({
+    namespace: "ns-test",
+    pauseDueAt: new Date(currentNow.getTime() - 1),
+    runtimeName: "runtime-stolen",
+    upstreamId: "upstream-stolen",
+  });
+  let stealNextClaim = true;
+  const racingDb = new Proxy(db, {
+    get(target, property) {
+      if (property === "execute") {
+        return async (query: Parameters<AssistantPgDatabase["execute"]>[0]) => {
+          const result = await target.execute(query);
+          if (stealNextClaim) {
+            stealNextClaim = false;
+            await target
+              .update(assistantDevboxRuntimes)
+              .set({
+                cleanupLeaseExpiresAt: new Date(currentNow.getTime() + DAY_MS),
+                cleanupLeaseOwner: "replacement-owner",
+              })
+              .where(eq(assistantDevboxRuntimes.upstreamId, "upstream-stolen"));
+          }
+          return result;
+        };
+      }
+      const value = Reflect.get(target, property, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  }) as AssistantPgDatabase;
+  let pauseCalls = 0;
+
+  const summary = await runChatDevboxLifecycleSweep({
+    api: {
+      delete: () => Promise.resolve("deleted" as const),
+      pause() {
+        pauseCalls += 1;
+        return Promise.resolve("paused" as const);
+      },
+    },
+    db: racingDb,
+    now: () => currentNow,
+  });
+
+  assert.equal(pauseCalls, 0);
+  assert.equal(summary.paused, 0);
+  assert.equal(summary.pauseFailed, 1);
+});
+
+test("chat lifecycle keeps the total sweep batch bounded", async () => {
+  await clearRuntimes();
+  const currentNow = new Date();
+  await db.insert(assistantDevboxRuntimes).values(
+    Array.from({ length: 21 }, (_, index) => ({
+      namespace: "ns-test",
+      pauseDueAt: new Date(currentNow.getTime() - 21 + index),
+      runtimeName: `runtime-batch-${index}`,
+      upstreamId: `upstream-batch-${index}`,
+    }))
+  );
+
+  const summary = await runChatDevboxLifecycleSweep({
+    api: {
+      delete: () => Promise.resolve("deleted" as const),
+      pause: () => Promise.resolve("paused" as const),
+    },
+    db,
+    now: () => currentNow,
+  });
+  const runtimes = await db.select().from(assistantDevboxRuntimes);
+
+  assert.equal(summary.paused, 20);
+  assert.equal(
+    runtimes.filter((runtime) => runtime.pausedAt === null).length,
+    1
+  );
+});
+
 test("activity waits for an in-flight delete claim before recreating the ledger", async () => {
   await clearRuntimes();
   const currentNow = new Date();

--- a/apps/ui/src/features/chat/devbox/lifecycle.ts
+++ b/apps/ui/src/features/chat/devbox/lifecycle.ts
@@ -193,7 +193,8 @@ function claimedRuntimesOf(result: unknown): ClaimedChatDevboxRuntime[] {
 async function claimPauseCandidates(
   ctx: ChatDevboxLifecycleContext,
   now: Date,
-  leaseOwner: string
+  leaseOwner: string,
+  limit: number
 ): Promise<ClaimedChatDevboxRuntime[]> {
   return claimedRuntimesOf(
     await ctx.db.execute(sql`
@@ -208,7 +209,7 @@ async function claimPauseCandidates(
           )
         ORDER BY "pause_due_at"
         FOR UPDATE SKIP LOCKED
-        LIMIT ${LIFECYCLE_BATCH_SIZE}
+        LIMIT ${limit}
       )
       UPDATE ${assistantDevboxRuntimes} runtime
       SET "cleanup_lease_owner" = ${leaseOwner},
@@ -224,7 +225,8 @@ async function claimPauseCandidates(
 async function claimDeleteCandidates(
   ctx: ChatDevboxLifecycleContext,
   now: Date,
-  leaseOwner: string
+  leaseOwner: string,
+  limit: number
 ): Promise<ClaimedChatDevboxRuntime[]> {
   return claimedRuntimesOf(
     await ctx.db.execute(sql`
@@ -239,7 +241,7 @@ async function claimDeleteCandidates(
           )
         ORDER BY "delete_due_at"
         FOR UPDATE SKIP LOCKED
-        LIMIT ${LIFECYCLE_BATCH_SIZE}
+        LIMIT ${limit}
       )
       UPDATE ${assistantDevboxRuntimes} runtime
       SET "cleanup_lease_owner" = ${leaseOwner},
@@ -250,6 +252,28 @@ async function claimDeleteCandidates(
       RETURNING runtime."upstream_id", runtime."namespace", runtime."runtime_name"
     `)
   );
+}
+
+async function renewCleanupClaim(
+  ctx: ChatDevboxLifecycleContext,
+  runtime: ClaimedChatDevboxRuntime,
+  leaseOwner: string
+): Promise<boolean> {
+  const renewed = await ctx.db
+    .update(assistantDevboxRuntimes)
+    .set({
+      cleanupLeaseExpiresAt: sql`now() + ${intervalFromMs(LIFECYCLE_CLAIM_TTL_MS)}`,
+      updatedAt: sql`now()`,
+    })
+    .where(
+      and(
+        eq(assistantDevboxRuntimes.upstreamId, runtime.upstreamId),
+        eq(assistantDevboxRuntimes.cleanupLeaseOwner, leaseOwner),
+        sql`${assistantDevboxRuntimes.cleanupLeaseExpiresAt} > now()`
+      )
+    )
+    .returning({ upstreamId: assistantDevboxRuntimes.upstreamId });
+  return renewed.length > 0;
 }
 
 async function releaseFailedClaim(
@@ -273,42 +297,131 @@ async function releaseFailedClaim(
     );
 }
 
-async function mapWithConcurrency<T>(
+async function runConcurrentWave<T>(
   values: readonly T[],
   operation: (value: T) => Promise<boolean>
 ): Promise<{ failed: number; succeeded: number }> {
-  let failed = 0;
-  let succeeded = 0;
-  for (let index = 0; index < values.length; index += LIFECYCLE_CONCURRENCY) {
-    const outcomes = await Promise.all(
-      values.slice(index, index + LIFECYCLE_CONCURRENCY).map(async (value) => {
-        try {
-          return await operation(value);
-        } catch (error) {
-          console.error("[chat-devbox-lifecycle] operation failed:", error);
-          return false;
-        }
-      })
-    );
-    succeeded += outcomes.filter(Boolean).length;
-    failed += outcomes.filter((outcome) => !outcome).length;
+  if (values.length > LIFECYCLE_CONCURRENCY) {
+    throw new Error("A Devbox cleanup wave exceeds the concurrency limit");
   }
-  return { failed, succeeded };
+  const outcomes = await Promise.all(
+    values.map(async (value) => {
+      try {
+        return await operation(value);
+      } catch (error) {
+        console.error("[chat-devbox-lifecycle] operation failed:", error);
+        return false;
+      }
+    })
+  );
+  return {
+    failed: outcomes.filter((outcome) => !outcome).length,
+    succeeded: outcomes.filter(Boolean).length,
+  };
+}
+
+async function processClaimedWaves(
+  claim: (
+    leaseOwner: string,
+    limit: number
+  ) => Promise<ClaimedChatDevboxRuntime[]>,
+  operation: (
+    runtime: ClaimedChatDevboxRuntime,
+    leaseOwner: string
+  ) => Promise<boolean>
+): Promise<{ failed: number; succeeded: number }> {
+  // Keep queued rows unclaimed so every lease covers only one active API wave.
+  const summary = { failed: 0, succeeded: 0 };
+  let remaining = LIFECYCLE_BATCH_SIZE;
+  while (remaining > 0) {
+    const leaseOwner = randomUUID();
+    const candidates = await claim(
+      leaseOwner,
+      Math.min(LIFECYCLE_CONCURRENCY, remaining)
+    );
+    if (candidates.length === 0) {
+      break;
+    }
+    remaining -= candidates.length;
+    const wave = await runConcurrentWave(candidates, (runtime) =>
+      operation(runtime, leaseOwner)
+    );
+    summary.failed += wave.failed;
+    summary.succeeded += wave.succeeded;
+  }
+  return summary;
 }
 
 async function sweepPauses(
   ctx: ChatDevboxLifecycleContext,
   now: Date
 ): Promise<{ failed: number; succeeded: number }> {
-  const leaseOwner = randomUUID();
-  const candidates = await claimPauseCandidates(ctx, now, leaseOwner);
-  return await mapWithConcurrency(candidates, async (runtime) => {
-    try {
-      const result = await ctx.api.pause(
-        runtime.namespace,
-        runtime.runtimeName
-      );
-      if (result === "missing") {
+  return await processClaimedWaves(
+    (leaseOwner, limit) => claimPauseCandidates(ctx, now, leaseOwner, limit),
+    async (runtime, leaseOwner) => {
+      if (!(await renewCleanupClaim(ctx, runtime, leaseOwner))) {
+        return false;
+      }
+      try {
+        const result = await ctx.api.pause(
+          runtime.namespace,
+          runtime.runtimeName
+        );
+        if (result === "missing") {
+          await ctx.db
+            .delete(assistantDevboxRuntimes)
+            .where(
+              and(
+                eq(assistantDevboxRuntimes.upstreamId, runtime.upstreamId),
+                eq(assistantDevboxRuntimes.cleanupLeaseOwner, leaseOwner)
+              )
+            );
+          return true;
+        }
+
+        await ctx.db
+          .update(assistantDevboxRuntimes)
+          .set({
+            cleanupLeaseExpiresAt: null,
+            cleanupLeaseOwner: null,
+            deleteDueAt: new Date(now.getTime() + DELETE_AFTER_PAUSE_MS),
+            pausedAt: now,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(assistantDevboxRuntimes.upstreamId, runtime.upstreamId),
+              eq(assistantDevboxRuntimes.cleanupLeaseOwner, leaseOwner)
+            )
+          );
+        return true;
+      } catch (error) {
+        try {
+          await releaseFailedClaim(ctx, runtime, leaseOwner, now);
+        } catch (releaseError) {
+          console.error(
+            "[chat-devbox-lifecycle] failed to release cleanup claim:",
+            releaseError
+          );
+        }
+        throw error;
+      }
+    }
+  );
+}
+
+async function sweepDeletes(
+  ctx: ChatDevboxLifecycleContext,
+  now: Date
+): Promise<{ failed: number; succeeded: number }> {
+  return await processClaimedWaves(
+    (leaseOwner, limit) => claimDeleteCandidates(ctx, now, leaseOwner, limit),
+    async (runtime, leaseOwner) => {
+      if (!(await renewCleanupClaim(ctx, runtime, leaseOwner))) {
+        return false;
+      }
+      try {
+        await ctx.api.delete(runtime.namespace, runtime.runtimeName);
         await ctx.db
           .delete(assistantDevboxRuntimes)
           .where(
@@ -318,68 +431,19 @@ async function sweepPauses(
             )
           );
         return true;
+      } catch (error) {
+        try {
+          await releaseFailedClaim(ctx, runtime, leaseOwner, now);
+        } catch (releaseError) {
+          console.error(
+            "[chat-devbox-lifecycle] failed to release cleanup claim:",
+            releaseError
+          );
+        }
+        throw error;
       }
-
-      await ctx.db
-        .update(assistantDevboxRuntimes)
-        .set({
-          cleanupLeaseExpiresAt: null,
-          cleanupLeaseOwner: null,
-          deleteDueAt: new Date(now.getTime() + DELETE_AFTER_PAUSE_MS),
-          pausedAt: now,
-          updatedAt: now,
-        })
-        .where(
-          and(
-            eq(assistantDevboxRuntimes.upstreamId, runtime.upstreamId),
-            eq(assistantDevboxRuntimes.cleanupLeaseOwner, leaseOwner)
-          )
-        );
-      return true;
-    } catch (error) {
-      try {
-        await releaseFailedClaim(ctx, runtime, leaseOwner, now);
-      } catch (releaseError) {
-        console.error(
-          "[chat-devbox-lifecycle] failed to release cleanup claim:",
-          releaseError
-        );
-      }
-      throw error;
     }
-  });
-}
-
-async function sweepDeletes(
-  ctx: ChatDevboxLifecycleContext,
-  now: Date
-): Promise<{ failed: number; succeeded: number }> {
-  const leaseOwner = randomUUID();
-  const candidates = await claimDeleteCandidates(ctx, now, leaseOwner);
-  return await mapWithConcurrency(candidates, async (runtime) => {
-    try {
-      await ctx.api.delete(runtime.namespace, runtime.runtimeName);
-      await ctx.db
-        .delete(assistantDevboxRuntimes)
-        .where(
-          and(
-            eq(assistantDevboxRuntimes.upstreamId, runtime.upstreamId),
-            eq(assistantDevboxRuntimes.cleanupLeaseOwner, leaseOwner)
-          )
-        );
-      return true;
-    } catch (error) {
-      try {
-        await releaseFailedClaim(ctx, runtime, leaseOwner, now);
-      } catch (releaseError) {
-        console.error(
-          "[chat-devbox-lifecycle] failed to release cleanup claim:",
-          releaseError
-        );
-      }
-      throw error;
-    }
-  });
+  );
 }
 
 export async function runChatDevboxLifecycleSweep(

--- a/apps/ui/src/features/chat/devbox/lifecycle.ts
+++ b/apps/ui/src/features/chat/devbox/lifecycle.ts
@@ -1,0 +1,414 @@
+import "server-only";
+
+import { randomUUID } from "node:crypto";
+
+import { and, eq, isNull, or, sql } from "drizzle-orm";
+import { DevboxApiError, deleteDevbox, pauseDevbox } from "@/lib/devbox/client";
+import { type AssistantPgDatabase, getAssistantDb } from "../persistence/db";
+import { assistantDevboxRuntimes } from "../persistence/schema";
+
+const DELETE_AFTER_PAUSE_MS = 24 * 60 * 60_000;
+const DEVBOX_OPERATION_TIMEOUT_MS = 10_000;
+const LIFECYCLE_ACTIVITY_WAIT_TIMEOUT_MS = 35_000;
+const LIFECYCLE_BATCH_SIZE = 20;
+const LIFECYCLE_CLAIM_TTL_MS = 30_000;
+const LIFECYCLE_CONCURRENCY = 4;
+const LIFECYCLE_RETRY_DELAY_MS = 30_000;
+const LIFECYCLE_SWEEP_INTERVAL_MS = 30_000;
+const LIFECYCLE_WAIT_POLL_MS = 100;
+
+function intervalFromMs(ms: number) {
+  return sql`make_interval(secs => ${ms / 1000})`;
+}
+
+interface ChatDevboxLifecycleApi {
+  delete: (
+    namespace: string,
+    runtimeName: string
+  ) => Promise<"deleted" | "missing">;
+  pause: (
+    namespace: string,
+    runtimeName: string
+  ) => Promise<"missing" | "paused">;
+}
+
+export interface ChatDevboxLifecycleContext {
+  api: ChatDevboxLifecycleApi;
+  db: AssistantPgDatabase;
+  now?: () => Date;
+}
+
+export interface ChatDevboxLifecycleSweepSummary {
+  deleted: number;
+  deleteFailed: number;
+  paused: number;
+  pauseFailed: number;
+}
+
+interface ClaimedChatDevboxRuntime {
+  namespace: string;
+  runtimeName: string;
+  upstreamId: string;
+}
+
+function isMissingDevboxError(error: unknown): boolean {
+  return error instanceof DevboxApiError && error.status === 404;
+}
+
+const serverApi: ChatDevboxLifecycleApi = {
+  async delete(namespace, runtimeName) {
+    try {
+      await deleteDevbox(namespace, runtimeName);
+      return "deleted";
+    } catch (error) {
+      if (isMissingDevboxError(error)) {
+        return "missing";
+      }
+      throw error;
+    }
+  },
+  async pause(namespace, runtimeName) {
+    try {
+      await pauseDevbox(
+        namespace,
+        runtimeName,
+        AbortSignal.timeout(DEVBOX_OPERATION_TIMEOUT_MS)
+      );
+      return "paused";
+    } catch (error) {
+      if (isMissingDevboxError(error)) {
+        return "missing";
+      }
+      throw error;
+    }
+  },
+};
+
+export async function recordChatDevboxActivity(
+  input: {
+    namespace: string;
+    pauseDueAt: Date;
+    runtimeName: string;
+    upstreamId: string;
+  },
+  db: AssistantPgDatabase = getAssistantDb()
+): Promise<void> {
+  const waitStartedAt = Date.now();
+  while (true) {
+    const now = new Date();
+    const changed = await db
+      .insert(assistantDevboxRuntimes)
+      .values({
+        namespace: input.namespace,
+        pauseDueAt: input.pauseDueAt,
+        runtimeName: input.runtimeName,
+        upstreamId: input.upstreamId,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        set: {
+          cleanupLeaseExpiresAt: null,
+          cleanupLeaseOwner: null,
+          deleteDueAt: null,
+          namespace: input.namespace,
+          pausedAt: null,
+          pauseDueAt: input.pauseDueAt,
+          runtimeName: input.runtimeName,
+          updatedAt: now,
+        },
+        setWhere: or(
+          isNull(assistantDevboxRuntimes.cleanupLeaseOwner),
+          isNull(assistantDevboxRuntimes.cleanupLeaseExpiresAt),
+          sql`${assistantDevboxRuntimes.cleanupLeaseExpiresAt} <= now()`
+        ),
+        target: assistantDevboxRuntimes.upstreamId,
+      })
+      .returning({ upstreamId: assistantDevboxRuntimes.upstreamId });
+    if (changed.length > 0) {
+      return;
+    }
+    if (Date.now() - waitStartedAt >= LIFECYCLE_ACTIVITY_WAIT_TIMEOUT_MS) {
+      throw new Error("Timed out waiting for the Devbox cleanup lease");
+    }
+    await new Promise((resolve) => setTimeout(resolve, LIFECYCLE_WAIT_POLL_MS));
+  }
+}
+
+function rowsOf(result: unknown): Record<string, unknown>[] {
+  if (Array.isArray(result)) {
+    return result as Record<string, unknown>[];
+  }
+  if (
+    result != null &&
+    typeof result === "object" &&
+    "rows" in result &&
+    Array.isArray(result.rows)
+  ) {
+    return result.rows as Record<string, unknown>[];
+  }
+  return [];
+}
+
+function claimedRuntimesOf(result: unknown): ClaimedChatDevboxRuntime[] {
+  return rowsOf(result).flatMap((record) => {
+    const namespace = record.namespace;
+    const runtimeName = record.runtime_name;
+    const upstreamId = record.upstream_id;
+    if (
+      typeof namespace !== "string" ||
+      typeof runtimeName !== "string" ||
+      typeof upstreamId !== "string"
+    ) {
+      return [];
+    }
+    return [{ namespace, runtimeName, upstreamId }];
+  });
+}
+
+async function claimPauseCandidates(
+  ctx: ChatDevboxLifecycleContext,
+  now: Date,
+  leaseOwner: string
+): Promise<ClaimedChatDevboxRuntime[]> {
+  return claimedRuntimesOf(
+    await ctx.db.execute(sql`
+      WITH candidates AS (
+        SELECT "upstream_id"
+        FROM ${assistantDevboxRuntimes}
+        WHERE "paused_at" IS NULL
+          AND "pause_due_at" <= ${now}
+          AND (
+            "cleanup_lease_expires_at" IS NULL
+            OR "cleanup_lease_expires_at" <= now()
+          )
+        ORDER BY "pause_due_at"
+        FOR UPDATE SKIP LOCKED
+        LIMIT ${LIFECYCLE_BATCH_SIZE}
+      )
+      UPDATE ${assistantDevboxRuntimes} runtime
+      SET "cleanup_lease_owner" = ${leaseOwner},
+          "cleanup_lease_expires_at" = now() + ${intervalFromMs(LIFECYCLE_CLAIM_TTL_MS)},
+          "updated_at" = ${now}
+      FROM candidates
+      WHERE runtime."upstream_id" = candidates."upstream_id"
+      RETURNING runtime."upstream_id", runtime."namespace", runtime."runtime_name"
+    `)
+  );
+}
+
+async function claimDeleteCandidates(
+  ctx: ChatDevboxLifecycleContext,
+  now: Date,
+  leaseOwner: string
+): Promise<ClaimedChatDevboxRuntime[]> {
+  return claimedRuntimesOf(
+    await ctx.db.execute(sql`
+      WITH candidates AS (
+        SELECT "upstream_id"
+        FROM ${assistantDevboxRuntimes}
+        WHERE "delete_due_at" IS NOT NULL
+          AND "delete_due_at" <= ${now}
+          AND (
+            "cleanup_lease_expires_at" IS NULL
+            OR "cleanup_lease_expires_at" <= now()
+          )
+        ORDER BY "delete_due_at"
+        FOR UPDATE SKIP LOCKED
+        LIMIT ${LIFECYCLE_BATCH_SIZE}
+      )
+      UPDATE ${assistantDevboxRuntimes} runtime
+      SET "cleanup_lease_owner" = ${leaseOwner},
+          "cleanup_lease_expires_at" = now() + ${intervalFromMs(LIFECYCLE_CLAIM_TTL_MS)},
+          "updated_at" = ${now}
+      FROM candidates
+      WHERE runtime."upstream_id" = candidates."upstream_id"
+      RETURNING runtime."upstream_id", runtime."namespace", runtime."runtime_name"
+    `)
+  );
+}
+
+async function releaseFailedClaim(
+  ctx: ChatDevboxLifecycleContext,
+  runtime: ClaimedChatDevboxRuntime,
+  leaseOwner: string,
+  now: Date
+): Promise<void> {
+  await ctx.db
+    .update(assistantDevboxRuntimes)
+    .set({
+      cleanupLeaseExpiresAt: sql`now() + ${intervalFromMs(LIFECYCLE_RETRY_DELAY_MS)}`,
+      cleanupLeaseOwner: null,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(assistantDevboxRuntimes.upstreamId, runtime.upstreamId),
+        eq(assistantDevboxRuntimes.cleanupLeaseOwner, leaseOwner)
+      )
+    );
+}
+
+async function mapWithConcurrency<T>(
+  values: readonly T[],
+  operation: (value: T) => Promise<boolean>
+): Promise<{ failed: number; succeeded: number }> {
+  let failed = 0;
+  let succeeded = 0;
+  for (let index = 0; index < values.length; index += LIFECYCLE_CONCURRENCY) {
+    const outcomes = await Promise.all(
+      values.slice(index, index + LIFECYCLE_CONCURRENCY).map(async (value) => {
+        try {
+          return await operation(value);
+        } catch (error) {
+          console.error("[chat-devbox-lifecycle] operation failed:", error);
+          return false;
+        }
+      })
+    );
+    succeeded += outcomes.filter(Boolean).length;
+    failed += outcomes.filter((outcome) => !outcome).length;
+  }
+  return { failed, succeeded };
+}
+
+async function sweepPauses(
+  ctx: ChatDevboxLifecycleContext,
+  now: Date
+): Promise<{ failed: number; succeeded: number }> {
+  const leaseOwner = randomUUID();
+  const candidates = await claimPauseCandidates(ctx, now, leaseOwner);
+  return await mapWithConcurrency(candidates, async (runtime) => {
+    try {
+      const result = await ctx.api.pause(
+        runtime.namespace,
+        runtime.runtimeName
+      );
+      if (result === "missing") {
+        await ctx.db
+          .delete(assistantDevboxRuntimes)
+          .where(
+            and(
+              eq(assistantDevboxRuntimes.upstreamId, runtime.upstreamId),
+              eq(assistantDevboxRuntimes.cleanupLeaseOwner, leaseOwner)
+            )
+          );
+        return true;
+      }
+
+      await ctx.db
+        .update(assistantDevboxRuntimes)
+        .set({
+          cleanupLeaseExpiresAt: null,
+          cleanupLeaseOwner: null,
+          deleteDueAt: new Date(now.getTime() + DELETE_AFTER_PAUSE_MS),
+          pausedAt: now,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(assistantDevboxRuntimes.upstreamId, runtime.upstreamId),
+            eq(assistantDevboxRuntimes.cleanupLeaseOwner, leaseOwner)
+          )
+        );
+      return true;
+    } catch (error) {
+      try {
+        await releaseFailedClaim(ctx, runtime, leaseOwner, now);
+      } catch (releaseError) {
+        console.error(
+          "[chat-devbox-lifecycle] failed to release cleanup claim:",
+          releaseError
+        );
+      }
+      throw error;
+    }
+  });
+}
+
+async function sweepDeletes(
+  ctx: ChatDevboxLifecycleContext,
+  now: Date
+): Promise<{ failed: number; succeeded: number }> {
+  const leaseOwner = randomUUID();
+  const candidates = await claimDeleteCandidates(ctx, now, leaseOwner);
+  return await mapWithConcurrency(candidates, async (runtime) => {
+    try {
+      await ctx.api.delete(runtime.namespace, runtime.runtimeName);
+      await ctx.db
+        .delete(assistantDevboxRuntimes)
+        .where(
+          and(
+            eq(assistantDevboxRuntimes.upstreamId, runtime.upstreamId),
+            eq(assistantDevboxRuntimes.cleanupLeaseOwner, leaseOwner)
+          )
+        );
+      return true;
+    } catch (error) {
+      try {
+        await releaseFailedClaim(ctx, runtime, leaseOwner, now);
+      } catch (releaseError) {
+        console.error(
+          "[chat-devbox-lifecycle] failed to release cleanup claim:",
+          releaseError
+        );
+      }
+      throw error;
+    }
+  });
+}
+
+export async function runChatDevboxLifecycleSweep(
+  ctx: ChatDevboxLifecycleContext
+): Promise<ChatDevboxLifecycleSweepSummary> {
+  const now = ctx.now?.() ?? new Date();
+  const pauses = await sweepPauses(ctx, now);
+  const deletes = await sweepDeletes(ctx, now);
+  return {
+    deleteFailed: deletes.failed,
+    deleted: deletes.succeeded,
+    pauseFailed: pauses.failed,
+    paused: pauses.succeeded,
+  };
+}
+
+const globalRuntime = globalThis as unknown as {
+  __sealaiChatDevboxLifecycleBusy?: boolean;
+  __sealaiChatDevboxLifecycleTimer?: ReturnType<typeof setInterval>;
+};
+
+export function startChatDevboxLifecycleRuntime(): void {
+  if (globalRuntime.__sealaiChatDevboxLifecycleTimer != null) {
+    return;
+  }
+  const ctx: ChatDevboxLifecycleContext = {
+    api: serverApi,
+    db: getAssistantDb(),
+  };
+  const sweep = () => {
+    if (globalRuntime.__sealaiChatDevboxLifecycleBusy) {
+      return;
+    }
+    globalRuntime.__sealaiChatDevboxLifecycleBusy = true;
+    runChatDevboxLifecycleSweep(ctx)
+      .catch((error) => {
+        console.error("[chat-devbox-lifecycle] sweep failed:", error);
+      })
+      .finally(() => {
+        globalRuntime.__sealaiChatDevboxLifecycleBusy = false;
+      });
+  };
+  globalRuntime.__sealaiChatDevboxLifecycleTimer = setInterval(
+    sweep,
+    LIFECYCLE_SWEEP_INTERVAL_MS
+  );
+  sweep();
+}
+
+export function stopChatDevboxLifecycleRuntimeForTests(): void {
+  const timer = globalRuntime.__sealaiChatDevboxLifecycleTimer;
+  if (timer != null) {
+    clearInterval(timer);
+    globalRuntime.__sealaiChatDevboxLifecycleBusy = false;
+    globalRuntime.__sealaiChatDevboxLifecycleTimer = undefined;
+  }
+}

--- a/apps/ui/src/features/chat/devbox/lifecycle.ts
+++ b/apps/ui/src/features/chat/devbox/lifecycle.ts
@@ -15,10 +15,27 @@ const LIFECYCLE_CLAIM_TTL_MS = 30_000;
 const LIFECYCLE_CONCURRENCY = 4;
 const LIFECYCLE_RETRY_DELAY_MS = 30_000;
 const LIFECYCLE_SWEEP_INTERVAL_MS = 30_000;
-const LIFECYCLE_WAIT_POLL_MS = 100;
+const LIFECYCLE_WAIT_INITIAL_MS = 100;
+const LIFECYCLE_WAIT_MAX_MS = 2000;
 
 function intervalFromMs(ms: number) {
   return sql`make_interval(secs => ${ms / 1000})`;
+}
+
+function waitWithSignal(ms: number, signal?: AbortSignal): Promise<void> {
+  signal?.throwIfAborted();
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", onAbort);
+      reject(signal?.reason ?? new DOMException("Aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 interface ChatDevboxLifecycleApi {
@@ -91,10 +108,13 @@ export async function recordChatDevboxActivity(
     runtimeName: string;
     upstreamId: string;
   },
-  db: AssistantPgDatabase = getAssistantDb()
+  db: AssistantPgDatabase = getAssistantDb(),
+  signal?: AbortSignal
 ): Promise<void> {
   const waitStartedAt = Date.now();
+  let waitMs = LIFECYCLE_WAIT_INITIAL_MS;
   while (true) {
+    signal?.throwIfAborted();
     const now = new Date();
     const changed = await db
       .insert(assistantDevboxRuntimes)
@@ -130,7 +150,12 @@ export async function recordChatDevboxActivity(
     if (Date.now() - waitStartedAt >= LIFECYCLE_ACTIVITY_WAIT_TIMEOUT_MS) {
       throw new Error("Timed out waiting for the Devbox cleanup lease");
     }
-    await new Promise((resolve) => setTimeout(resolve, LIFECYCLE_WAIT_POLL_MS));
+    const jitteredWaitMs = Math.max(
+      1,
+      Math.round(waitMs * (0.8 + Math.random() * 0.4))
+    );
+    await waitWithSignal(jitteredWaitMs, signal);
+    waitMs = Math.min(waitMs * 2, LIFECYCLE_WAIT_MAX_MS);
   }
 }
 

--- a/apps/ui/src/features/chat/persistence/db.ts
+++ b/apps/ui/src/features/chat/persistence/db.ts
@@ -8,6 +8,7 @@ import { getAppPostgresPool } from "@/lib/app-postgres/db";
 import {
   assistantChatMessages,
   assistantChats,
+  assistantDevboxRuntimes,
   assistantEntitlements,
   githubAppInstallSessions,
   githubConnections,
@@ -18,6 +19,7 @@ import {
 const assistantSchema = {
   assistantChatMessages,
   assistantChats,
+  assistantDevboxRuntimes,
   assistantEntitlements,
   githubAppInstallSessions,
   githubConnections,

--- a/apps/ui/src/features/chat/persistence/repository.test.ts
+++ b/apps/ui/src/features/chat/persistence/repository.test.ts
@@ -28,6 +28,7 @@ import {
 import {
   assistantChatMessages,
   assistantChats,
+  assistantDevboxRuntimes,
   assistantEntitlements,
   githubAppInstallSessions,
   githubConnections,
@@ -38,6 +39,7 @@ import {
 const assistantSchema = {
   assistantChatMessages,
   assistantChats,
+  assistantDevboxRuntimes,
   assistantEntitlements,
   githubAppInstallSessions,
   githubConnections,

--- a/apps/ui/src/features/chat/persistence/schema.ts
+++ b/apps/ui/src/features/chat/persistence/schema.ts
@@ -95,6 +95,44 @@ export const assistantEntitlements = ns.table(
   ]
 );
 
+/** Brain-owned lifecycle ledger for shared assistant Devbox runtimes. */
+export const assistantDevboxRuntimes = ns.table(
+  "assistant_devbox_runtimes",
+  {
+    upstreamId: text("upstream_id").primaryKey(),
+    namespace: text("namespace").notNull(),
+    runtimeName: text("runtime_name").notNull(),
+    pauseDueAt: timestamp("pause_due_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
+    pausedAt: timestamp("paused_at", { mode: "date", withTimezone: true }),
+    deleteDueAt: timestamp("delete_due_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    cleanupLeaseOwner: text("cleanup_lease_owner"),
+    cleanupLeaseExpiresAt: timestamp("cleanup_lease_expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("assistant_devbox_runtimes_pause_due_idx")
+      .on(table.pauseDueAt)
+      .where(sql`${table.pausedAt} IS NULL`),
+    index("assistant_devbox_runtimes_delete_due_idx")
+      .on(table.deleteDueAt)
+      .where(sql`${table.deleteDueAt} IS NOT NULL`),
+  ]
+);
+
 export const githubConnections = ns.table(
   "github_connections",
   {
@@ -216,6 +254,8 @@ export const githubOauthConnections = ns.table(
 export type AssistantChatRow = typeof assistantChats.$inferSelect;
 export type AssistantChatMessageRow = typeof assistantChatMessages.$inferSelect;
 export type AssistantEntitlementRow = typeof assistantEntitlements.$inferSelect;
+export type AssistantDevboxRuntimeRow =
+  typeof assistantDevboxRuntimes.$inferSelect;
 export type IdentityFingerprintRow = typeof identityFingerprints.$inferSelect;
 export type GithubAppInstallSessionRow =
   typeof githubAppInstallSessions.$inferSelect;

--- a/apps/ui/src/features/deploy/task/engine/constants.ts
+++ b/apps/ui/src/features/deploy/task/engine/constants.ts
@@ -7,6 +7,12 @@ import { DEPLOY_TIMEOUT_POLICY } from "../timeout-policy";
 export interface DeployTaskEngineCadence {
   /** Forced `cancelled` when a cancel request goes unacknowledged this long. */
   cancelAckDeadlineMs: number;
+  /** A paused Devbox is deleted after this window. */
+  devboxDeleteAfterPauseMs: number;
+  /** Paused Devboxes deleted per reaper sweep. */
+  devboxDeleteBatchSize: number;
+  /** Maximum Devbox API operations in flight per sweep. */
+  devboxOperationConcurrency: number;
   /** Devbox pauses attempted per reaper sweep. */
   devboxPauseBatchSize: number;
   /** Lease lifetime granted by a claim or renewal. */
@@ -15,24 +21,21 @@ export interface DeployTaskEngineCadence {
   leaseRenewIntervalMs: number;
   /** A lease held longer than this fails with a timeout reason. */
   maxActiveRunMs: number;
-  /** Terminal tasks purged per reaper sweep. */
-  purgeBatchSize: number;
   /** A row still `queued` past this deadline failed to start (crash gap). */
   queuedStartDeadlineMs: number;
   /** Reaper sweep interval per process. */
   reaperIntervalMs: number;
-  /** Terminal tasks are purged after this window. */
-  retentionMs: number;
 }
 
 export const DEPLOY_TASK_ENGINE_CADENCE: DeployTaskEngineCadence = {
   cancelAckDeadlineMs: 90_000,
+  devboxDeleteAfterPauseMs: 24 * 60 * 60_000,
+  devboxDeleteBatchSize: 20,
+  devboxOperationConcurrency: 4,
   devboxPauseBatchSize: 10,
   leaseDurationMs: 60_000,
   leaseRenewIntervalMs: 20_000,
   maxActiveRunMs: DEPLOY_TIMEOUT_POLICY.overallMs,
-  purgeBatchSize: 20,
   queuedStartDeadlineMs: 120_000,
   reaperIntervalMs: 30_000,
-  retentionMs: 30 * 24 * 60 * 60_000,
 };

--- a/apps/ui/src/features/deploy/task/engine/engine.test.ts
+++ b/apps/ui/src/features/deploy/task/engine/engine.test.ts
@@ -1772,8 +1772,8 @@ test("deadline transition CAS defines cancel-versus-timeout boundary priority", 
   }
 });
 
-test("reaper pauses devboxes of terminal tasks and purges after retention", async () => {
-  const ctx = testCtx({ retentionMs: 60_000 });
+test("reaper pauses terminal-task devboxes and deletes only runtimes after retention", async () => {
+  const ctx = testCtx({ devboxDeleteAfterPauseMs: 60_000 });
 
   const failedWithDevbox = await insertTaskRow(harness.db, {
     completedAt: new Date(Date.now() - 1000),
@@ -1782,38 +1782,26 @@ test("reaper pauses devboxes of terminal tasks and purges after retention", asyn
     runtimeState: "Running",
     status: "failed",
   });
-  const purgeDue = await insertTaskRow(harness.db, {
+  const deleteDue = await insertTaskRow(harness.db, {
     completedAt: new Date(Date.now() - 120_000),
     runtimeName: "devbox-b",
+    runtimePausedAt: new Date(Date.now() - 120_000),
     runtimeProvider: "devbox",
     runtimeState: "paused",
     status: "cancelled",
   });
 
-  const purgeEvents: string[] = [];
-  const unsubscribe = await harness.notify.subscribe((event) => {
-    if (event.kind === "purge") {
-      purgeEvents.push(event.taskId);
-    }
-  });
-
   const summary = await runDeployTaskReaperSweep(ctx);
   assert.ok(summary.devboxPaused >= 1);
-  assert.equal(summary.purged, 1);
+  assert.equal(summary.devboxDeleted, 1);
 
   assert.ok(devbox.paused.includes("ns-test/devbox-a"));
-  assert.equal((await taskById(failedWithDevbox.id)).runtimeState, "paused");
+  const pausedTask = await taskById(failedWithDevbox.id);
+  assert.equal(pausedTask.runtimeState, "paused");
+  assert.ok(pausedTask.runtimePausedAt);
 
   assert.ok(devbox.deleted.includes("ns-test/devbox-b"));
-  const [purgedRow] = await harness.db
-    .select({ id: deployTasks.id })
-    .from(deployTasks)
-    .where(eq(deployTasks.id, purgeDue.id));
-  assert.equal(purgedRow, undefined);
-
-  await new Promise((resolve) => setTimeout(resolve, 50));
-  await unsubscribe();
-  assert.deepEqual(purgeEvents, [purgeDue.id]);
+  assert.equal((await taskById(deleteDue.id)).runtimeState, "deleted");
 });
 
 test("timer renewal keeps a slow integration alive across lease expiry", async () => {
@@ -1850,7 +1838,7 @@ test("timer renewal keeps a slow integration alive across lease expiry", async (
   assert.equal((await taskById(result.task.id)).status, "completed");
 });
 
-test("a redeploy chain keeps the root's identity after the root is purged", async () => {
+test("a redeploy chain keeps the root identity if a predecessor is missing", async () => {
   const ctx = testCtx();
   const root = await insertTaskRow(harness.db, {
     artifactSummary: {
@@ -1871,7 +1859,7 @@ test("a redeploy chain keeps the root's identity after the root is purged", asyn
   if (cloneB.kind !== "created") {
     return;
   }
-  // B fails without ever generating artifacts; the root is purged.
+  // B fails without ever generating artifacts; simulate a legacy missing root.
   await harness.db
     .update(deployTasks)
     .set({ completedAt: new Date(), status: "failed" })
@@ -1897,11 +1885,15 @@ test("a redeploy chain keeps the root's identity after the root is purged", asyn
   assert.equal(stored.source.kind, "template");
 });
 
-test("purge retries on the next sweep when devbox deletion fails", async () => {
-  const ctx = testCtx({ retentionMs: 60_000 });
+test("Devbox deletion retries without deleting task history", async () => {
+  const ctx = testCtx({
+    devboxDeleteAfterPauseMs: 60_000,
+    reaperIntervalMs: 0,
+  });
   const stuck = await insertTaskRow(harness.db, {
     completedAt: new Date(Date.now() - 120_000),
     runtimeName: "devbox-stuck",
+    runtimePausedAt: new Date(Date.now() - 120_000),
     runtimeProvider: "devbox",
     runtimeState: "paused",
     status: "failed",
@@ -1909,14 +1901,51 @@ test("purge retries on the next sweep when devbox deletion fails", async () => {
 
   devbox.failNextDelete = true;
   const first = await runDeployTaskReaperSweep(ctx);
-  assert.equal(first.purgeFailed, 1);
-  assert.ok(await taskById(stuck.id));
+  assert.equal(first.devboxDeleteFailed, 1);
+  assert.equal((await taskById(stuck.id)).runtimeState, "paused");
 
   const second = await runDeployTaskReaperSweep(ctx);
-  assert.equal(second.purged, 1);
-  const [gone] = await harness.db
-    .select({ id: deployTasks.id })
-    .from(deployTasks)
-    .where(eq(deployTasks.id, stuck.id));
-  assert.equal(gone, undefined);
+  assert.equal(second.devboxDeleted, 1);
+  assert.equal((await taskById(stuck.id)).runtimeState, "deleted");
+});
+
+test("concurrent reapers claim one paused Devbox deletion only once", async () => {
+  const ctx = testCtx({ devboxDeleteAfterPauseMs: 60_000 });
+  const due = await insertTaskRow(harness.db, {
+    completedAt: new Date(Date.now() - 120_000),
+    runtimeName: "devbox-claimed-once",
+    runtimePausedAt: new Date(Date.now() - 120_000),
+    runtimeProvider: "devbox",
+    runtimeState: "paused",
+    status: "failed",
+  });
+  let deleteCalls = 0;
+  let releaseDelete!: () => void;
+  let markDeleteStarted!: () => void;
+  const deleteStarted = new Promise<void>((resolve) => {
+    markDeleteStarted = resolve;
+  });
+  const deleteBlocked = new Promise<void>((resolve) => {
+    releaseDelete = resolve;
+  });
+  devbox.deleteDevbox = async (namespace, name) => {
+    deleteCalls += 1;
+    devbox.deleted.push(`${namespace}/${name}`);
+    markDeleteStarted();
+    await deleteBlocked;
+    return "deleted";
+  };
+
+  const first = runDeployTaskReaperSweep(ctx);
+  await deleteStarted;
+  const second = await runDeployTaskReaperSweep(ctx);
+
+  assert.equal(second.devboxDeleted, 0);
+  assert.equal(deleteCalls, 1);
+  releaseDelete();
+  assert.equal((await first).devboxDeleted, 1);
+  const stored = await taskById(due.id);
+  assert.equal(stored.runtimeState, "deleted");
+  assert.equal(stored.runtimeCleanupLeaseOwner, null);
+  assert.equal(stored.runtimeCleanupLeaseExpiresAt, null);
 });

--- a/apps/ui/src/features/deploy/task/engine/notify.ts
+++ b/apps/ui/src/features/deploy/task/engine/notify.ts
@@ -2,15 +2,14 @@
  * One global Postgres NOTIFY channel carries every deployment-task change so
  * execution, projection streams, and timeline streams work across server
  * processes (ADR 0037). Payloads are identifiers only; subscribers re-read the
- * row. `purge` is the exception: the row is gone, so the ids are the event.
- * A `reset` event is synthesized locally after the LISTEN connection
+ * row. A `reset` event is synthesized locally after the LISTEN connection
  * reconnects — notifications during the gap are lost, so subscribers must
  * re-bootstrap.
  */
 export const DEPLOY_TASK_NOTIFY_CHANNEL = "sealai_deploy_task_changed";
 
 export interface DeployTaskNotifyMessage {
-  kind: "change" | "purge";
+  kind: "change";
   namespace: string;
   projectId: string | null;
   taskId: string;
@@ -43,7 +42,7 @@ export function parseDeployTaskNotifyMessage(
     return null;
   }
   const record = parsed as Record<string, unknown>;
-  if (record.kind !== "change" && record.kind !== "purge") {
+  if (record.kind !== "change") {
     return null;
   }
   if (

--- a/apps/ui/src/features/deploy/task/engine/reaper.ts
+++ b/apps/ui/src/features/deploy/task/engine/reaper.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { type SQL, sql } from "drizzle-orm";
 
 import {
@@ -29,14 +31,14 @@ import {
 
 export interface DeployTaskReaperSummary {
   cancelAckForced: number;
+  devboxDeleted: number;
+  devboxDeleteFailed: number;
   devboxPaused: number;
   devboxPauseFailed: number;
   interrupted: number;
   interruptedWithCancel: number;
   invalidBlocked: number;
   neverStarted: number;
-  purged: number;
-  purgeFailed: number;
   timedOut: number;
 }
 
@@ -198,7 +200,6 @@ async function sweepInvalidBlockedTasks(
 
 interface DevboxTaskRecord {
   namespace: string;
-  projectId: string | null;
   runtimeName: string;
   taskId: string;
 }
@@ -212,8 +213,6 @@ function devboxRecordsOf(result: unknown): DevboxTaskRecord[] {
     return [
       {
         namespace: String(record.namespace ?? ""),
-        projectId:
-          record.project_uid == null ? null : String(record.project_uid),
         runtimeName,
         taskId: String(record.id),
       },
@@ -224,14 +223,62 @@ function devboxRecordsOf(result: unknown): DevboxTaskRecord[] {
 async function markRuntimeState(
   ctx: DeployTaskEngineContext,
   taskId: string,
-  runtimeState: "deleted" | "paused"
+  runtimeState: "deleted" | "paused",
+  cleanupLeaseOwner: string
+): Promise<void> {
+  if (runtimeState === "paused") {
+    await ctx.db.execute(sql`
+      UPDATE ${TASKS}
+      SET "runtime_state" = 'paused',
+          "runtime_paused_at" = coalesce("runtime_paused_at", now()),
+          "runtime_cleanup_lease_owner" = NULL,
+          "runtime_cleanup_lease_expires_at" = NULL
+      WHERE "id" = ${taskId}
+        AND "status" IN (${statusListSql(DEPLOY_TASK_TERMINAL_STATUSES)})
+        AND "runtime_cleanup_lease_owner" = ${cleanupLeaseOwner}
+    `);
+    return;
+  }
+  await ctx.db.execute(sql`
+    UPDATE ${TASKS}
+    SET "runtime_state" = 'deleted',
+        "runtime_cleanup_lease_owner" = NULL,
+        "runtime_cleanup_lease_expires_at" = NULL
+    WHERE "id" = ${taskId}
+      AND "status" IN (${statusListSql(DEPLOY_TASK_TERMINAL_STATUSES)})
+      AND "runtime_cleanup_lease_owner" = ${cleanupLeaseOwner}
+  `);
+}
+
+async function releaseDevboxCleanupClaim(
+  ctx: DeployTaskEngineContext,
+  taskId: string,
+  cleanupLeaseOwner: string
 ): Promise<void> {
   await ctx.db.execute(sql`
     UPDATE ${TASKS}
-    SET "runtime_state" = ${runtimeState}, "updated_at" = now()
+    SET "runtime_cleanup_lease_owner" = NULL,
+        "runtime_cleanup_lease_expires_at" = now() + ${intervalFromMs(ctx.cadence.reaperIntervalMs)}
     WHERE "id" = ${taskId}
-      AND "status" IN (${statusListSql(DEPLOY_TASK_TERMINAL_STATUSES)})
+      AND "runtime_cleanup_lease_owner" = ${cleanupLeaseOwner}
   `);
+}
+
+async function processWithConcurrency<T>(
+  records: readonly T[],
+  concurrency: number,
+  operation: (record: T) => Promise<boolean>
+): Promise<{ failed: number; succeeded: number }> {
+  let failed = 0;
+  let succeeded = 0;
+  for (let index = 0; index < records.length; index += concurrency) {
+    const outcomes = await Promise.all(
+      records.slice(index, index + concurrency).map(operation)
+    );
+    succeeded += outcomes.filter(Boolean).length;
+    failed += outcomes.filter((outcome) => !outcome).length;
+  }
+  return { failed, succeeded };
 }
 
 /**
@@ -242,98 +289,138 @@ async function markRuntimeState(
 async function sweepTerminalDevboxPauses(
   ctx: DeployTaskEngineContext
 ): Promise<{ failed: number; paused: number }> {
+  const cleanupLeaseOwner = `${ctx.processId}:${randomUUID()}`;
   const candidates = await ctx.db.execute(sql`
-    SELECT "id", "namespace", "project_uid", "runtime_name"
-    FROM ${TASKS}
-    WHERE "status" IN (${statusListSql(DEPLOY_TASK_TERMINAL_STATUSES)})
-      AND "runtime_provider" = 'devbox'
-      AND "runtime_name" IS NOT NULL
-      AND (lower(coalesce("runtime_state", '')) NOT IN ('paused', 'deleted', 'archived'))
-    ORDER BY "completed_at" ASC NULLS FIRST
-    LIMIT ${ctx.cadence.devboxPauseBatchSize}
+    WITH candidates AS (
+      SELECT "id"
+      FROM ${TASKS}
+      WHERE "status" IN (${statusListSql(DEPLOY_TASK_TERMINAL_STATUSES)})
+        AND "runtime_provider" = 'devbox'
+        AND "runtime_name" IS NOT NULL
+        AND (lower(coalesce("runtime_state", '')) NOT IN ('paused', 'deleted', 'archived'))
+        AND (
+          "runtime_cleanup_lease_expires_at" IS NULL
+          OR "runtime_cleanup_lease_expires_at" <= now()
+        )
+      ORDER BY "completed_at" ASC NULLS FIRST
+      FOR UPDATE SKIP LOCKED
+      LIMIT ${ctx.cadence.devboxPauseBatchSize}
+    )
+    UPDATE ${TASKS} task
+    SET "runtime_cleanup_lease_owner" = ${cleanupLeaseOwner},
+        "runtime_cleanup_lease_expires_at" = now() + ${intervalFromMs(ctx.cadence.leaseDurationMs)}
+    FROM candidates
+    WHERE task."id" = candidates."id"
+    RETURNING task."id", task."namespace", task."runtime_name"
   `);
-  let paused = 0;
-  let failed = 0;
-  for (const record of devboxRecordsOf(candidates)) {
-    try {
-      const result = await ctx.devbox.pauseDevbox(
-        record.namespace,
-        record.runtimeName
-      );
-      await markRuntimeState(
-        ctx,
-        record.taskId,
-        result === "missing" ? "deleted" : "paused"
-      );
-      paused += 1;
-    } catch (error) {
-      failed += 1;
-      console.error(
-        `[deploy-task-reaper] devbox pause failed for task ${record.taskId}:`,
-        error
-      );
+  const result = await processWithConcurrency(
+    devboxRecordsOf(candidates),
+    ctx.cadence.devboxOperationConcurrency,
+    async (record) => {
+      try {
+        const pauseResult = await ctx.devbox.pauseDevbox(
+          record.namespace,
+          record.runtimeName
+        );
+        await markRuntimeState(
+          ctx,
+          record.taskId,
+          pauseResult === "missing" ? "deleted" : "paused",
+          cleanupLeaseOwner
+        );
+        return true;
+      } catch (error) {
+        try {
+          await releaseDevboxCleanupClaim(
+            ctx,
+            record.taskId,
+            cleanupLeaseOwner
+          );
+        } catch (releaseError) {
+          console.error(
+            `[deploy-task-reaper] cleanup claim release failed for task ${record.taskId}:`,
+            releaseError
+          );
+        }
+        console.error(
+          `[deploy-task-reaper] devbox pause failed for task ${record.taskId}:`,
+          error
+        );
+        return false;
+      }
     }
-  }
-  return { failed, paused };
+  );
+  return { failed: result.failed, paused: result.succeeded };
 }
 
 /**
- * Retention purge (ADR 0038): devbox first, then the row (events/messages
- * cascade), then the purge notification whose ids are the removal event.
- * Any failure leaves the row for the next sweep — purge is idempotent.
+ * Delete paused terminal-task Devboxes after their runtime retention window.
+ * Task rows, events, messages, and deployment results are permanent records.
  */
-async function sweepRetentionPurge(
+async function sweepPausedDevboxDeletes(
   ctx: DeployTaskEngineContext
-): Promise<{ failed: number; purged: number }> {
-  const dueTasks = await ctx.db.execute(sql`
-    SELECT "id", "namespace", "project_uid", "runtime_name", "runtime_provider", "runtime_state"
-    FROM ${TASKS}
-    WHERE "status" IN (${statusListSql(DEPLOY_TASK_TERMINAL_STATUSES)})
-      AND "completed_at" IS NOT NULL
-      AND "completed_at" < now() - ${intervalFromMs(ctx.cadence.retentionMs)}
-    ORDER BY "completed_at" ASC
-    LIMIT ${ctx.cadence.purgeBatchSize}
+): Promise<{ deleted: number; failed: number }> {
+  const cleanupLeaseOwner = `${ctx.processId}:${randomUUID()}`;
+  const candidates = await ctx.db.execute(sql`
+    WITH candidates AS (
+      SELECT "id"
+      FROM ${TASKS}
+      WHERE "status" IN (${statusListSql(DEPLOY_TASK_TERMINAL_STATUSES)})
+        AND "runtime_provider" = 'devbox'
+        AND "runtime_name" IS NOT NULL
+        AND lower(coalesce("runtime_state", '')) IN ('paused', 'archived')
+        AND "runtime_paused_at" IS NOT NULL
+        AND "runtime_paused_at" <= now() - ${intervalFromMs(ctx.cadence.devboxDeleteAfterPauseMs)}
+        AND (
+          "runtime_cleanup_lease_expires_at" IS NULL
+          OR "runtime_cleanup_lease_expires_at" <= now()
+        )
+      ORDER BY "runtime_paused_at" ASC
+      FOR UPDATE SKIP LOCKED
+      LIMIT ${ctx.cadence.devboxDeleteBatchSize}
+    )
+    UPDATE ${TASKS} task
+    SET "runtime_cleanup_lease_owner" = ${cleanupLeaseOwner},
+        "runtime_cleanup_lease_expires_at" = now() + ${intervalFromMs(ctx.cadence.leaseDurationMs)}
+    FROM candidates
+    WHERE task."id" = candidates."id"
+    RETURNING task."id", task."namespace", task."runtime_name"
   `);
-  let purged = 0;
-  let failed = 0;
-  for (const record of rowsOf(dueTasks)) {
-    const taskId = String(record.id);
-    const namespace = String(record.namespace ?? "");
-    const projectId =
-      record.project_uid == null ? null : String(record.project_uid);
-    try {
-      const runtimeName =
-        typeof record.runtime_name === "string" ? record.runtime_name : null;
-      const isDevbox = record.runtime_provider === "devbox";
-      const alreadyDeleted =
-        String(record.runtime_state ?? "").toLowerCase() === "deleted";
-      if (isDevbox && runtimeName != null && !alreadyDeleted) {
-        await ctx.devbox.deleteDevbox(namespace, runtimeName);
-        await markRuntimeState(ctx, taskId, "deleted");
-      }
-      await ctx.db.execute(
-        sql`DELETE FROM ${TASKS} WHERE "id" = ${taskId} AND "status" IN (${statusListSql(DEPLOY_TASK_TERMINAL_STATUSES)})`
-      );
-      purged += 1;
+  const result = await processWithConcurrency(
+    devboxRecordsOf(candidates),
+    ctx.cadence.devboxOperationConcurrency,
+    async (record) => {
       try {
-        await ctx.notify.publish({
-          kind: "purge",
-          namespace,
-          projectId,
-          taskId,
-        });
+        await ctx.devbox.deleteDevbox(record.namespace, record.runtimeName);
+        await markRuntimeState(
+          ctx,
+          record.taskId,
+          "deleted",
+          cleanupLeaseOwner
+        );
+        return true;
       } catch (error) {
-        console.error("[deploy-task-reaper] purge notify failed:", error);
+        try {
+          await releaseDevboxCleanupClaim(
+            ctx,
+            record.taskId,
+            cleanupLeaseOwner
+          );
+        } catch (releaseError) {
+          console.error(
+            `[deploy-task-reaper] cleanup claim release failed for task ${record.taskId}:`,
+            releaseError
+          );
+        }
+        console.error(
+          `[deploy-task-reaper] devbox delete failed for task ${record.taskId}:`,
+          error
+        );
+        return false;
       }
-    } catch (error) {
-      failed += 1;
-      console.error(
-        `[deploy-task-reaper] purge failed for task ${taskId}:`,
-        error
-      );
     }
-  }
-  return { failed, purged };
+  );
+  return { deleted: result.succeeded, failed: result.failed };
 }
 
 /**
@@ -427,18 +514,18 @@ export async function runDeployTaskReaperSweep(
   const invalidBlocked = await sweepInvalidBlockedTasks(ctx);
 
   const devboxSweep = await sweepTerminalDevboxPauses(ctx);
-  const purgeSweep = await sweepRetentionPurge(ctx);
+  const devboxDeleteSweep = await sweepPausedDevboxDeletes(ctx);
 
   return {
     cancelAckForced: cancelAckForced.length,
     devboxPauseFailed: devboxSweep.failed,
     devboxPaused: devboxSweep.paused,
+    devboxDeleteFailed: devboxDeleteSweep.failed,
+    devboxDeleted: devboxDeleteSweep.deleted,
     invalidBlocked,
     interrupted: interrupted.length,
     interruptedWithCancel: interruptedWithCancel.length,
     neverStarted: neverStarted.length,
-    purgeFailed: purgeSweep.failed,
-    purged: purgeSweep.purged,
     timedOut: timedOut.length,
   };
 }

--- a/apps/ui/src/features/deploy/task/engine/server.ts
+++ b/apps/ui/src/features/deploy/task/engine/server.ts
@@ -14,6 +14,8 @@ import type {
 import { getDeployTaskNotifyTransport } from "./notify-server";
 import { startDeployTaskEngineRuntime } from "./runtime";
 
+const DEVBOX_REAPER_OPERATION_TIMEOUT_MS = 10_000;
+
 function isMissingDevboxError(error: unknown): boolean {
   return error instanceof DevboxApiError && error.status === 404;
 }
@@ -32,7 +34,11 @@ const serverDevbox: DeployTaskEngineDevbox = {
   },
   async pauseDevbox(namespace, name) {
     try {
-      await pauseDevbox(namespace, name);
+      await pauseDevbox(
+        namespace,
+        name,
+        AbortSignal.timeout(DEVBOX_REAPER_OPERATION_TIMEOUT_MS)
+      );
       return "paused";
     } catch (error) {
       if (isMissingDevboxError(error)) {

--- a/apps/ui/src/features/deploy/task/engine/testing/fixtures.ts
+++ b/apps/ui/src/features/deploy/task/engine/testing/fixtures.ts
@@ -34,6 +34,7 @@ export interface TaskRowFixtureInput {
   retriedFromTaskId?: string | null;
   runner?: DeploymentTaskRunner;
   runtimeName?: string | null;
+  runtimePausedAt?: Date | null;
   runtimeProvider?: string | null;
   runtimeState?: string | null;
   source?: DeploymentTaskSource;
@@ -67,6 +68,7 @@ export async function insertTaskRow(
       retriedFromTaskId: null,
       runner: { kind: "template" },
       runtimeName: null,
+      runtimePausedAt: null,
       runtimeProvider: null,
       runtimeState: null,
       source: { kind: "template", templateName: "demo" },

--- a/apps/ui/src/features/deploy/task/projection-events.test.ts
+++ b/apps/ui/src/features/deploy/task/projection-events.test.ts
@@ -189,32 +189,6 @@ it("independent tasks re-read concurrently", async () => {
   subscription.unsubscribe();
 });
 
-it("drops a re-read that raced a purge instead of resurrecting the task", async () => {
-  const { events, subscription } = subscribeCollectingEvents();
-  await subscription.ready;
-
-  notifyChange("task-1");
-  expect(issuedReads.length).toBe(1);
-  notifyListener?.({
-    kind: "purge",
-    namespace: "ns-test",
-    projectId: "project-1",
-    taskId: "task-1",
-  });
-  // The read was started before the purge deleted the row, so it can still
-  // return the stale row — the tombstone must swallow it.
-  issuedReads[0]?.resolve(taskRow({ status: "running" }));
-  await drain();
-
-  expect(events.map((event) => event.type)).toEqual(["remove"]);
-
-  // Purged ids stay tombstoned: later change notifications are ignored.
-  notifyChange("task-1");
-  await drain();
-  expect(issuedReads.length).toBe(1);
-  subscription.unsubscribe();
-});
-
 it("rejects ready when the notify subscribe fails", async () => {
   subscribeShouldFail = new Error("LISTEN refused");
   const { subscription } = subscribeCollectingEvents();
@@ -288,33 +262,5 @@ it("flushes held deliveries when the reset snapshot read fails", async () => {
   issuedListReads[0]?.reject(new Error("snapshot read failed"));
   await drain();
   expect(events.map(eventLabel)).toEqual(["upsert:task-1"]);
-  subscription.unsubscribe();
-});
-
-it("filters purged tasks out of a reset snapshot", async () => {
-  const { events, subscription } = subscribeWithDeferredSnapshots();
-  await subscription.ready;
-
-  notifyListener?.({ kind: "reset" });
-  // The purge lands while the snapshot read is in flight; a read whose
-  // visibility predates the delete can still contain the purged row.
-  notifyListener?.({
-    kind: "purge",
-    namespace: "ns-test",
-    projectId: "project-1",
-    taskId: "task-1",
-  });
-  issuedListReads[0]?.resolve([{ id: "task-1" } as DeploymentTaskProjection]);
-  await drain();
-
-  expect(events).toEqual([
-    { projections: [], type: "snapshot" },
-    {
-      namespace: "ns-test",
-      projectId: "project-1",
-      taskId: "task-1",
-      type: "remove",
-    },
-  ]);
   subscription.unsubscribe();
 });

--- a/apps/ui/src/features/deploy/task/projection-events.ts
+++ b/apps/ui/src/features/deploy/task/projection-events.ts
@@ -15,8 +15,8 @@ type DeploymentTaskProjectionListener = (
 /**
  * Project-scoped projection events, driven by the global NOTIFY channel
  * (ADR 0037): payloads carry ids only, so each event re-reads the row —
- * serialized per task so deliveries stay monotonic; a purge notification is
- * itself the removal; a transport reset re-reads the whole project because
+ * serialized per task so deliveries stay monotonic; a transport reset
+ * re-reads the whole project because
  * notifications during the gap are lost, holding per-task deliveries back
  * until its snapshot lands so the snapshot never erases a newer delivery.
  */
@@ -45,10 +45,7 @@ export function subscribeDeploymentTaskProjectionEvents(input: {
   // project-scoped): concurrent re-reads can resolve out of order and
   // deliver an older row state after a newer one; the trailing read folds
   // every notification that arrived mid-read into one final delivery.
-  // Purged ids are tombstoned so a re-read racing the purge cannot
-  // resurrect the task — task ids are never reused.
   const inflightReads = new Map<string, { queued: boolean }>();
-  const purgedTaskIds = new Set<string>();
 
   // Reset snapshots replace the listener's whole set, so a snapshot must
   // never land after a per-task delivery it does not contain — the replace
@@ -87,12 +84,7 @@ export function subscribeDeploymentTaskProjectionEvents(input: {
     inflightReads.set(taskId, slot);
     getDeployTaskById(taskId)
       .then((row) => {
-        if (
-          cancelled ||
-          purgedTaskIds.has(taskId) ||
-          row == null ||
-          row.namespace !== input.namespace
-        ) {
+        if (cancelled || row == null || row.namespace !== input.namespace) {
           return;
         }
         const rowProjectId = row.projectId?.trim() ?? "";
@@ -136,12 +128,7 @@ export function subscribeDeploymentTaskProjectionEvents(input: {
             if (cancelled || generation !== resetGeneration) {
               return;
             }
-            // The read can predate a purge that was already delivered:
-            // tombstoned ids never re-enter through a snapshot.
-            const snapshot = projections.filter(
-              (projection) => !purgedTaskIds.has(projection.id)
-            );
-            input.listener({ projections: snapshot, type: "snapshot" });
+            input.listener({ projections, type: "snapshot" });
             flushBufferedDuringReset();
           })
           .catch((error) => {
@@ -158,25 +145,6 @@ export function subscribeDeploymentTaskProjectionEvents(input: {
         return;
       }
       if (event.namespace !== input.namespace) {
-        return;
-      }
-      if (event.kind === "purge") {
-        purgedTaskIds.add(event.taskId);
-        const inflight = inflightReads.get(event.taskId);
-        if (inflight != null) {
-          inflight.queued = false;
-        }
-        if (event.projectId === input.projectId) {
-          deliver({
-            namespace: event.namespace,
-            projectId: input.projectId,
-            taskId: event.taskId,
-            type: "remove",
-          });
-        }
-        return;
-      }
-      if (purgedTaskIds.has(event.taskId)) {
         return;
       }
       emitTask(event.taskId);

--- a/apps/ui/src/features/deploy/task/runner.ts
+++ b/apps/ui/src/features/deploy/task/runner.ts
@@ -44,10 +44,7 @@ import {
   refreshDevboxPause,
   resumeDevbox,
 } from "@/lib/devbox/client";
-import {
-  getDevboxArchiveAfterPauseTime,
-  getDevboxDefaultImage,
-} from "@/lib/devbox/config";
+import { getDevboxDefaultImage } from "@/lib/devbox/config";
 import type { DevboxInfo } from "@/lib/devbox/types";
 import { kubeconfigBearerHeader } from "@/lib/kubeconfig-header";
 import { routingDomainFromKubeconfig } from "@/lib/kubeconfig-routing-domain";
@@ -1827,7 +1824,6 @@ async function ensureDeployDevbox(input: {
     await createDevbox(
       input.namespace,
       {
-        archiveAfterPauseTime: getDevboxArchiveAfterPauseTime(),
         env: {
           ...buildCodexGatewayEnv(gatewayCredentials),
           ...(input.githubToken?.trim()

--- a/apps/ui/src/features/deploy/task/schema.ts
+++ b/apps/ui/src/features/deploy/task/schema.ts
@@ -303,6 +303,18 @@ export const deployTasks = ns.table(
     runtimeProvider: text("runtime_provider"),
     runtimeName: text("runtime_name"),
     runtimeState: text("runtime_state"),
+    runtimePausedAt: timestamp("runtime_paused_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    runtimeCleanupLeaseOwner: text("runtime_cleanup_lease_owner"),
+    runtimeCleanupLeaseExpiresAt: timestamp(
+      "runtime_cleanup_lease_expires_at",
+      {
+        mode: "date",
+        withTimezone: true,
+      }
+    ),
     gatewayUrl: text("gateway_url"),
     gatewaySessionId: text("gateway_session_id"),
     gatewayThreadId: text("gateway_thread_id"),
@@ -372,7 +384,7 @@ export const deployTasks = ns.table(
       table.updatedAt
     ),
     // Reaper scans (ADR 0037): leased statuses by lease expiry, queued by
-    // age, terminal by completion time.
+    // age, terminal by completion time, and paused runtimes by deletion due.
     index("deploy_tasks_leased_expiry_idx")
       .on(table.leaseExpiresAt)
       .where(sql`${table.status} IN ('running', 'applying')`),
@@ -382,6 +394,11 @@ export const deployTasks = ns.table(
     index("deploy_tasks_terminal_completed_idx")
       .on(table.completedAt)
       .where(sql`${table.status} IN ('completed', 'failed', 'cancelled')`),
+    index("deploy_tasks_runtime_paused_idx")
+      .on(table.runtimePausedAt)
+      .where(
+        sql`${table.runtimeProvider} = 'devbox' AND lower(coalesce(${table.runtimeState}, '')) IN ('paused', 'archived')`
+      ),
     // One active clone per predecessor (ADR 0038): a concurrent redeploy
     // loses this insert and surfaces as a conflict. Keyed by namespace so a
     // stray cross-namespace row (predecessor lookups are namespace-scoped,

--- a/apps/ui/src/features/deploy/task/timeline-events.ts
+++ b/apps/ui/src/features/deploy/task/timeline-events.ts
@@ -71,7 +71,7 @@ export function subscribeDeploymentTaskTimelineEvents(input: {
         emitCurrent();
         return;
       }
-      if (event.taskId !== input.taskId || event.kind === "purge") {
+      if (event.taskId !== input.taskId) {
         return;
       }
       emitCurrent();

--- a/apps/ui/src/features/deploy/task/types.ts
+++ b/apps/ui/src/features/deploy/task/types.ts
@@ -234,7 +234,7 @@ export interface DeployTaskDTO {
   projectId: string | null;
   projectName: string | null;
   resultUrl: string | null;
-  /** Redeploy lineage (predecessor task id, purgeable; ADR 0038). */
+  /** Redeploy lineage (predecessor task id; ADR 0038). */
   retriedFromTaskId?: string | null;
   runner: DeploymentTaskRunner;
   runtimeName: string | null;

--- a/apps/ui/src/features/onboarding/profile-http-handlers.test.ts
+++ b/apps/ui/src/features/onboarding/profile-http-handlers.test.ts
@@ -11,6 +11,7 @@ import { SignJWT } from "jose";
 import {
   assistantChatMessages,
   assistantChats,
+  assistantDevboxRuntimes,
   assistantEntitlements,
   githubAppInstallSessions,
   githubConnections,
@@ -29,6 +30,7 @@ import { onboardingProfiles } from "./schema";
 const testSchema = {
   assistantChatMessages,
   assistantChats,
+  assistantDevboxRuntimes,
   assistantEntitlements,
   githubAppInstallSessions,
   githubConnections,

--- a/apps/ui/src/instrumentation.ts
+++ b/apps/ui/src/instrumentation.ts
@@ -54,4 +54,18 @@ export async function register() {
       error
     );
   }
+  try {
+    const { startChatDevboxLifecycleRuntime } = await import(
+      "@/features/chat/devbox/lifecycle"
+    );
+    startChatDevboxLifecycleRuntime();
+  } catch (error) {
+    if (process.env.NODE_ENV === "production") {
+      throw error;
+    }
+    console.warn(
+      "[instrumentation] chat Devbox lifecycle failed to start:",
+      error
+    );
+  }
 }

--- a/apps/ui/src/lib/devbox/client.test.ts
+++ b/apps/ui/src/lib/devbox/client.test.ts
@@ -18,7 +18,7 @@ afterAll(() => {
   process.env.DEVBOX_TOKEN = originalToken;
 });
 
-const { execDevbox, pauseDevbox } = await import("./client");
+const { deleteDevbox, execDevbox, pauseDevbox } = await import("./client");
 
 test("exec Devbox fetch is cancelled by the caller abort signal", async () => {
   let fetchSignal: AbortSignal | null | undefined;
@@ -80,4 +80,15 @@ test("pause Devbox fetch is cancelled by the caller abort signal", async () => {
   assert.equal(fetchSignal?.aborted, false);
   controller.abort();
   assert.equal(fetchSignal?.aborted, true);
+});
+
+test("delete Devbox leaves network retry to the lifecycle reaper", async () => {
+  let fetchCalls = 0;
+  globalThis.fetch = (() => {
+    fetchCalls += 1;
+    return Promise.reject(new TypeError("fetch failed"));
+  }) as unknown as typeof fetch;
+
+  await assert.rejects(deleteDevbox("ns-test", "runtime"));
+  assert.equal(fetchCalls, 1);
 });

--- a/apps/ui/src/lib/devbox/client.ts
+++ b/apps/ui/src/lib/devbox/client.ts
@@ -23,6 +23,7 @@ import type {
 
 const DEVBOX_REQUEST_TIMEOUT_MS = 60_000;
 const DEVBOX_NETWORK_RETRY_DELAYS_MS = [500, 1500, 3000];
+const DEVBOX_DELETE_TIMEOUT_MS = 10_000;
 
 export class DevboxApiError extends Error {
   status: number;
@@ -129,6 +130,7 @@ async function devboxRequest<T>(
     skipAuth?: boolean;
     searchParams?: URLSearchParams;
     includeApiPrefix?: boolean;
+    networkRetryDelaysMs?: readonly number[];
     timeoutMs?: number;
   }
 ): Promise<DevboxEnvelope<T>> {
@@ -136,17 +138,14 @@ async function devboxRequest<T>(
     authNamespace,
     headers: initHeaders,
     includeApiPrefix,
+    networkRetryDelaysMs = DEVBOX_NETWORK_RETRY_DELAYS_MS,
     searchParams,
     skipAuth,
     timeoutMs,
     ...requestInit
   } = init ?? {};
 
-  for (
-    let attempt = 0;
-    attempt <= DEVBOX_NETWORK_RETRY_DELAYS_MS.length;
-    attempt += 1
-  ) {
+  for (let attempt = 0; attempt <= networkRetryDelaysMs.length; attempt += 1) {
     requestInit.signal?.throwIfAborted();
     const headers = new Headers(initHeaders);
 
@@ -184,7 +183,7 @@ async function devboxRequest<T>(
       return await parseJsonResponse<T>(response);
     } catch (error) {
       requestInit.signal?.throwIfAborted();
-      const retryDelay = DEVBOX_NETWORK_RETRY_DELAYS_MS[attempt];
+      const retryDelay = networkRetryDelaysMs[attempt];
       if (!isRetryableNetworkError(error) || retryDelay === undefined) {
         throw error;
       }
@@ -293,7 +292,12 @@ export async function resumeDevbox(
 export async function deleteDevbox(authNamespace: string, name: string) {
   return await devboxRequest<DeleteDevboxResult>(
     `/${encodeURIComponent(name)}`,
-    { authNamespace, method: "DELETE" }
+    {
+      authNamespace,
+      method: "DELETE",
+      networkRetryDelaysMs: [],
+      timeoutMs: DEVBOX_DELETE_TIMEOUT_MS,
+    }
   );
 }
 

--- a/apps/ui/src/lib/devbox/config-core.ts
+++ b/apps/ui/src/lib/devbox/config-core.ts
@@ -47,10 +47,6 @@ export function getDevboxDefaultImageFromEnv(
   return image === "" ? undefined : image;
 }
 
-export function getDevboxArchiveAfterPauseTimeFromEnv(env: DevboxEnv): string {
-  return env.DEVBOX_ARCHIVE_AFTER_PAUSE_TIME?.trim() || "24h";
-}
-
 export function validateDevboxAuthNamespace(namespace: string): string {
   const trimmed = namespace.trim();
   if (!DNS_1123_LABEL_REGEX.test(trimmed)) {

--- a/apps/ui/src/lib/devbox/config.ts
+++ b/apps/ui/src/lib/devbox/config.ts
@@ -2,7 +2,6 @@ import "server-only";
 
 import {
   DEVBOX_API_PREFIX,
-  getDevboxArchiveAfterPauseTimeFromEnv,
   getDevboxAuthTokenFromEnv,
   getDevboxBaseUrlFromEnv,
   getDevboxDefaultImageFromEnv,
@@ -23,10 +22,6 @@ export function getDevboxApiPrefix(): string {
 
 export function getDevboxDefaultImage(): string | undefined {
   return getDevboxDefaultImageFromEnv(process.env);
-}
-
-export function getDevboxArchiveAfterPauseTime(): string | undefined {
-  return getDevboxArchiveAfterPauseTimeFromEnv(process.env);
 }
 
 export async function getDevboxAuthToken(namespace: string): Promise<string> {

--- a/apps/ui/src/lib/devbox/types.ts
+++ b/apps/ui/src/lib/devbox/types.ts
@@ -54,7 +54,6 @@ export interface CreateDevboxKubeAccess {
 }
 
 export interface CreateDevboxInput {
-  archiveAfterPauseTime?: string;
   env?: Record<string, string>;
   image?: string;
   kubeAccess?: CreateDevboxKubeAccess;

--- a/apps/ui/src/lib/identity-fingerprint-core.test.ts
+++ b/apps/ui/src/lib/identity-fingerprint-core.test.ts
@@ -11,6 +11,7 @@ import { migrate } from "drizzle-orm/pglite/migrator";
 import {
   assistantChatMessages,
   assistantChats,
+  assistantDevboxRuntimes,
   assistantEntitlements,
   githubAppInstallSessions,
   githubConnections,
@@ -28,6 +29,7 @@ import {
 const assistantSchema = {
   assistantChatMessages,
   assistantChats,
+  assistantDevboxRuntimes,
   assistantEntitlements,
   githubAppInstallSessions,
   githubConnections,

--- a/charts/brain-system/values.local.example.yaml
+++ b/charts/brain-system/values.local.example.yaml
@@ -61,7 +61,6 @@ ui:
     DEVBOX_TOKEN: ""
     DEVBOX_JWT_SIGNING_KEY: "REPLACE_ME_DEVBOX_JWT_SIGNING_KEY"
     DEVBOX_RUNTIME_IMAGE: ""
-    DEVBOX_ARCHIVE_AFTER_PAUSE_TIME: "24h"
     DEVBOX_JWT_TTL_SECONDS: "14400"
     # Storage ceiling for newly created deployment runtimes; existing Devboxes are unchanged.
     DEPLOY_DEVBOX_STORAGE_LIMIT: "10Gi"

--- a/charts/brain-system/values.yaml
+++ b/charts/brain-system/values.yaml
@@ -129,7 +129,6 @@ ui:
     DEVBOX_TOKEN: ""
     DEVBOX_JWT_SIGNING_KEY: ""
     DEVBOX_RUNTIME_IMAGE: ""
-    DEVBOX_ARCHIVE_AFTER_PAUSE_TIME: "24h"
     DEVBOX_JWT_TTL_SECONDS: "14400"
     DEPLOY_DEVBOX_STORAGE_LIMIT: "10Gi"
     # Optional. Leave empty to use the production brain-deploy skill source.

--- a/docs/adr/0038-model-deployment-lifecycle-actions-as-cancel-redeploy-retention.md
+++ b/docs/adr/0038-model-deployment-lifecycle-actions-as-cancel-redeploy-retention.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Accepted; supplemented by ADR-0056 — a Redeploy resolves a fresh Deployment
+Accepted; amended 2026-08-05 to retain task history permanently and delete
+paused Devboxes after 24 hours. Supplemented by ADR-0056 — a Redeploy resolves a fresh Deployment
 Credential Binding from the initiating Workspace Actor and never inherits the
 predecessor's actor, credential owner, or connection reference.
 
@@ -56,3 +57,15 @@ The original runner deleted a failed template deployment's labeled resources on 
 - **Cleanup requires both a typed apply-stage failure and a freshly allocated identity.** The apply provider call marks its own errors (`stage: "apply"` on the attached failure details); cleanup runs only when that marker is present and the template instance name was allocated by this run. Only then does the selector provably match nothing but this run's partial creation.
 - **Everything else preserves resources.** Readiness timeouts (failing with the readiness-timeout reason per ADR 0037), post-apply persistence errors, pre-apply generation errors, and any failure on a reused identity leave resources untouched — their deletion stays an explicit canvas action, and a Redeploy converges on whatever remains.
 - **Misjudgment degrades toward preservation.** A lost or absent stage marker skips cleanup; the failure summary for a readiness timeout tells the user the created resources were preserved and that Redeploy reuses them.
+
+## Amendment (2026-08-05): Task history is permanent; paused Devboxes are deleted after 24 hours
+
+The original retention decision coupled two resources with different ownership and value: an ephemeral Devbox runtime and the durable Deployment Task audit record. It also relied on Devbox archive to retain an execution environment that no supported workflow resumes. This amendment supersedes every earlier statement in this ADR that Deployment Tasks, events, messages, transcripts, or results are purged after 30 days.
+
+- **Deployment Task history has no application-level expiry.** Task rows, events, messages, timeline snapshots, failure details, artifact summaries, and deployment results remain in PostgreSQL. The engine publishes no purge notification and exposes no task deletion action. Existing `retried_from_task_id` storage remains unchanged for compatibility; its lack of a foreign key no longer implies that predecessors are routinely purgeable.
+- **Deploy Devboxes are deleted independently.** Every terminal AI Deploy Task is brought to `runtime_state=paused` and records `runtime_paused_at` when Brain confirms the pause. After 24 hours, the reaper calls the Devbox DELETE API. Success and not-found both converge on `runtime_state=deleted`; API failure leaves the task and paused timestamp intact for a later sweep.
+- **Chat Devboxes use a durable lifecycle ledger.** Brain records the upstream id, namespace, runtime name, and pause deadline before Create, Resume, warmup, or pause refresh. Confirmed pause starts a 24-hour delete deadline. Activity clears a pending delete before the external Resume path, while short-lived database cleanup claims serialize Pause/Delete against activity so an active Resume cannot race a deletion.
+- **Platform archive is no longer part of the contract.** Brain stops sending `archiveAfterPauseTime`. Historical Deploy Devboxes already represented by task rows enter the new deletion flow through a migration backfill. Historical chat Devboxes that Brain cannot identify safely are not discovered by a destructive global scan.
+- **Runtime cleanup is bounded, leased, and idempotent.** A reaper claims eligible rows with `FOR UPDATE SKIP LOCKED`, commits immediately, calls the Devbox API outside any database transaction, then finalizes through the cleanup owner token. Claims expire after the bounded API window so another process can recover after a crash; failures release the owner and defer eligibility to the next 30-second sweep. DELETE has a 10-second request timeout and no in-request network retry. The reaper processes bounded batches with at most four concurrent Devbox operations, treats 404 as success, and never deletes database history when the Devbox API is unavailable.
+
+There remains no user-facing task or Devbox delete action. The only product-visible lifecycle actions are still Cancel, Blocking Input submission, and Redeploy.


### PR DESCRIPTION
## Summary

- delete Chat and Deploy Devboxes after they have remained paused for 24 hours
- keep Deployment Task rows, events, timeline history, runner transcripts, and deployment results permanently
- add a durable Chat Devbox lifecycle ledger and migration, and track Deploy Devbox pause timestamps
- remove the previous 30-day task purge path and the `archiveAfterPauseTime` Devbox contract

## Why

The previous lifecycle coupled ephemeral Devbox storage to durable deployment history. Paused Devboxes could remain archived for an extended period while Deployment Task audit records were deleted after 30 days. This change separates those lifecycles: runtime storage is reclaimed promptly, while task history remains available.

## Behavior and impact

- terminal Deploy Devboxes are paused, then deleted 24 hours after the confirmed pause
- Chat Devboxes are tracked before create/resume activity; confirmed pause starts their 24-hour deletion deadline
- successful deletion and 404 both converge on `runtimeState=deleted`
- API failures leave lifecycle state intact so the next reaper sweep retries
- no user-facing task or Devbox deletion action is added
- historical paused Deploy Devboxes are backfilled by the database migration

## Validation

- `bun check`
- `bun typecheck`
- 86 focused UI tests
- `helm lint charts/brain-system`
- `bun run db:generate` (no additional schema changes)
- `git diff --check`

## Notes

A live Devbox DELETE canary was not run because the resource API timed out and no dedicated test namespace was available. Root `bun lint` currently fails on unchanged `packages/ui` files that match `main`; the same ESLint failure appears in PR CI.
