### PR TITLE
feat(onboarding): survey dialog with stepwise profile persistence

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -818,6 +818,51 @@ A user-scoped API key minted from the caller's kubeconfig through the `aiproxy-w
 
 _Avoid_: system token, platform key, service account token.
 
+## Onboarding
+
+### Onboarding Profile
+
+The per-person survey record captured by the first-entry sampling dialog
+(the user understanding loop). An Onboarding Profile belongs to the bare
+global `userUid` — Brain's only namespace-less personal resource — so one
+person holds at most one profile per region, regardless of workspaces
+(ADR-0061).
+
+_Avoid_: first-login record, workspace profile, per-workspace survey, user cohort row.
+
+### Sampled
+
+The terminal predicate on an Onboarding Profile: a person is Sampled once a
+completed or dismissed record exists, and the sampling dialog never shows
+again. Anything short of a terminal record — including an abandoned
+mid-survey attempt — leaves the person Unsampled, and the predicate is
+re-judged on every entry.
+
+_Avoid_: has logged in before, first-login flag, seen-dialog cookie, survey done.
+
+### Onboarding Gate
+
+The client-side judgment that decides whether the sampling dialog appears
+for the current person. The Gate is opportunistic and non-blocking: the
+console always renders, and the dialog appears only on a definitive
+Unsampled verdict. Any unknown outcome — credentials never arriving, a
+failed or unresolved status check — means the Gate silently stands down
+until the next entry. Sampling is never bought at the cost of console
+access.
+
+_Avoid_: login wall, blocking splash, mandatory interstitial, onboarding redirect.
+
+### Cohort Tag
+
+The stable machine-readable enum value recorded for a survey answer (e.g.
+`real_business`), decoupled from display copy so a copy revision never
+splits a cohort. Only first-order answers — what the person actually
+selected or typed — are recorded as Cohort Tags; derived interpretations
+(business intent, company context) are read-time computations and are never
+stored.
+
+_Avoid_: raw answer text, display label, derived segment column, business intent field.
+
 ## Design System
 
 ### Component Registry

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -494,6 +494,51 @@ The per-cluster, OpenAI-compatible gateway (Sealos `aiproxy`) serving user-bille
 
 _Avoid_: model provider, LLM backend, system token, platform key.
 
+## Onboarding
+
+### Onboarding Profile
+
+The per-person survey record captured by the first-entry sampling dialog
+(the user understanding loop). An Onboarding Profile belongs to the bare
+global `userUid` — Brain's only namespace-less personal resource — so one
+person holds at most one profile per region, regardless of workspaces
+(ADR-0061).
+
+_Avoid_: first-login record, workspace profile, per-workspace survey, user cohort row.
+
+### Sampled
+
+The terminal predicate on an Onboarding Profile: a person is Sampled once a
+completed or dismissed record exists, and the sampling dialog never shows
+again. Anything short of a terminal record — including an abandoned
+mid-survey attempt — leaves the person Unsampled, and the predicate is
+re-judged on every entry.
+
+_Avoid_: has logged in before, first-login flag, seen-dialog cookie, survey done.
+
+### Onboarding Gate
+
+The client-side judgment that decides whether the sampling dialog appears
+for the current person. The Gate is opportunistic and non-blocking: the
+console always renders, and the dialog appears only on a definitive
+Unsampled verdict. Any unknown outcome — credentials never arriving, a
+failed or unresolved status check — means the Gate silently stands down
+until the next entry. Sampling is never bought at the cost of console
+access.
+
+_Avoid_: login wall, blocking splash, mandatory interstitial, onboarding redirect.
+
+### Cohort Tag
+
+The stable machine-readable enum value recorded for a survey answer (e.g.
+`real_business`), decoupled from display copy so a copy revision never
+splits a cohort. Only first-order answers — what the person actually
+selected or typed — are recorded as Cohort Tags; derived interpretations
+(business intent, company context) are read-time computations and are never
+stored.
+
+_Avoid_: raw answer text, display label, derived segment column, business intent field.
+
 ## Design System
 
 ### Component Registry

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -539,51 +539,6 @@ stored.
 
 _Avoid_: raw answer text, display label, derived segment column, business intent field.
 
-## Onboarding
-
-### Onboarding Profile
-
-The per-person survey record captured by the first-entry sampling dialog
-(the user understanding loop). An Onboarding Profile belongs to the bare
-global `userUid` — Brain's only namespace-less personal resource — so one
-person holds at most one profile per region, regardless of workspaces
-(ADR-0061).
-
-_Avoid_: first-login record, workspace profile, per-workspace survey, user cohort row.
-
-### Sampled
-
-The terminal predicate on an Onboarding Profile: a person is Sampled once a
-completed or dismissed record exists, and the sampling dialog never shows
-again. Anything short of a terminal record — including an abandoned
-mid-survey attempt — leaves the person Unsampled, and the predicate is
-re-judged on every entry.
-
-_Avoid_: has logged in before, first-login flag, seen-dialog cookie, survey done.
-
-### Onboarding Gate
-
-The client-side judgment that decides whether the sampling dialog appears
-for the current person. The Gate is opportunistic and non-blocking: the
-console always renders, and the dialog appears only on a definitive
-Unsampled verdict. Any unknown outcome — credentials never arriving, a
-failed or unresolved status check — means the Gate silently stands down
-until the next entry. Sampling is never bought at the cost of console
-access.
-
-_Avoid_: login wall, blocking splash, mandatory interstitial, onboarding redirect.
-
-### Cohort Tag
-
-The stable machine-readable enum value recorded for a survey answer (e.g.
-`real_business`), decoupled from display copy so a copy revision never
-splits a cohort. Only first-order answers — what the person actually
-selected or typed — are recorded as Cohort Tags; derived interpretations
-(business intent, company context) are read-time computations and are never
-stored.
-
-_Avoid_: raw answer text, display label, derived segment column, business intent field.
-
 ## Design System
 
 ### Component Registry

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -516,6 +516,17 @@ re-judged on every entry.
 
 _Avoid_: has logged in before, first-login flag, seen-dialog cookie, survey done.
 
+### Terminal Snapshot
+
+The full set of confirmed answers a survey session carries on its terminal
+action (submit or skip), making the resulting Sampled record complete on
+its own — it never depends on the per-step best-effort saves having
+survived. Only answers the person confirmed by advancing are part of the
+snapshot; an unconfirmed selection or unsubmitted draft is not. A snapshot
+never erases previously saved answers it does not itself carry.
+
+_Avoid_: final sync, answer replay, batched answers, form dump.
+
 ### Onboarding Gate
 
 The client-side judgment that decides whether the sampling dialog appears

--- a/apps/ui/drizzle.config.ts
+++ b/apps/ui/drizzle.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
   schema: [
     "./src/features/chat/persistence/schema.ts",
     "./src/features/deploy/task/schema.ts",
+    "./src/features/onboarding/schema.ts",
     "./src/lib/project-persistence/schema.ts",
   ],
   dbCredentials: { url: process.env.DATABASE_URL ?? "" },

--- a/apps/ui/drizzle/0011_onboarding_profiles.sql
+++ b/apps/ui/drizzle/0011_onboarding_profiles.sql
@@ -1,0 +1,17 @@
+CREATE SCHEMA "sealai_onboarding";
+--> statement-breakpoint
+CREATE TABLE "sealai_onboarding"."onboarding_profiles" (
+	"user_uid" text PRIMARY KEY NOT NULL,
+	"status" text NOT NULL,
+	"dismissed_at_step" integer,
+	"role_type" text,
+	"role_other_text" text,
+	"usage_context" text,
+	"usage_other_text" text,
+	"priority_tags" jsonb,
+	"priority_display_order" jsonb,
+	"priority_other_text" text,
+	"open_goal_text" text,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/apps/ui/drizzle/meta/0011_snapshot.json
+++ b/apps/ui/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1933 @@
+{
+  "id": "cf4cbc1d-01b6-4fa3-936c-70d9d816091a",
+  "prevId": "77ccc87d-883f-4159-a4dc-7736b73fe782",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "sealai_assistant.assistant_chat_messages": {
+      "name": "assistant_chat_messages",
+      "schema": "sealai_assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assistant_chat_messages_chat_id_idx": {
+          "name": "assistant_chat_messages_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assistant_chat_messages_chat_id_created_idx": {
+          "name": "assistant_chat_messages_chat_id_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assistant_chat_messages_chat_id_assistant_chats_id_fk": {
+          "name": "assistant_chat_messages_chat_id_assistant_chats_id_fk",
+          "tableFrom": "assistant_chat_messages",
+          "tableTo": "assistant_chats",
+          "schemaTo": "sealai_assistant",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.assistant_chats": {
+      "name": "assistant_chats",
+      "schema": "sealai_assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_actor": {
+          "name": "workspace_actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Chat'"
+        },
+        "title_ai_generated": {
+          "name": "title_ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assistant_chats_updated_at_idx": {
+          "name": "assistant_chats_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assistant_chats_namespace_actor_updated_at_idx": {
+          "name": "assistant_chats_namespace_actor_updated_at_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_actor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.assistant_entitlements": {
+      "name": "assistant_entitlements",
+      "schema": "sealai_assistant",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "free_turns_used": {
+          "name": "free_turns_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assistant_entitlements_updated_at_idx": {
+          "name": "assistant_entitlements_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.github_app_install_sessions": {
+      "name": "github_app_install_sessions",
+      "schema": "sealai_assistant",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_actor": {
+          "name": "workspace_actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "owner_identity_version": {
+          "name": "owner_identity_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "return_path": {
+          "name": "return_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_app_install_sessions_expires_at_idx": {
+          "name": "github_app_install_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_app_install_sessions_namespace_idx": {
+          "name": "github_app_install_sessions_namespace_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.github_connections": {
+      "name": "github_connections",
+      "schema": "sealai_assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github_app'"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'User'"
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_connections_updated_at_idx": {
+          "name": "github_connections_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_namespace_updated_at_idx": {
+          "name": "github_connections_namespace_updated_at_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_namespace_unique_idx": {
+          "name": "github_connections_namespace_unique_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_installation_idx": {
+          "name": "github_connections_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.github_oauth_connections": {
+      "name": "github_oauth_connections",
+      "schema": "sealai_assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_actor": {
+          "name": "workspace_actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "owner_identity_version": {
+          "name": "owner_identity_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "github_login": {
+          "name": "github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bearer'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_oauth_connections_updated_at_idx": {
+          "name": "github_oauth_connections_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_oauth_connections_github_login_idx": {
+          "name": "github_oauth_connections_github_login_idx",
+          "columns": [
+            {
+              "expression": "github_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_oauth_connections_current_owner_unique_idx": {
+          "name": "github_oauth_connections_current_owner_unique_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_actor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sealai_assistant\".\"github_oauth_connections\".\"owner_identity_version\" = 2",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.identity_fingerprints": {
+      "name": "identity_fingerprints",
+      "schema": "sealai_assistant",
+      "columns": {
+        "cr_name": {
+          "name": "cr_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_uid": {
+          "name": "user_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minted_at": {
+          "name": "minted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_deployment.deploy_task_events": {
+      "name": "deploy_task_events",
+      "schema": "sealai_deployment",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nextval('sealai_deployment.deploy_task_events_seq'::regclass)"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deploy_task_events_task_created_at_idx": {
+          "name": "deploy_task_events_task_created_at_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deploy_task_events_task_id_deploy_tasks_id_fk": {
+          "name": "deploy_task_events_task_id_deploy_tasks_id_fk",
+          "tableFrom": "deploy_task_events",
+          "tableTo": "deploy_tasks",
+          "schemaTo": "sealai_deployment",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "deploy_task_events_pk": {
+          "name": "deploy_task_events_pk",
+          "columns": ["task_id", "seq"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_deployment.deploy_task_messages": {
+      "name": "deploy_task_messages",
+      "schema": "sealai_deployment",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deploy_task_messages_task_id_idx": {
+          "name": "deploy_task_messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_task_messages_task_created_idx": {
+          "name": "deploy_task_messages_task_created_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deploy_task_messages_task_id_deploy_tasks_id_fk": {
+          "name": "deploy_task_messages_task_id_deploy_tasks_id_fk",
+          "tableFrom": "deploy_task_messages",
+          "tableTo": "deploy_tasks",
+          "schemaTo": "sealai_deployment",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_deployment.deploy_tasks": {
+      "name": "deploy_tasks",
+      "schema": "sealai_deployment",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_uid": {
+          "name": "project_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creating_actor": {
+          "name": "creating_actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_binding": {
+          "name": "credential_binding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_connection_id": {
+          "name": "github_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_from": {
+          "name": "created_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_name": {
+          "name": "runtime_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_url": {
+          "name": "gateway_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_session_id": {
+          "name": "gateway_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_thread_id": {
+          "name": "gateway_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_turn_id": {
+          "name": "gateway_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_state_snapshot": {
+          "name": "gateway_state_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_details": {
+          "name": "failure_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_summary": {
+          "name": "artifact_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "canvas_projection": {
+          "name": "canvas_projection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "timeline_snapshot": {
+          "name": "timeline_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocking_inputs": {
+          "name": "blocking_inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "preview_url": {
+          "name": "preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_url": {
+          "name": "result_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_epoch": {
+          "name": "lease_epoch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_claimed_at": {
+          "name": "lease_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retried_from_task_id": {
+          "name": "retried_from_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deploy_tasks_namespace_updated_at_idx": {
+          "name": "deploy_tasks_namespace_updated_at_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_project_uid_updated_at_idx": {
+          "name": "deploy_tasks_project_uid_updated_at_idx",
+          "columns": [
+            {
+              "expression": "project_uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_status_updated_at_idx": {
+          "name": "deploy_tasks_status_updated_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_leased_expiry_idx": {
+          "name": "deploy_tasks_leased_expiry_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"status\" IN ('running', 'applying')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_queued_created_idx": {
+          "name": "deploy_tasks_queued_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_terminal_completed_idx": {
+          "name": "deploy_tasks_terminal_completed_idx",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"status\" IN ('completed', 'failed', 'cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_one_active_clone_idx": {
+          "name": "deploy_tasks_one_active_clone_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retried_from_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"retried_from_task_id\" IS NOT NULL AND \"sealai_deployment\".\"deploy_tasks\".\"status\" IN ('queued', 'running', 'blocked', 'applying')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_onboarding.onboarding_profiles": {
+      "name": "onboarding_profiles",
+      "schema": "sealai_onboarding",
+      "columns": {
+        "user_uid": {
+          "name": "user_uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dismissed_at_step": {
+          "name": "dismissed_at_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_type": {
+          "name": "role_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_other_text": {
+          "name": "role_other_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_context": {
+          "name": "usage_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_other_text": {
+          "name": "usage_other_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_tags": {
+          "name": "priority_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_display_order": {
+          "name": "priority_display_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_other_text": {
+          "name": "priority_other_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_goal_text": {
+          "name": "open_goal_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_canvas_layouts": {
+      "name": "project_canvas_layouts",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_uid": {
+          "name": "project_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name_snapshot": {
+          "name": "project_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "nodes": {
+          "name": "nodes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_canvas_layouts_updated_at_idx": {
+          "name": "project_canvas_layouts_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_canvas_layouts_pk": {
+          "name": "project_canvas_layouts_pk",
+          "columns": ["namespace", "project_uid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_delete_operations": {
+      "name": "project_delete_operations",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_uid": {
+          "name": "actor_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_id": {
+          "name": "preview_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_delete_operations_expires_at_idx": {
+          "name": "project_delete_operations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_delete_operations_pk": {
+          "name": "project_delete_operations_pk",
+          "columns": ["namespace", "project_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_delete_previews": {
+      "name": "project_delete_previews",
+      "schema": "sealai_project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_uid": {
+          "name": "actor_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_summary": {
+          "name": "resource_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_delete_previews_expires_at_idx": {
+          "name": "project_delete_previews_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_delete_previews_target_idx": {
+          "name": "project_delete_previews_target_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_delete_previews_pk": {
+          "name": "project_delete_previews_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_management_audit_events": {
+      "name": "project_management_audit_events",
+      "schema": "sealai_project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_uid": {
+          "name": "actor_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_summary": {
+          "name": "resource_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_management_audit_events_target_idx": {
+          "name": "project_management_audit_events_target_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_management_audit_events_pk": {
+          "name": "project_management_audit_events_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_navigation_preferences": {
+      "name": "project_navigation_preferences",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_project_ids": {
+          "name": "pinned_project_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_navigation_preferences_updated_at_idx": {
+          "name": "project_navigation_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_navigation_preferences_pk": {
+          "name": "project_navigation_preferences_pk",
+          "columns": ["namespace"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.projects": {
+      "name": "projects",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_namespace_lower_display_name_idx": {
+          "name": "projects_namespace_lower_display_name_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"display_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "projects_pk": {
+          "name": "projects_pk",
+          "columns": ["namespace", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "sealai_assistant": "sealai_assistant",
+    "sealai_deployment": "sealai_deployment",
+    "sealai_onboarding": "sealai_onboarding",
+    "sealai_project": "sealai_project"
+  },
+  "sequences": {
+    "sealai_deployment.deploy_task_events_seq": {
+      "name": "deploy_task_events_seq",
+      "schema": "sealai_deployment",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/ui/drizzle/meta/_journal.json
+++ b/apps/ui/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1785399621883,
       "tag": "0010_tiny_cardiac",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1785920126051,
+      "tag": "0011_onboarding_profiles",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/ui/scripts/reset-local-db.mjs
+++ b/apps/ui/scripts/reset-local-db.mjs
@@ -28,6 +28,7 @@ try {
     DROP SCHEMA IF EXISTS
       sealai_assistant,
       sealai_deployment,
+      sealai_onboarding,
       sealai_project,
       drizzle
     CASCADE;

--- a/apps/ui/src/app/api/onboarding-profile/complete/route.ts
+++ b/apps/ui/src/app/api/onboarding-profile/complete/route.ts
@@ -1,0 +1,6 @@
+import { onboardingProfileRouteHandlers } from "@/features/onboarding/profile-route-handlers";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export const POST = onboardingProfileRouteHandlers.complete;

--- a/apps/ui/src/app/api/onboarding-profile/dismiss/route.ts
+++ b/apps/ui/src/app/api/onboarding-profile/dismiss/route.ts
@@ -1,0 +1,6 @@
+import { onboardingProfileRouteHandlers } from "@/features/onboarding/profile-route-handlers";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export const POST = onboardingProfileRouteHandlers.dismiss;

--- a/apps/ui/src/app/api/onboarding-profile/sampling/route.ts
+++ b/apps/ui/src/app/api/onboarding-profile/sampling/route.ts
@@ -1,0 +1,6 @@
+import { onboardingProfileRouteHandlers } from "@/features/onboarding/profile-route-handlers";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export const GET = onboardingProfileRouteHandlers.sampling;

--- a/apps/ui/src/app/api/onboarding-profile/step/route.ts
+++ b/apps/ui/src/app/api/onboarding-profile/step/route.ts
@@ -1,0 +1,6 @@
+import { onboardingProfileRouteHandlers } from "@/features/onboarding/profile-route-handlers";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export const POST = onboardingProfileRouteHandlers.answerStep;

--- a/apps/ui/src/app/project/layout.test.tsx
+++ b/apps/ui/src/app/project/layout.test.tsx
@@ -6,6 +6,9 @@ import { isValidElement, type ReactNode } from "react";
 // layout reaches it through the Devbox warmup server action.
 mock.module("server-only", () => ({}));
 
+const { OnboardingGate } = await import(
+  "@/features/onboarding/onboarding-gate"
+);
 const { DevboxBootstrap, SealosSdkBootstrap } = await import(
   "@/features/shell/auth-bootstrap"
 );
@@ -43,4 +46,12 @@ test("project layout mounts the Devbox warmup", () => {
 
   assert.ok(mounted.has(DevboxBootstrap), "DevboxBootstrap is mounted");
   assert.ok(mounted.has(SealosSdkBootstrap), "SealosSdkBootstrap is mounted");
+});
+
+// The Onboarding Gate covers the whole console surface from this layout
+// (ADR-0061); an unmounted gate silently stops all sampling.
+test("project layout mounts the Onboarding Gate", () => {
+  const mounted = mountedComponents(ProjectLayout({ children: null }));
+
+  assert.ok(mounted.has(OnboardingGate), "OnboardingGate is mounted");
 });

--- a/apps/ui/src/app/project/layout.tsx
+++ b/apps/ui/src/app/project/layout.tsx
@@ -1,3 +1,4 @@
+import { OnboardingGate } from "@/features/onboarding/onboarding-gate";
 import {
   AppShellChrome,
   AppShellSidebar,
@@ -22,6 +23,7 @@ export default function ProjectLayout({
       <AuthBootstrap serverEncodedKubeconfig="" serverNamespace="" />
       <SealosSdkBootstrap />
       <DevboxBootstrap />
+      <OnboardingGate />
       <AppShellSidebar />
       <AppShellView className="min-w-0 flex-1 basis-0">
         <ProjectWorkspaceLayout>{children}</ProjectWorkspaceLayout>

--- a/apps/ui/src/features/analytics/brain-gtm.ts
+++ b/apps/ui/src/features/analytics/brain-gtm.ts
@@ -57,12 +57,37 @@ interface BrainGtmCardActionEvent {
   project_id: string;
 }
 
+/** The sampling dialog's 4 steps; the dialog's appearance counts as step 1. */
+export type BrainGtmOnboardingStep = 1 | 2 | 3 | 4;
+
+// The three onboarding funnel events carry step numbers only (spec #88):
+// answer values, free text, and user IDs have no fields to travel in, so the
+// privacy rule is enforced by the closed union rather than by discipline.
+
+export interface BrainGtmOnboardingStepViewEvent {
+  event: "onboarding_step_view";
+  step: BrainGtmOnboardingStep;
+}
+
+export interface BrainGtmOnboardingSkipEvent {
+  event: "onboarding_skip";
+  /** The step the person left from. */
+  step: BrainGtmOnboardingStep;
+}
+
+export interface BrainGtmOnboardingCompleteEvent {
+  event: "onboarding_complete";
+}
+
 export type BrainGtmEvent =
   | BrainGtmCardActionEvent
   | BrainGtmDeploymentCreateEvent
   | BrainGtmDeploymentDeleteEvent
   | BrainGtmDeploymentStartEvent
-  | BrainGtmModuleViewEvent;
+  | BrainGtmModuleViewEvent
+  | BrainGtmOnboardingCompleteEvent
+  | BrainGtmOnboardingSkipEvent
+  | BrainGtmOnboardingStepViewEvent;
 
 export interface BrainGtmSessionStorage {
   getItem: (key: string) => string | null;

--- a/apps/ui/src/features/chat/runtime/conversation-handlers.test.ts
+++ b/apps/ui/src/features/chat/runtime/conversation-handlers.test.ts
@@ -296,6 +296,7 @@ test("reading another member's conversation is indistinguishable from a missing 
   const missingBody = await missing.json();
   assert.deepEqual(foreignBody, missingBody);
   assert.deepEqual(missingBody, {
+    code: "assistant_conversation_not_found",
     error: "Assistant conversation not found.",
   });
 });

--- a/apps/ui/src/features/chat/runtime/conversation-handlers.ts
+++ b/apps/ui/src/features/chat/runtime/conversation-handlers.ts
@@ -1,17 +1,12 @@
 import type { UIMessage } from "ai";
+import type { AppTokenVerificationConfig } from "@/lib/app-token";
+import type { ObserveIdentityFingerprint } from "@/lib/identity-fingerprint-core";
 import {
-  type AppTokenVerificationConfig,
-  appTokenFromRequest,
-} from "@/lib/app-token";
-import {
-  IdentityBindingSupersededError,
-  type ObserveIdentityFingerprint,
-} from "@/lib/identity-fingerprint-core";
-import {
-  authorizeWorkspaceActor,
-  encodedKubeconfigFromRequest,
-  type VerifyKubeconfigNamespace,
-} from "@/lib/request-kubeconfig-auth";
+  authorizePersonalResourceRequest,
+  jsonError,
+  supersededBindingResponse,
+} from "@/lib/personal-resource-http";
+import type { VerifyKubeconfigNamespace } from "@/lib/request-kubeconfig-auth";
 import { verifiedPersonalResourceActor } from "@/lib/verified-personal-actor";
 import {
   type AssistantConversationOwner,
@@ -20,7 +15,6 @@ import {
   normalizeAssistantNamespace,
   type VerifiedAssistantConversationActor,
 } from "../persistence/types";
-import { jsonError } from "./errors";
 
 export interface AssistantConversationHandlerDependencies {
   /**
@@ -46,49 +40,42 @@ export interface AssistantConversationHandlerDependencies {
 }
 
 function conversationNotFound(): Response {
-  return jsonError("Assistant conversation not found.", 404);
-}
-
-/** The adoption write found the binding superseded by a merge (ADR-0059). */
-function supersededBindingResponse(error: unknown): Response | null {
-  return error instanceof IdentityBindingSupersededError
-    ? jsonError("Authentication is required.", 401)
-    : null;
+  return jsonError({
+    code: "assistant_conversation_not_found",
+    message: "Assistant conversation not found.",
+    status: 404,
+  });
 }
 
 export function createAssistantConversationHandlers(
   dependencies: AssistantConversationHandlerDependencies
 ) {
   const authorize = async (
-    request: Request,
-    clientNamespace = new URL(request.url).searchParams.get("namespace")
+    request: Request
   ): Promise<
     | { ok: true; actor: VerifiedAssistantConversationActor }
     | { ok: false; response: Response }
   > => {
-    const authorization = await authorizeWorkspaceActor({
-      appToken: appTokenFromRequest(request),
+    const result = await authorizePersonalResourceRequest(request, {
       appTokenConfig: dependencies.appTokenConfig,
-      encodedKubeconfig: encodedKubeconfigFromRequest(request),
-      expectedNamespace: clientNamespace?.trim() || undefined,
       normalizeNamespace: normalizeAssistantNamespace,
       observeFingerprint: dependencies.observeFingerprint,
       verify: dependencies.verify,
     });
-    if (!authorization.ok) {
-      return {
-        ok: false,
-        response: jsonError(authorization.message, authorization.status),
-      };
-    }
-    return { actor: verifiedPersonalResourceActor(authorization), ok: true };
+    return result.ok
+      ? { actor: verifiedPersonalResourceActor(result.authorization), ok: true }
+      : result;
   };
 
   return {
     messagesGet: async (request: Request): Promise<Response> => {
       const chatId = new URL(request.url).searchParams.get("chatId")?.trim();
       if (!chatId) {
-        return jsonError("chatId query parameter required", 400);
+        return jsonError({
+          code: "invalid_request",
+          message: "chatId query parameter required",
+          status: 400,
+        });
       }
       const authorization = await authorize(request);
       if (!authorization.ok) {
@@ -109,7 +96,11 @@ export function createAssistantConversationHandlers(
           return superseded;
         }
         console.error("[api/chat/messages] persistence unavailable");
-        return jsonError("Assistant chat persistence is unavailable.", 503);
+        return jsonError({
+          code: "assistant_chat_unavailable",
+          message: "Assistant chat persistence is unavailable.",
+          status: 503,
+        });
       }
     },
     session: async (request: Request): Promise<Response> => {
@@ -128,10 +119,12 @@ export function createAssistantConversationHandlers(
           return superseded;
         }
         console.error("[api/chat/session] persistence unavailable");
-        return jsonError(
-          "Could not load assistant session (database / DATABASE_URL).",
-          503
-        );
+        return jsonError({
+          code: "assistant_chat_unavailable",
+          message:
+            "Could not load assistant session (database / DATABASE_URL).",
+          status: 503,
+        });
       }
     },
     threads: async (request: Request): Promise<Response> => {
@@ -150,10 +143,12 @@ export function createAssistantConversationHandlers(
           return superseded;
         }
         console.error("[api/chat/threads] persistence unavailable");
-        return jsonError(
-          "Assistant chat persistence is unavailable (check DATABASE_URL).",
-          503
-        );
+        return jsonError({
+          code: "assistant_chat_unavailable",
+          message:
+            "Assistant chat persistence is unavailable (check DATABASE_URL).",
+          status: 503,
+        });
       }
     },
   };

--- a/apps/ui/src/features/deploy/github/connection-http-handlers.ts
+++ b/apps/ui/src/features/deploy/github/connection-http-handlers.ts
@@ -3,10 +3,11 @@ import {
   type AppTokenVerificationConfig,
   appTokenFromRequest,
 } from "@/lib/app-token";
+import type { ObserveIdentityFingerprint } from "@/lib/identity-fingerprint-core";
 import {
-  IdentityBindingSupersededError,
-  type ObserveIdentityFingerprint,
-} from "@/lib/identity-fingerprint-core";
+  jsonError,
+  supersededBindingResponse,
+} from "@/lib/personal-resource-http";
 import {
   authorizeWorkspaceActor,
   encodedKubeconfigFromRequest,
@@ -87,17 +88,6 @@ function publicConnectionStatus(connection: object | null): object | null {
   return status;
 }
 
-function jsonError(input: {
-  code: string;
-  message: string;
-  status: number;
-}): Response {
-  return Response.json(
-    { code: input.code, error: input.message },
-    { status: input.status }
-  );
-}
-
 async function authorizeGithubConnectionOwner(input: {
   appToken: string;
   appTokenConfig?: AppTokenVerificationConfig | null;
@@ -153,17 +143,6 @@ function authorizeGithubConnectionRequest(
       new URL(request.url).searchParams.get("namespace")?.trim() || undefined,
     verify: options.verify,
   });
-}
-
-/** The write found the binding superseded by a concurrent merge (ADR-0059). */
-function supersededBindingResponse(error: unknown): Response | null {
-  return error instanceof IdentityBindingSupersededError
-    ? jsonError({
-        code: "app_token_superseded",
-        message: "Authentication is required.",
-        status: 401,
-      })
-    : null;
 }
 
 async function authorizeGithubSessionRequest(

--- a/apps/ui/src/features/dev-tweaks/dev-tweaks-pane.test.tsx
+++ b/apps/ui/src/features/dev-tweaks/dev-tweaks-pane.test.tsx
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  actAndDrain,
+  installTestDom,
+  restoreActEnvironment,
+  setActEnvironment,
+} from "@/features/project-canvas/react-test-harness";
+
+import { devTweaksStore } from "./dev-tweaks-store";
+
+// Dialog content sits at z-[51] and select popups at z-[52], both portaled
+// to <body> (packages/ui dialog.tsx / app-select.tsx). The pane must clear
+// that whole band, or a modal that only the pane can switch off (e.g. the
+// onboarding forceModal knob) buries its own off switch.
+const POPUP_BAND_TOP = 52;
+
+const Z_LAYER_RE = /z-\[(\d+)\]/;
+
+test("the pane portals to <body> and stacks above the popup band", async () => {
+  const dom = installTestDom();
+  const previousActEnvironment = setActEnvironment(true);
+  const { render } = await import("@testing-library/react/pure");
+  const { DevTweaksPane } = await import("./dev-tweaks-pane");
+  let rendered: ReturnType<typeof render> | undefined;
+
+  try {
+    devTweaksStore.setOpen(true);
+    await actAndDrain(() => {
+      rendered = render(
+        <div id="deep-app-shell">
+          <DevTweaksPane />
+        </div>
+      );
+    });
+
+    const pane = document.querySelector('aside[aria-label="Dev tweaks"]');
+    assert.ok(pane, "the pane is rendered while the store is open");
+    assert.equal(
+      pane.parentElement,
+      document.body,
+      "the pane escapes the app tree via a body portal, so later-mounted popup portals cannot bury it by DOM order"
+    );
+
+    const zMatch = Z_LAYER_RE.exec(pane.className);
+    assert.ok(
+      zMatch,
+      `the pane carries an explicit z layer: ${pane.className}`
+    );
+    assert.ok(
+      Number(zMatch[1]) > POPUP_BAND_TOP,
+      `the pane's z layer (${zMatch[1]}) clears the popup band (dialogs 51, selects 52)`
+    );
+  } finally {
+    await actAndDrain(() => {
+      devTweaksStore.setOpen(false);
+    });
+    await actAndDrain(() => {
+      rendered?.unmount();
+    });
+    restoreActEnvironment(previousActEnvironment);
+    await dom.restore();
+  }
+});

--- a/apps/ui/src/features/dev-tweaks/dev-tweaks-pane.tsx
+++ b/apps/ui/src/features/dev-tweaks/dev-tweaks-pane.tsx
@@ -8,6 +8,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+import { createPortal } from "react-dom";
 
 import {
   type DevTweakDef,
@@ -62,10 +63,14 @@ export function DevTweaksPane() {
     return null;
   }
 
-  return (
+  // Portaled to <body> at z-[60] so it stacks above every popup layer —
+  // dialogs sit at z-[51] and their pointer-blocking internal backdrop at
+  // z-auto, so a debug pane rendered in-tree gets buried and its knobs
+  // (e.g. the onboarding forceModal switch) become unreachable.
+  return createPortal(
     <aside
       aria-label="Dev tweaks"
-      className="fixed top-16 right-4 z-50 flex max-h-[calc(100dvh-5rem)] w-80 flex-col overflow-hidden rounded-xl border bg-popover/95 text-popover-foreground shadow-xl backdrop-blur-sm"
+      className="fixed top-16 right-4 z-[60] flex max-h-[calc(100dvh-5rem)] w-80 flex-col overflow-hidden rounded-xl border bg-popover/95 text-popover-foreground shadow-xl backdrop-blur-sm"
     >
       <header className="flex items-center gap-1 border-b px-3 py-2">
         <h2 className="flex-1 truncate font-medium text-xs">Dev tweaks</h2>
@@ -101,7 +106,8 @@ export function DevTweaksPane() {
       <footer className="border-t px-3 py-1.5 text-muted-foreground text-xs">
         ⌃⌥T toggles this pane
       </footer>
-    </aside>
+    </aside>,
+    document.body
   );
 }
 

--- a/apps/ui/src/features/onboarding/client.test.ts
+++ b/apps/ui/src/features/onboarding/client.test.ts
@@ -1,0 +1,102 @@
+// bun:test, not node:test: this file shares a `bun test` run with the
+// react-harness suites, whose in-flight async tests make Bun's node:test
+// shim reject a second file's registrations as nested test() calls.
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+
+import {
+  answerOnboardingStep,
+  completeOnboardingProfile,
+  dismissOnboardingProfile,
+  onboardingWriteQueueSettled,
+} from "./client";
+
+const credentials = {
+  appToken: "token",
+  kubeconfig: "kc",
+  namespace: "ns-user",
+};
+
+const STEP_PATH_RE = /\/step/;
+const COMPLETE_PATH_RE = /\/complete/;
+const DISMISS_PATH_RE = /\/dismiss/;
+
+function installFetchStub(handler: (path: string) => Promise<Response>): {
+  calls: string[];
+  restore: () => void;
+} {
+  const calls: string[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const path = String(input);
+    calls.push(path);
+    return handler(path);
+  }) as typeof fetch;
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+test("a terminal write cannot overtake an in-flight step write", async () => {
+  let releaseStep: (() => void) | undefined;
+  const stub = installFetchStub((path) => {
+    if (path.includes("/step")) {
+      return new Promise((resolve) => {
+        releaseStep = () => resolve(new Response(null, { status: 200 }));
+      });
+    }
+    return Promise.resolve(new Response(null, { status: 200 }));
+  });
+  try {
+    answerOnboardingStep(credentials, {
+      roleOtherText: null,
+      roleType: "founder",
+      step: 1,
+    });
+    completeOnboardingProfile(credentials, "ship an app");
+    await flushMicrotasks();
+
+    // The step write is on the wire; the terminal complete is still queued
+    // behind it — the store's terminal-wins can never see them reordered.
+    assert.equal(stub.calls.length, 1);
+    assert.match(stub.calls[0] ?? "", STEP_PATH_RE);
+
+    assert.ok(releaseStep, "the step fetch was issued");
+    releaseStep?.();
+    await onboardingWriteQueueSettled();
+
+    assert.equal(stub.calls.length, 2);
+    assert.match(stub.calls[1] ?? "", COMPLETE_PATH_RE);
+  } finally {
+    stub.restore();
+  }
+});
+
+test("a failed write releases the queue for the writes behind it", async () => {
+  const stub = installFetchStub((path) =>
+    path.includes("/step")
+      ? Promise.reject(new Error("network down"))
+      : Promise.resolve(new Response(null, { status: 200 }))
+  );
+  try {
+    answerOnboardingStep(credentials, {
+      roleOtherText: null,
+      roleType: "founder",
+      step: 1,
+    });
+    dismissOnboardingProfile(credentials, 2);
+    await onboardingWriteQueueSettled();
+
+    assert.equal(stub.calls.length, 2);
+    assert.match(stub.calls[1] ?? "", DISMISS_PATH_RE);
+  } finally {
+    stub.restore();
+  }
+});

--- a/apps/ui/src/features/onboarding/client.test.ts
+++ b/apps/ui/src/features/onboarding/client.test.ts
@@ -60,7 +60,10 @@ test("a terminal write cannot overtake an in-flight step write", async () => {
       roleType: "founder",
       step: 1,
     });
-    completeOnboardingProfile(credentials, "ship an app");
+    completeOnboardingProfile(credentials, {
+      answers: [{ roleOtherText: null, roleType: "founder", step: 1 }],
+      openGoalText: "ship an app",
+    });
     await flushMicrotasks();
 
     // The step write is on the wire; the terminal complete is still queued
@@ -91,7 +94,10 @@ test("a failed write releases the queue for the writes behind it", async () => {
       roleType: "founder",
       step: 1,
     });
-    dismissOnboardingProfile(credentials, 2);
+    dismissOnboardingProfile(credentials, {
+      answers: [{ roleOtherText: null, roleType: "founder", step: 1 }],
+      dismissedAtStep: 2,
+    });
     await onboardingWriteQueueSettled();
 
     assert.equal(stub.calls.length, 2);

--- a/apps/ui/src/features/onboarding/client.ts
+++ b/apps/ui/src/features/onboarding/client.ts
@@ -40,23 +40,41 @@ export async function fetchOnboardingSamplingVerdict(
   }
 }
 
+/**
+ * Profile writes are fire-and-forget for the UI but strictly ordered on the
+ * wire: a terminal complete/dismiss racing ahead of an in-flight step write
+ * would make terminal-wins silently drop that step's answer, so each write
+ * waits for the previous one to settle before it is sent.
+ */
+let onboardingWriteQueue: Promise<void> = Promise.resolve();
+
+/** Test seam: the tail of the ordered write queue. */
+export function onboardingWriteQueueSettled(): Promise<void> {
+  return onboardingWriteQueue;
+}
+
 /** The shared fire-and-forget POST every profile write travels. */
 function postOnboardingProfileWrite(
   credentials: OnboardingFetcherCredentials,
   path: "complete" | "dismiss" | "step",
   payload: unknown
 ): void {
-  fetch(
-    `/api/onboarding-profile/${path}?namespace=${encodeURIComponent(credentials.namespace)}`,
-    {
-      body: JSON.stringify(payload),
-      headers: {
-        "content-type": "application/json",
-        ...personalResourceAuthHeaders(credentials),
-      },
-      method: "POST",
-    }
-  ).catch(() => undefined);
+  onboardingWriteQueue = onboardingWriteQueue.then(() =>
+    fetch(
+      `/api/onboarding-profile/${path}?namespace=${encodeURIComponent(credentials.namespace)}`,
+      {
+        body: JSON.stringify(payload),
+        headers: {
+          "content-type": "application/json",
+          ...personalResourceAuthHeaders(credentials),
+        },
+        method: "POST",
+      }
+    ).then(
+      () => undefined,
+      () => undefined
+    )
+  );
 }
 
 /**

--- a/apps/ui/src/features/onboarding/client.ts
+++ b/apps/ui/src/features/onboarding/client.ts
@@ -1,0 +1,57 @@
+import { personalResourceAuthHeaders } from "@/lib/personal-resource-headers";
+
+import {
+  type OnboardingSamplingVerdict,
+  onboardingSamplingVerdictSchema,
+} from "./types";
+
+/** Credentials every Onboarding Profile fetcher sends (ADR-0061). */
+export interface OnboardingFetcherCredentials {
+  appToken: string;
+  kubeconfig: string;
+  namespace: string;
+}
+
+/**
+ * `null` on any failure (HTTP error, parse failure, network) — the Gate
+ * treats it as an unknown outcome and silently stands down.
+ */
+export async function fetchOnboardingSamplingVerdict(
+  credentials: OnboardingFetcherCredentials
+): Promise<OnboardingSamplingVerdict | null> {
+  try {
+    const res = await fetch(
+      `/api/onboarding-profile/sampling?namespace=${encodeURIComponent(credentials.namespace)}`,
+      { headers: personalResourceAuthHeaders(credentials) }
+    );
+    if (!res.ok) {
+      return null;
+    }
+    const parsed = onboardingSamplingVerdictSchema.safeParse(await res.json());
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fire-and-forget terminal dismiss: Skip never waits on it, and the write is
+ * terminal-wins idempotent server-side, so a failure at worst re-shows the
+ * dialog on the next entry.
+ */
+export function dismissOnboardingProfile(
+  credentials: OnboardingFetcherCredentials,
+  dismissedAtStep: number
+): void {
+  fetch(
+    `/api/onboarding-profile/dismiss?namespace=${encodeURIComponent(credentials.namespace)}`,
+    {
+      body: JSON.stringify({ dismissedAtStep }),
+      headers: {
+        "content-type": "application/json",
+        ...personalResourceAuthHeaders(credentials),
+      },
+      method: "POST",
+    }
+  ).catch(() => undefined);
+}

--- a/apps/ui/src/features/onboarding/client.ts
+++ b/apps/ui/src/features/onboarding/client.ts
@@ -58,6 +58,28 @@ export function answerOnboardingStep(
 }
 
 /**
+ * Fire-and-forget terminal complete: Submit & Enter Console never waits on
+ * it, and the write is terminal-wins idempotent server-side, so a failure at
+ * worst re-shows the dialog on the next entry.
+ */
+export function completeOnboardingProfile(
+  credentials: OnboardingFetcherCredentials,
+  openGoalText: string | null
+): void {
+  fetch(
+    `/api/onboarding-profile/complete?namespace=${encodeURIComponent(credentials.namespace)}`,
+    {
+      body: JSON.stringify({ openGoalText }),
+      headers: {
+        "content-type": "application/json",
+        ...personalResourceAuthHeaders(credentials),
+      },
+      method: "POST",
+    }
+  ).catch(() => undefined);
+}
+
+/**
  * Fire-and-forget terminal dismiss: Skip never waits on it, and the write is
  * terminal-wins idempotent server-side, so a failure at worst re-shows the
  * dialog on the next entry.

--- a/apps/ui/src/features/onboarding/client.ts
+++ b/apps/ui/src/features/onboarding/client.ts
@@ -1,6 +1,7 @@
 import { personalResourceAuthHeaders } from "@/lib/personal-resource-headers";
 
 import {
+  type AnswerOnboardingStepRequest,
   type OnboardingSamplingVerdict,
   onboardingSamplingVerdictSchema,
 } from "./types";
@@ -32,6 +33,28 @@ export async function fetchOnboardingSamplingVerdict(
   } catch {
     return null;
   }
+}
+
+/**
+ * Fire-and-forget stepwise answer write: Next never waits on it, and a
+ * silent failure at worst re-asks the question on the next entry (the row
+ * stays short of terminal, so the person is still Unsampled).
+ */
+export function answerOnboardingStep(
+  credentials: OnboardingFetcherCredentials,
+  payload: AnswerOnboardingStepRequest
+): void {
+  fetch(
+    `/api/onboarding-profile/step?namespace=${encodeURIComponent(credentials.namespace)}`,
+    {
+      body: JSON.stringify(payload),
+      headers: {
+        "content-type": "application/json",
+        ...personalResourceAuthHeaders(credentials),
+      },
+      method: "POST",
+    }
+  ).catch(() => undefined);
 }
 
 /**

--- a/apps/ui/src/features/onboarding/client.ts
+++ b/apps/ui/src/features/onboarding/client.ts
@@ -2,6 +2,8 @@ import { personalResourceAuthHeaders } from "@/lib/personal-resource-headers";
 
 import {
   type AnswerOnboardingStepRequest,
+  type CompleteOnboardingProfileRequest,
+  type DismissOnboardingProfileRequest,
   type OnboardingSamplingVerdict,
   onboardingSamplingVerdictSchema,
 } from "./types";
@@ -41,10 +43,11 @@ export async function fetchOnboardingSamplingVerdict(
 }
 
 /**
- * Profile writes are fire-and-forget for the UI but strictly ordered on the
- * wire: a terminal complete/dismiss racing ahead of an in-flight step write
- * would make terminal-wins silently drop that step's answer, so each write
- * waits for the previous one to settle before it is sent.
+ * Profile writes are fire-and-forget for the UI but ordered on the wire:
+ * each write waits for the previous one to settle before it is sent. The
+ * final answers never depend on this — the terminal write carries the whole
+ * Terminal Snapshot — but ordering keeps the wire deterministic, so
+ * terminal-wins is the only server-side guard the writes need.
  */
 let onboardingWriteQueue: Promise<void> = Promise.resolve();
 
@@ -78,9 +81,11 @@ function postOnboardingProfileWrite(
 }
 
 /**
- * Fire-and-forget stepwise answer write: Next never waits on it, and a
- * silent failure at worst re-asks the question on the next entry (the row
- * stays short of terminal, so the person is still Unsampled).
+ * Fire-and-forget stepwise answer write, the abandonment safety net: Next
+ * never waits on it, and a silent failure costs nothing final — a session
+ * that reaches Submit or Skip re-sends every confirmed answer on the
+ * terminal write's snapshot, and a session that abandons is still Unsampled
+ * and re-asked on the next entry.
  */
 export function answerOnboardingStep(
   credentials: OnboardingFetcherCredentials,
@@ -91,24 +96,27 @@ export function answerOnboardingStep(
 
 /**
  * Fire-and-forget terminal complete: Submit & Enter Console never waits on
- * it, and the write is terminal-wins idempotent server-side, so a failure at
- * worst re-shows the dialog on the next entry.
+ * it. The payload carries the Terminal Snapshot, so this one request is
+ * sufficient for a complete row — no earlier stepwise write needs to have
+ * landed. Terminal-wins keeps it idempotent server-side; a failure at worst
+ * re-shows the dialog on the next entry.
  */
 export function completeOnboardingProfile(
   credentials: OnboardingFetcherCredentials,
-  openGoalText: string | null
+  payload: CompleteOnboardingProfileRequest
 ): void {
-  postOnboardingProfileWrite(credentials, "complete", { openGoalText });
+  postOnboardingProfileWrite(credentials, "complete", payload);
 }
 
 /**
- * Fire-and-forget terminal dismiss: Skip never waits on it, and the write is
- * terminal-wins idempotent server-side, so a failure at worst re-shows the
- * dialog on the next entry.
+ * Fire-and-forget terminal dismiss: Skip never waits on it. Like complete,
+ * the payload carries the Terminal Snapshot of the steps confirmed before
+ * the skip. Terminal-wins keeps it idempotent server-side; a failure at
+ * worst re-shows the dialog on the next entry.
  */
 export function dismissOnboardingProfile(
   credentials: OnboardingFetcherCredentials,
-  dismissedAtStep: number
+  payload: DismissOnboardingProfileRequest
 ): void {
-  postOnboardingProfileWrite(credentials, "dismiss", { dismissedAtStep });
+  postOnboardingProfileWrite(credentials, "dismiss", payload);
 }

--- a/apps/ui/src/features/onboarding/client.ts
+++ b/apps/ui/src/features/onboarding/client.ts
@@ -14,17 +14,22 @@ export interface OnboardingFetcherCredentials {
 }
 
 /**
- * `null` on any failure (HTTP error, parse failure, network) — the Gate
- * treats it as an unknown outcome and silently stands down.
+ * `"unauthorized"` on a definitive authorization refusal — retrying the same
+ * credentials cannot change that answer, so the Gate fails closed at once.
+ * `null` on any other failure (HTTP error, parse failure, network) — the
+ * Gate retries it as an unknown outcome and then silently stands down.
  */
 export async function fetchOnboardingSamplingVerdict(
   credentials: OnboardingFetcherCredentials
-): Promise<OnboardingSamplingVerdict | null> {
+): Promise<OnboardingSamplingVerdict | "unauthorized" | null> {
   try {
     const res = await fetch(
       `/api/onboarding-profile/sampling?namespace=${encodeURIComponent(credentials.namespace)}`,
       { headers: personalResourceAuthHeaders(credentials) }
     );
+    if (res.status === 401 || res.status === 403) {
+      return "unauthorized";
+    }
     if (!res.ok) {
       return null;
     }
@@ -35,17 +40,14 @@ export async function fetchOnboardingSamplingVerdict(
   }
 }
 
-/**
- * Fire-and-forget stepwise answer write: Next never waits on it, and a
- * silent failure at worst re-asks the question on the next entry (the row
- * stays short of terminal, so the person is still Unsampled).
- */
-export function answerOnboardingStep(
+/** The shared fire-and-forget POST every profile write travels. */
+function postOnboardingProfileWrite(
   credentials: OnboardingFetcherCredentials,
-  payload: AnswerOnboardingStepRequest
+  path: "complete" | "dismiss" | "step",
+  payload: unknown
 ): void {
   fetch(
-    `/api/onboarding-profile/step?namespace=${encodeURIComponent(credentials.namespace)}`,
+    `/api/onboarding-profile/${path}?namespace=${encodeURIComponent(credentials.namespace)}`,
     {
       body: JSON.stringify(payload),
       headers: {
@@ -58,6 +60,18 @@ export function answerOnboardingStep(
 }
 
 /**
+ * Fire-and-forget stepwise answer write: Next never waits on it, and a
+ * silent failure at worst re-asks the question on the next entry (the row
+ * stays short of terminal, so the person is still Unsampled).
+ */
+export function answerOnboardingStep(
+  credentials: OnboardingFetcherCredentials,
+  payload: AnswerOnboardingStepRequest
+): void {
+  postOnboardingProfileWrite(credentials, "step", payload);
+}
+
+/**
  * Fire-and-forget terminal complete: Submit & Enter Console never waits on
  * it, and the write is terminal-wins idempotent server-side, so a failure at
  * worst re-shows the dialog on the next entry.
@@ -66,17 +80,7 @@ export function completeOnboardingProfile(
   credentials: OnboardingFetcherCredentials,
   openGoalText: string | null
 ): void {
-  fetch(
-    `/api/onboarding-profile/complete?namespace=${encodeURIComponent(credentials.namespace)}`,
-    {
-      body: JSON.stringify({ openGoalText }),
-      headers: {
-        "content-type": "application/json",
-        ...personalResourceAuthHeaders(credentials),
-      },
-      method: "POST",
-    }
-  ).catch(() => undefined);
+  postOnboardingProfileWrite(credentials, "complete", { openGoalText });
 }
 
 /**
@@ -88,15 +92,5 @@ export function dismissOnboardingProfile(
   credentials: OnboardingFetcherCredentials,
   dismissedAtStep: number
 ): void {
-  fetch(
-    `/api/onboarding-profile/dismiss?namespace=${encodeURIComponent(credentials.namespace)}`,
-    {
-      body: JSON.stringify({ dismissedAtStep }),
-      headers: {
-        "content-type": "application/json",
-        ...personalResourceAuthHeaders(credentials),
-      },
-      method: "POST",
-    }
-  ).catch(() => undefined);
+  postOnboardingProfileWrite(credentials, "dismiss", { dismissedAtStep });
 }

--- a/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
@@ -243,6 +243,62 @@ test("an empty Other refuses Next with the inline error until text arrives", asy
   }
 });
 
+test("the morphed Other input claims focus on select, wrapper press, and refused Next", async () => {
+  const dom = installTestDom();
+  const previousActEnvironment = setActEnvironment(true);
+  const { render } = await import("@testing-library/react/pure");
+  const { fireEvent } = await import("@testing-library/dom");
+  let rendered: ReturnType<typeof render> | undefined;
+
+  try {
+    await actAndDrain(() => {
+      rendered = render(
+        <OnboardingSurveyCard
+          onAnswerStep={() => undefined}
+          onComplete={() => undefined}
+          onSkip={() => undefined}
+        />
+      );
+    });
+
+    // Selecting Other focuses the revealed input — typing starts without a
+    // second click.
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Other"));
+    });
+    const otherInput = document.querySelector("input");
+    assert.ok(otherInput, "the morphed Other input is rendered");
+    assert.equal(document.activeElement, otherInput);
+
+    // The field wrapper's padding belongs to the input's hit area: a pointer
+    // press anywhere on it (outside the glyph) focuses the input.
+    await actAndDrain(() => {
+      otherInput.blur();
+    });
+    assert.notEqual(document.activeElement, otherInput);
+    const wrapper = otherInput.parentElement;
+    assert.ok(wrapper, "the input sits in the field wrapper");
+    await actAndDrain(() => {
+      fireEvent.pointerDown(wrapper);
+    });
+    assert.equal(document.activeElement, otherInput);
+
+    // A refused Next surfaces the error and sends focus into the empty field.
+    await actAndDrain(() => {
+      otherInput.blur();
+    });
+    await clickNext();
+    assert.match(document.body.textContent ?? "", OTHER_REQUIRED_RE);
+    assert.equal(document.activeElement, otherInput);
+  } finally {
+    await actAndDrain(() => {
+      rendered?.unmount();
+    });
+    restoreActEnvironment(previousActEnvironment);
+    await dom.restore();
+  }
+});
+
 test("the survey walks Steps 1-4, persists each advance, and submits terminally", async () => {
   const dom = installTestDom();
   const previousActEnvironment = setActEnvironment(true);

--- a/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
@@ -25,6 +25,7 @@ const STEP_ONE_TITLE_RE = /Tell us a bit about you\./;
 const STEP_TWO_TITLE_RE = /What are you using Sealos for\?/;
 const STEP_THREE_SUBTITLE_RE = /Choose up to 3\./;
 const STEP_FOUR_TITLE_RE = /Anything specific you're trying to achieve\?/;
+const OTHER_REQUIRED_RE = /This field is required\./;
 
 function bodyButtons(): HTMLButtonElement[] {
   return [...document.querySelectorAll("button")] as HTMLButtonElement[];
@@ -38,7 +39,7 @@ function buttonByText(text: string): HTMLButtonElement {
   return button;
 }
 
-/** Option cards prefix their text with the label ("Stability — I need…"). */
+/** Option cards prefix their text with the label ("Stability: I need…"). */
 function optionButton(label: string): HTMLButtonElement {
   const button = bodyButtons().find((candidate) =>
     candidate.textContent?.trim().startsWith(label)
@@ -150,14 +151,89 @@ test("Step 1 skips with the step number and gates Next on a selection", async ()
       fireEvent.click(buttonByText("Other"));
     });
     const otherInput = document.querySelector("input");
-    assert.ok(otherInput, "selecting Other reveals the free-text input");
-    // The Other text is optional: revealing it never blocks Next.
+    assert.ok(otherInput, "selecting Other morphs the card into an input");
+    // Empty Other keeps Next clickable — the click surfaces the inline
+    // required error instead of disabling the button (pinned below).
     assert.equal(next.disabled, false);
 
     await actAndDrain(() => {
       fireEvent.click(buttonByText("Skip"));
     });
     assert.deepEqual(skips, [{ dismissedAtStep: 1 }]);
+  } finally {
+    await actAndDrain(() => {
+      rendered?.unmount();
+    });
+    restoreActEnvironment(previousActEnvironment);
+    await dom.restore();
+  }
+});
+
+test("an empty Other refuses Next with the inline error until text arrives", async () => {
+  const dom = installTestDom();
+  const previousActEnvironment = setActEnvironment(true);
+  const { render } = await import("@testing-library/react/pure");
+  const { fireEvent } = await import("@testing-library/dom");
+  const answers: unknown[] = [];
+  let rendered: ReturnType<typeof render> | undefined;
+
+  try {
+    await actAndDrain(() => {
+      rendered = render(
+        <OnboardingSurveyCard
+          onAnswerStep={(payload) => {
+            answers.push(payload);
+          }}
+          onComplete={() => undefined}
+          onSkip={() => undefined}
+        />
+      );
+    });
+
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Other"));
+    });
+    assert.doesNotMatch(document.body.textContent ?? "", OTHER_REQUIRED_RE);
+
+    // Next with no text: the error appears, nothing advances or persists.
+    await clickNext();
+    assert.match(document.body.textContent ?? "", OTHER_REQUIRED_RE);
+    assert.match(document.body.textContent ?? "", STEP_INDICATOR_RE);
+    assert.equal(answers.length, 0);
+
+    // Typing clears the error display without another Next.
+    const otherInput = document.querySelector("input");
+    assert.ok(otherInput, "the morphed Other input is rendered");
+    await actAndDrain(() => {
+      otherInput.focus();
+      fireEvent.input(otherInput, { target: { value: "SRE" } });
+      fireEvent.keyUp(otherInput, { key: "d" });
+    });
+    assert.doesNotMatch(document.body.textContent ?? "", OTHER_REQUIRED_RE);
+
+    // The glyph inside the morphed field unselects Other, restoring the card.
+    const unselect = bodyButtons().find(
+      (candidate) => candidate.getAttribute("aria-label") === "Unselect Other"
+    );
+    assert.ok(unselect, "the morphed field keeps the selection glyph");
+    await actAndDrain(() => {
+      fireEvent.click(unselect);
+    });
+    assert.equal(document.querySelector("input"), null);
+    assert.ok(buttonByText("Other"), "the Other card is restored");
+
+    // With text in place, Next advances and the trimmed pair persists.
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Other"));
+    });
+    const revived = document.querySelector("input");
+    assert.ok(revived, "re-selecting Other morphs the card again");
+    // The Other text survives the unselect round-trip by design.
+    await clickNext();
+    assert.deepEqual(answers, [
+      { roleOtherText: "SRE", roleType: "other", step: 1 },
+    ]);
+    assert.match(document.body.textContent ?? "", STEP_TWO_INDICATOR_RE);
   } finally {
     await actAndDrain(() => {
       rendered?.unmount();

--- a/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
@@ -308,7 +308,10 @@ test("the survey walks Steps 1-4, persists each advance, and submits terminally"
   const completes: unknown[] = [];
   let rendered: ReturnType<typeof render> | undefined;
 
-  const typeInto = async (input: HTMLInputElement, value: string) => {
+  const typeInto = async (
+    input: HTMLInputElement | HTMLTextAreaElement,
+    value: string
+  ) => {
     await actAndDrain(() => {
       // A real focus (emitting focusin) plus a keyUp flush: React falls back
       // to keystroke polling for change detection when react-dom was first
@@ -401,8 +404,9 @@ test("the survey walks Steps 1-4, persists each advance, and submits terminally"
 
     // Step 4: the open goal is optional; submit fires the terminal payload.
     assert.match(document.body.textContent ?? "", STEP_FOUR_TITLE_RE);
-    const goalInput = document.querySelector("input");
-    assert.ok(goalInput, "the open goal input is rendered");
+    // The open goal is an auto-growing textarea (2000 characters allowed).
+    const goalInput = document.querySelector("textarea");
+    assert.ok(goalInput, "the open goal field is rendered");
     await typeInto(goalInput, " test a product idea ");
     await actAndDrain(() => {
       fireEvent.click(buttonByText("Submit & Enter Console"));

--- a/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
@@ -159,7 +159,9 @@ test("Step 1 skips with the step number and gates Next on a selection", async ()
     await actAndDrain(() => {
       fireEvent.click(buttonByText("Skip"));
     });
-    assert.deepEqual(skips, [{ dismissedAtStep: 1 }]);
+    // Nothing was confirmed with Next, so the Terminal Snapshot is empty —
+    // the unconfirmed Other pick on the current step stays out.
+    assert.deepEqual(skips, [{ answers: [], dismissedAtStep: 1 }]);
   } finally {
     await actAndDrain(() => {
       rendered?.unmount();
@@ -411,7 +413,12 @@ test("the survey walks Steps 1-4, persists each advance, and submits terminally"
     await actAndDrain(() => {
       fireEvent.click(buttonByText("Submit & Enter Console"));
     });
-    assert.deepEqual(completes, [{ openGoalText: "test a product idea" }]);
+    // The terminal payload re-sends every confirmed answer as the Terminal
+    // Snapshot — exactly the three step payloads — so a completed row never
+    // depends on the fire-and-forget step writes having landed.
+    assert.deepEqual(completes, [
+      { answers, openGoalText: "test a product idea" },
+    ]);
     assert.equal(answers.length, 3, "submit is terminal, not a step write");
   } finally {
     await actAndDrain(() => {
@@ -490,8 +497,19 @@ test("the funnel emits one view per step shown and complete at submit time", asy
       funnelEntry("onboarding_step_view", 4),
       funnelEntry("onboarding_complete"),
     ]);
-    // The event fired at click time and the owner's callback still ran.
-    assert.deepEqual(completes, [{ openGoalText: null }]);
+    // The event fired at click time and the owner's callback still ran,
+    // carrying the snapshot of the three confirmed steps (the display order
+    // inside is the session's shuffle, so only the steps are pinned here).
+    assert.equal(completes.length, 1);
+    const complete = completes[0] as {
+      answers: { step: number }[];
+      openGoalText: string | null;
+    };
+    assert.equal(complete.openGoalText, null);
+    assert.deepEqual(
+      complete.answers.map((answer) => answer.step),
+      [1, 2, 3]
+    );
   } finally {
     await actAndDrain(() => {
       rendered?.unmount();
@@ -537,8 +555,16 @@ test("Skip fires the funnel event with the step it left from", async () => {
       funnelEntry("onboarding_step_view", 2),
       funnelEntry("onboarding_skip", 2),
     ]);
-    // The event fired at click time and the owner's dismiss still ran.
-    assert.deepEqual(skips, [{ dismissedAtStep: 2 }]);
+    // The event fired at click time and the owner's dismiss still ran,
+    // with the confirmed Step 1 answer riding the Terminal Snapshot.
+    assert.deepEqual(skips, [
+      {
+        answers: [
+          { roleOtherText: null, roleType: "individual_developer", step: 1 },
+        ],
+        dismissedAtStep: 2,
+      },
+    ]);
   } finally {
     await actAndDrain(() => {
       rendered?.unmount();
@@ -592,7 +618,14 @@ test("a broken dataLayer never touches the survey flow", async () => {
     await actAndDrain(() => {
       fireEvent.click(buttonByText("Skip"));
     });
-    assert.deepEqual(skips, [{ dismissedAtStep: 2 }]);
+    assert.deepEqual(skips, [
+      {
+        answers: [
+          { roleOtherText: null, roleType: "individual_developer", step: 1 },
+        ],
+        dismissedAtStep: 2,
+      },
+    ]);
   } finally {
     await actAndDrain(() => {
       rendered?.unmount();

--- a/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
@@ -24,7 +24,7 @@ const STEP_FOUR_INDICATOR_RE = /Step 4 of 4/;
 const STEP_ONE_TITLE_RE = /Tell us a bit about you\./;
 const STEP_TWO_TITLE_RE = /What are you using Sealos for\?/;
 const STEP_THREE_SUBTITLE_RE = /Choose up to 3\./;
-const STEP_FOUR_TITLE_RE = /Anything specific you’re trying to achieve\?/;
+const STEP_FOUR_TITLE_RE = /Anything specific you're trying to achieve\?/;
 
 function bodyButtons(): HTMLButtonElement[] {
   return [...document.querySelectorAll("button")] as HTMLButtonElement[];
@@ -38,7 +38,7 @@ function buttonByText(text: string): HTMLButtonElement {
   return button;
 }
 
-/** Option cards prefix their text with the label ("Stability: I need…"). */
+/** Option cards prefix their text with the label ("Stability — I need…"). */
 function optionButton(label: string): HTMLButtonElement {
   const button = bodyButtons().find((candidate) =>
     candidate.textContent?.trim().startsWith(label)
@@ -61,11 +61,15 @@ async function clickNext(): Promise<void> {
   });
 }
 
-// The dialog primitive never renders in the test DOM (repo pattern: dialog
-// shells are asserted structurally), so the shell's non-dismissible contract
-// is pinned on the element tree: `open` is fully controlled, the only
-// open-change handler is the documented no-op, and no close/cancel control
-// exists — Skip inside the card is the only exit.
+// The dialog primitive cannot render in this suite: Base UI picks its
+// layout-effect shim at module load (`@base-ui/utils` `useIsoLayoutEffect`:
+// `typeof document !== 'undefined' ? React.useLayoutEffect : noop`), and
+// test files import the dialog chain before any suite-local DOM registers,
+// so the portal never mounts (repo pattern: dialog shells are asserted
+// structurally). The non-dismissible contract is therefore pinned
+// on the element tree: `open` is fully controlled, the only open-change
+// handler is the documented no-op, and no close/cancel control exists —
+// Skip inside the card is the only exit.
 test("the sampling dialog shell refuses every close except Skip", () => {
   const tree = OnboardingDialog({
     onAnswerStep: () => undefined,

--- a/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
@@ -19,7 +19,12 @@ import {
 
 const STEP_INDICATOR_RE = /Step 1 of 4/;
 const STEP_TWO_INDICATOR_RE = /Step 2 of 4/;
+const STEP_THREE_INDICATOR_RE = /Step 3 of 4/;
+const STEP_FOUR_INDICATOR_RE = /Step 4 of 4/;
 const STEP_ONE_TITLE_RE = /Tell us a bit about you\./;
+const STEP_TWO_TITLE_RE = /What are you using Sealos for\?/;
+const STEP_THREE_SUBTITLE_RE = /Choose up to 3\./;
+const STEP_FOUR_TITLE_RE = /Anything specific you’re trying to achieve\?/;
 
 function bodyButtons(): HTMLButtonElement[] {
   return [...document.querySelectorAll("button")] as HTMLButtonElement[];
@@ -33,6 +38,15 @@ function buttonByText(text: string): HTMLButtonElement {
   return button;
 }
 
+/** Option cards prefix their text with the label ("Stability: I need…"). */
+function optionButton(label: string): HTMLButtonElement {
+  const button = bodyButtons().find((candidate) =>
+    candidate.textContent?.trim().startsWith(label)
+  );
+  assert.ok(button, `option "${label}" is rendered`);
+  return button;
+}
+
 // The dialog primitive never renders in the test DOM (repo pattern: dialog
 // shells are asserted structurally), so the shell's non-dismissible contract
 // is pinned on the element tree: `open` is fully controlled, the only
@@ -41,6 +55,7 @@ function buttonByText(text: string): HTMLButtonElement {
 test("the sampling dialog shell refuses every close except Skip", () => {
   const tree = OnboardingDialog({
     onAnswerStep: () => undefined,
+    onComplete: () => undefined,
     onSkip: () => undefined,
     open: true,
   });
@@ -84,6 +99,7 @@ test("Step 1 skips with the step number and gates Next on a selection", async ()
       rendered = render(
         <OnboardingSurveyCard
           onAnswerStep={() => undefined}
+          onComplete={() => undefined}
           onSkip={(payload) => {
             skips.push(payload);
           }}
@@ -133,14 +149,35 @@ test("Step 1 skips with the step number and gates Next on a selection", async ()
   }
 });
 
-test("Next persists the role answer and advances to the Step 2 placeholder", async () => {
+test("the survey walks Steps 1-4, persists each advance, and submits terminally", async () => {
   const dom = installTestDom();
   const previousActEnvironment = setActEnvironment(true);
   const { render } = await import("@testing-library/react/pure");
   const { fireEvent } = await import("@testing-library/dom");
   const answers: unknown[] = [];
-  const skips: { dismissedAtStep: number }[] = [];
+  const completes: unknown[] = [];
   let rendered: ReturnType<typeof render> | undefined;
+
+  const typeInto = async (input: HTMLInputElement, value: string) => {
+    await actAndDrain(() => {
+      // A real focus (emitting focusin) plus a keyUp flush: React falls back
+      // to keystroke polling for change detection when react-dom was first
+      // loaded without a DOM, as happens mid-suite — fireEvent.change alone
+      // is dropped there.
+      input.focus();
+      fireEvent.input(input, { target: { value } });
+      fireEvent.keyUp(input, { key: "d" });
+    });
+  };
+  const clickNext = async () => {
+    const next = bodyButtons().find((candidate) =>
+      candidate.textContent?.includes("Next")
+    );
+    assert.ok(next, "the explicit Next button is rendered");
+    await actAndDrain(() => {
+      fireEvent.click(next);
+    });
+  };
 
   try {
     await actAndDrain(() => {
@@ -149,54 +186,89 @@ test("Next persists the role answer and advances to the Step 2 placeholder", asy
           onAnswerStep={(payload) => {
             answers.push(payload);
           }}
-          onSkip={(payload) => {
-            skips.push(payload);
+          onComplete={(payload) => {
+            completes.push(payload);
           }}
+          onSkip={() => undefined}
         />
       );
     });
 
+    // Step 1: the Other pair persists at the moment Next advances.
     await actAndDrain(() => {
       fireEvent.click(buttonByText("Other"));
     });
-    const otherInput = document.querySelector("input");
-    assert.ok(otherInput, "the Other input is revealed");
-    await actAndDrain(() => {
-      // A real focus (emitting focusin) plus a keyUp flush: React falls back
-      // to keystroke polling for change detection when react-dom was first
-      // loaded without a DOM, as happens mid-suite — fireEvent.change alone
-      // is dropped there.
-      otherInput.focus();
-      fireEvent.input(otherInput, {
-        target: { value: "  platform team lead " },
-      });
-      fireEvent.keyUp(otherInput, { key: "d" });
-    });
-    assert.equal(otherInput.value, "  platform team lead ");
-
-    const next = bodyButtons().find((candidate) =>
-      candidate.textContent?.includes("Next")
-    );
-    assert.ok(next, "the explicit Next button is rendered");
-    await actAndDrain(() => {
-      fireEvent.click(next);
-    });
-
-    // The write fires exactly once, at the moment of advancing, with the
-    // normalized Other pair; the indicator moves to the real step.
+    const roleInput = document.querySelector("input");
+    assert.ok(roleInput, "the Other input is revealed");
+    await typeInto(roleInput, "  platform team lead ");
+    await clickNext();
     assert.deepEqual(answers, [
       { roleOtherText: "platform team lead", roleType: "other", step: 1 },
     ]);
     assert.match(document.body.textContent ?? "", STEP_TWO_INDICATOR_RE);
     assert.doesNotMatch(document.body.textContent ?? "", STEP_ONE_TITLE_RE);
-    // The placeholder has nothing to answer, so Next is locked again.
-    assert.equal(next.disabled, true);
 
-    // Skip from the placeholder reports the real step.
+    // Step 2: single-select usage context.
+    assert.match(document.body.textContent ?? "", STEP_TWO_TITLE_RE);
     await actAndDrain(() => {
-      fireEvent.click(buttonByText("Skip"));
+      fireEvent.click(buttonByText("Running a real business project"));
     });
-    assert.deepEqual(skips, [{ dismissedAtStep: 2 }]);
+    await clickNext();
+    assert.deepEqual(answers.at(-1), {
+      step: 2,
+      usageContext: "real_business",
+      usageOtherText: null,
+    });
+    assert.match(document.body.textContent ?? "", STEP_THREE_INDICATOR_RE);
+
+    // Step 3: multi-select capped at 3, Other pinned last with optional text.
+    assert.match(document.body.textContent ?? "", STEP_THREE_SUBTITLE_RE);
+    await actAndDrain(() => {
+      fireEvent.click(optionButton("Stability"));
+    });
+    await actAndDrain(() => {
+      fireEvent.click(optionButton("Low cost"));
+    });
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Other"));
+    });
+    // The cap is 3: every unselected option is locked out.
+    assert.equal(optionButton("Performance").disabled, true);
+    const priorityInput = document.querySelector("input");
+    assert.ok(priorityInput, "the Step 3 Other input is revealed");
+    await typeInto(priorityInput, " fair pricing ");
+    await clickNext();
+    // assert.deepEqual's assertion signature narrowed `answers` to the Step 1
+    // payload shape above, so the cast has to travel through unknown.
+    const priorityAnswer = answers.at(-1) as unknown as {
+      priorityDisplayOrder: string[];
+      priorityOtherText: string | null;
+      priorityTags: string[];
+      step: number;
+    };
+    // Array order = click order; the shuffled display order is captured
+    // alongside, all seven tags with Other pinned last.
+    assert.deepEqual(priorityAnswer.priorityTags, [
+      "stability",
+      "low_cost",
+      "other",
+    ]);
+    assert.equal(priorityAnswer.priorityOtherText, "fair pricing");
+    assert.equal(priorityAnswer.step, 3);
+    assert.equal(priorityAnswer.priorityDisplayOrder.length, 7);
+    assert.equal(priorityAnswer.priorityDisplayOrder.at(-1), "other");
+    assert.match(document.body.textContent ?? "", STEP_FOUR_INDICATOR_RE);
+
+    // Step 4: the open goal is optional; submit fires the terminal payload.
+    assert.match(document.body.textContent ?? "", STEP_FOUR_TITLE_RE);
+    const goalInput = document.querySelector("input");
+    assert.ok(goalInput, "the open goal input is rendered");
+    await typeInto(goalInput, " test a product idea ");
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Submit & Enter Console"));
+    });
+    assert.deepEqual(completes, [{ openGoalText: "test a product idea" }]);
+    assert.equal(answers.length, 3, "submit is terminal, not a step write");
   } finally {
     await actAndDrain(() => {
       rendered?.unmount();

--- a/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
@@ -47,6 +47,20 @@ function optionButton(label: string): HTMLButtonElement {
   return button;
 }
 
+/** Clicks the explicit Next button, asserting it is rendered. */
+async function clickNext(): Promise<void> {
+  // Imported lazily like every DOM library here: the module may only load
+  // after installTestDom has put a document in place.
+  const { fireEvent } = await import("@testing-library/dom");
+  const next = bodyButtons().find((candidate) =>
+    candidate.textContent?.includes("Next")
+  );
+  assert.ok(next, "the explicit Next button is rendered");
+  await actAndDrain(() => {
+    fireEvent.click(next);
+  });
+}
+
 // The dialog primitive never renders in the test DOM (repo pattern: dialog
 // shells are asserted structurally), so the shell's non-dismissible contract
 // is pinned on the element tree: `open` is fully controlled, the only
@@ -169,16 +183,6 @@ test("the survey walks Steps 1-4, persists each advance, and submits terminally"
       fireEvent.keyUp(input, { key: "d" });
     });
   };
-  const clickNext = async () => {
-    const next = bodyButtons().find((candidate) =>
-      candidate.textContent?.includes("Next")
-    );
-    assert.ok(next, "the explicit Next button is rendered");
-    await actAndDrain(() => {
-      fireEvent.click(next);
-    });
-  };
-
   try {
     await actAndDrain(() => {
       rendered = render(
@@ -269,6 +273,186 @@ test("the survey walks Steps 1-4, persists each advance, and submits terminally"
     });
     assert.deepEqual(completes, [{ openGoalText: "test a product idea" }]);
     assert.equal(answers.length, 3, "submit is terminal, not a step write");
+  } finally {
+    await actAndDrain(() => {
+      rendered?.unmount();
+    });
+    restoreActEnvironment(previousActEnvironment);
+    await dom.restore();
+  }
+});
+
+/**
+ * The exact dataLayer entry a funnel event lands as: the event name, the
+ * shared context/module envelope, and — for view/skip — the bare step
+ * number. deepEqual on these pins the privacy rule observably: no answer
+ * value, free text, or user ID rides along.
+ */
+function funnelEntry(event: string, step?: number) {
+  return {
+    context: "app",
+    event,
+    module: "brain",
+    ...(step === undefined ? {} : { step }),
+  };
+}
+
+test("the funnel emits one view per step shown and complete at submit time", async () => {
+  const dom = installTestDom();
+  const previousActEnvironment = setActEnvironment(true);
+  const { render } = await import("@testing-library/react/pure");
+  const { fireEvent } = await import("@testing-library/dom");
+  const dataLayer: unknown[] = [];
+  Object.assign(window, { dataLayer });
+  const completes: unknown[] = [];
+  let rendered: ReturnType<typeof render> | undefined;
+
+  try {
+    await actAndDrain(() => {
+      rendered = render(
+        <OnboardingSurveyCard
+          onAnswerStep={() => undefined}
+          onComplete={(payload) => {
+            completes.push(payload);
+          }}
+          onSkip={() => undefined}
+        />
+      );
+    });
+
+    // The dialog's appearance is the step 1 view.
+    assert.deepEqual(dataLayer, [funnelEntry("onboarding_step_view", 1)]);
+
+    // Interaction within a step re-renders without re-viewing it.
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Individual developer"));
+    });
+    assert.deepEqual(dataLayer, [funnelEntry("onboarding_step_view", 1)]);
+
+    await clickNext();
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Just exploring Sealos"));
+    });
+    await clickNext();
+    await actAndDrain(() => {
+      fireEvent.click(optionButton("Stability"));
+    });
+    await clickNext();
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Submit & Enter Console"));
+    });
+
+    // The whole flow, exactly: four views in order, then the completion.
+    assert.deepEqual(dataLayer, [
+      funnelEntry("onboarding_step_view", 1),
+      funnelEntry("onboarding_step_view", 2),
+      funnelEntry("onboarding_step_view", 3),
+      funnelEntry("onboarding_step_view", 4),
+      funnelEntry("onboarding_complete"),
+    ]);
+    // The event fired at click time and the owner's callback still ran.
+    assert.deepEqual(completes, [{ openGoalText: null }]);
+  } finally {
+    await actAndDrain(() => {
+      rendered?.unmount();
+    });
+    restoreActEnvironment(previousActEnvironment);
+    await dom.restore();
+  }
+});
+
+test("Skip fires the funnel event with the step it left from", async () => {
+  const dom = installTestDom();
+  const previousActEnvironment = setActEnvironment(true);
+  const { render } = await import("@testing-library/react/pure");
+  const { fireEvent } = await import("@testing-library/dom");
+  const dataLayer: unknown[] = [];
+  Object.assign(window, { dataLayer });
+  const skips: { dismissedAtStep: number }[] = [];
+  let rendered: ReturnType<typeof render> | undefined;
+
+  try {
+    await actAndDrain(() => {
+      rendered = render(
+        <OnboardingSurveyCard
+          onAnswerStep={() => undefined}
+          onComplete={() => undefined}
+          onSkip={(payload) => {
+            skips.push(payload);
+          }}
+        />
+      );
+    });
+
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Individual developer"));
+    });
+    await clickNext();
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Skip"));
+    });
+
+    assert.deepEqual(dataLayer, [
+      funnelEntry("onboarding_step_view", 1),
+      funnelEntry("onboarding_step_view", 2),
+      funnelEntry("onboarding_skip", 2),
+    ]);
+    // The event fired at click time and the owner's dismiss still ran.
+    assert.deepEqual(skips, [{ dismissedAtStep: 2 }]);
+  } finally {
+    await actAndDrain(() => {
+      rendered?.unmount();
+    });
+    restoreActEnvironment(previousActEnvironment);
+    await dom.restore();
+  }
+});
+
+test("a broken dataLayer never touches the survey flow", async () => {
+  const dom = installTestDom();
+  const previousActEnvironment = setActEnvironment(true);
+  const { render } = await import("@testing-library/react/pure");
+  const { fireEvent } = await import("@testing-library/dom");
+  // Analytics is best-effort: every push throws, nothing may escape.
+  Object.assign(window, {
+    dataLayer: {
+      push: () => {
+        throw new Error("transport failed");
+      },
+    },
+  });
+  const answers: unknown[] = [];
+  const skips: { dismissedAtStep: number }[] = [];
+  let rendered: ReturnType<typeof render> | undefined;
+
+  try {
+    await actAndDrain(() => {
+      rendered = render(
+        <OnboardingSurveyCard
+          onAnswerStep={(payload) => {
+            answers.push(payload);
+          }}
+          onComplete={() => undefined}
+          onSkip={(payload) => {
+            skips.push(payload);
+          }}
+        />
+      );
+    });
+
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Individual developer"));
+    });
+    await clickNext();
+
+    // The survey advanced and persisted as if analytics did not exist.
+    assert.match(document.body.textContent ?? "", STEP_TWO_INDICATOR_RE);
+    assert.equal(answers.length, 1);
+
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Skip"));
+    });
+    assert.deepEqual(skips, [{ dismissedAtStep: 2 }]);
   } finally {
     await actAndDrain(() => {
       rendered?.unmount();

--- a/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { AppDialog } from "@workspace/ui/components/app-dialog";
+
+import {
+  actAndDrain,
+  installTestDom,
+  restoreActEnvironment,
+  setActEnvironment,
+  walkElements,
+} from "@/features/project-canvas/react-test-harness";
+
+import {
+  OnboardingDialog,
+  OnboardingSurveyCard,
+  refuseOnboardingDialogClose,
+} from "./onboarding-dialog";
+
+const STEP_INDICATOR_RE = /Step 1 of 4/;
+const STEP_ONE_TITLE_RE = /Tell us a bit about you\./;
+
+function bodyButtons(): HTMLButtonElement[] {
+  return [...document.querySelectorAll("button")] as HTMLButtonElement[];
+}
+
+function buttonByText(text: string): HTMLButtonElement {
+  const button = bodyButtons().find(
+    (candidate) => candidate.textContent?.trim() === text
+  );
+  assert.ok(button, `button "${text}" is rendered`);
+  return button;
+}
+
+// The dialog primitive never renders in the test DOM (repo pattern: dialog
+// shells are asserted structurally), so the shell's non-dismissible contract
+// is pinned on the element tree: `open` is fully controlled, the only
+// open-change handler is the documented no-op, and no close/cancel control
+// exists — Skip inside the card is the only exit.
+test("the sampling dialog shell refuses every close except Skip", () => {
+  const tree = OnboardingDialog({ onSkip: () => undefined, open: true });
+  const elements = [...walkElements(tree)];
+
+  const root = elements.find((element) => element.type === AppDialog.Root);
+  assert.ok(root, "the shared AppDialog.Root is used");
+  const rootProps = root.props as {
+    onOpenChange?: unknown;
+    open?: unknown;
+  };
+  assert.equal(rootProps.open, true);
+  assert.equal(rootProps.onOpenChange, refuseOnboardingDialogClose);
+  // The handler ignores the close request entirely; with `open` controlled,
+  // escape-key and outside-press therefore cannot close the dialog.
+  assert.equal(refuseOnboardingDialogClose(), undefined);
+
+  const content = elements.find(
+    (element) => element.type === AppDialog.Content
+  );
+  assert.ok(content, "the shared AppDialog.Content is used");
+  assert.equal((content.props as { size?: unknown }).size, "xl");
+
+  assert.equal(
+    elements.some((element) => element.type === AppDialog.Cancel),
+    false,
+    "no cancel/close control is mounted"
+  );
+});
+
+test("Step 1 skips with the step number and gates Next on a selection", async () => {
+  const dom = installTestDom();
+  const previousActEnvironment = setActEnvironment(true);
+  const { render } = await import("@testing-library/react/pure");
+  const { fireEvent } = await import("@testing-library/dom");
+  const skips: { dismissedAtStep: number }[] = [];
+  let rendered: ReturnType<typeof render> | undefined;
+
+  try {
+    await actAndDrain(() => {
+      rendered = render(
+        <OnboardingSurveyCard
+          onSkip={(payload) => {
+            skips.push(payload);
+          }}
+        />
+      );
+    });
+
+    assert.match(document.body.textContent ?? "", STEP_INDICATOR_RE);
+    assert.match(document.body.textContent ?? "", STEP_ONE_TITLE_RE);
+
+    const next = bodyButtons().find((candidate) =>
+      candidate.textContent?.includes("Next")
+    );
+    assert.ok(next, "the explicit Next button is rendered");
+    assert.equal(next.disabled, true);
+
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Individual developer"));
+    });
+    assert.equal(next.disabled, false);
+
+    // Re-picking the selected option clears it and re-locks Next.
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Individual developer"));
+    });
+    assert.equal(next.disabled, true);
+
+    assert.equal(document.querySelector("input"), null);
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Other"));
+    });
+    const otherInput = document.querySelector("input");
+    assert.ok(otherInput, "selecting Other reveals the free-text input");
+    // The Other text is optional: revealing it never blocks Next.
+    assert.equal(next.disabled, false);
+
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Skip"));
+    });
+    assert.deepEqual(skips, [{ dismissedAtStep: 1 }]);
+  } finally {
+    await actAndDrain(() => {
+      rendered?.unmount();
+    });
+    restoreActEnvironment(previousActEnvironment);
+    await dom.restore();
+  }
+});

--- a/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
@@ -18,6 +18,7 @@ import {
 } from "./onboarding-dialog";
 
 const STEP_INDICATOR_RE = /Step 1 of 4/;
+const STEP_TWO_INDICATOR_RE = /Step 2 of 4/;
 const STEP_ONE_TITLE_RE = /Tell us a bit about you\./;
 
 function bodyButtons(): HTMLButtonElement[] {
@@ -38,7 +39,11 @@ function buttonByText(text: string): HTMLButtonElement {
 // open-change handler is the documented no-op, and no close/cancel control
 // exists — Skip inside the card is the only exit.
 test("the sampling dialog shell refuses every close except Skip", () => {
-  const tree = OnboardingDialog({ onSkip: () => undefined, open: true });
+  const tree = OnboardingDialog({
+    onAnswerStep: () => undefined,
+    onSkip: () => undefined,
+    open: true,
+  });
   const elements = [...walkElements(tree)];
 
   const root = elements.find((element) => element.type === AppDialog.Root);
@@ -78,6 +83,7 @@ test("Step 1 skips with the step number and gates Next on a selection", async ()
     await actAndDrain(() => {
       rendered = render(
         <OnboardingSurveyCard
+          onAnswerStep={() => undefined}
           onSkip={(payload) => {
             skips.push(payload);
           }}
@@ -118,6 +124,79 @@ test("Step 1 skips with the step number and gates Next on a selection", async ()
       fireEvent.click(buttonByText("Skip"));
     });
     assert.deepEqual(skips, [{ dismissedAtStep: 1 }]);
+  } finally {
+    await actAndDrain(() => {
+      rendered?.unmount();
+    });
+    restoreActEnvironment(previousActEnvironment);
+    await dom.restore();
+  }
+});
+
+test("Next persists the role answer and advances to the Step 2 placeholder", async () => {
+  const dom = installTestDom();
+  const previousActEnvironment = setActEnvironment(true);
+  const { render } = await import("@testing-library/react/pure");
+  const { fireEvent } = await import("@testing-library/dom");
+  const answers: unknown[] = [];
+  const skips: { dismissedAtStep: number }[] = [];
+  let rendered: ReturnType<typeof render> | undefined;
+
+  try {
+    await actAndDrain(() => {
+      rendered = render(
+        <OnboardingSurveyCard
+          onAnswerStep={(payload) => {
+            answers.push(payload);
+          }}
+          onSkip={(payload) => {
+            skips.push(payload);
+          }}
+        />
+      );
+    });
+
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Other"));
+    });
+    const otherInput = document.querySelector("input");
+    assert.ok(otherInput, "the Other input is revealed");
+    await actAndDrain(() => {
+      // A real focus (emitting focusin) plus a keyUp flush: React falls back
+      // to keystroke polling for change detection when react-dom was first
+      // loaded without a DOM, as happens mid-suite — fireEvent.change alone
+      // is dropped there.
+      otherInput.focus();
+      fireEvent.input(otherInput, {
+        target: { value: "  platform team lead " },
+      });
+      fireEvent.keyUp(otherInput, { key: "d" });
+    });
+    assert.equal(otherInput.value, "  platform team lead ");
+
+    const next = bodyButtons().find((candidate) =>
+      candidate.textContent?.includes("Next")
+    );
+    assert.ok(next, "the explicit Next button is rendered");
+    await actAndDrain(() => {
+      fireEvent.click(next);
+    });
+
+    // The write fires exactly once, at the moment of advancing, with the
+    // normalized Other pair; the indicator moves to the real step.
+    assert.deepEqual(answers, [
+      { roleOtherText: "platform team lead", roleType: "other", step: 1 },
+    ]);
+    assert.match(document.body.textContent ?? "", STEP_TWO_INDICATOR_RE);
+    assert.doesNotMatch(document.body.textContent ?? "", STEP_ONE_TITLE_RE);
+    // The placeholder has nothing to answer, so Next is locked again.
+    assert.equal(next.disabled, true);
+
+    // Skip from the placeholder reports the real step.
+    await actAndDrain(() => {
+      fireEvent.click(buttonByText("Skip"));
+    });
+    assert.deepEqual(skips, [{ dismissedAtStep: 2 }]);
   } finally {
     await actAndDrain(() => {
       rendered?.unmount();

--- a/apps/ui/src/features/onboarding/onboarding-dialog.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { AppButton } from "@workspace/ui/components/app-button";
+import { AppDialog } from "@workspace/ui/components/app-dialog";
+import { AppInput } from "@workspace/ui/components/app-input";
+import { cn } from "@workspace/ui/lib/utils";
+import { ArrowRight, Check } from "lucide-react";
+import { useReducer } from "react";
+
+import {
+  canAdvanceOnboardingStep,
+  initialOnboardingSurveyState,
+  onboardingSkipPayload,
+  onboardingSurveyReducer,
+} from "./survey-state";
+import {
+  ONBOARDING_SURVEY_TOTAL_STEPS,
+  type OnboardingRoleType,
+} from "./types";
+
+const ROLE_OPTIONS: readonly { label: string; value: OnboardingRoleType }[] = [
+  { label: "Individual developer", value: "individual_developer" },
+  { label: "Startup founder / Indie hacker", value: "founder" },
+  { label: "Engineering team member", value: "engineering_team_member" },
+  { label: "DevOps / Platform engineer", value: "devops_platform_engineer" },
+  { label: "AI-assisted builder / Vibe coder", value: "ai_builder" },
+  { label: "Student / Learner", value: "student" },
+  { label: "Other", value: "other" },
+];
+
+export interface OnboardingSurveyCardProps {
+  /** Skip: the single exit on this slice; the owner closes and persists. */
+  onSkip: (payload: { dismissedAtStep: number }) => void;
+}
+
+/**
+ * The survey's Step 1 frame: all interactive content of the sampling dialog,
+ * kept free of the dialog primitive so behavior is testable in a plain DOM.
+ */
+export function OnboardingSurveyCard({ onSkip }: OnboardingSurveyCardProps) {
+  const [state, dispatch] = useReducer(
+    onboardingSurveyReducer,
+    initialOnboardingSurveyState
+  );
+
+  return (
+    <div className="flex min-h-144 flex-col p-9">
+      <div className="flex items-center justify-between">
+        <span className="text-muted-foreground text-sm">
+          Step {state.currentStep} of {ONBOARDING_SURVEY_TOTAL_STEPS}
+        </span>
+        <button
+          className="text-muted-foreground text-sm transition-colors hover:text-foreground"
+          onClick={() => onSkip(onboardingSkipPayload(state))}
+          type="button"
+        >
+          Skip
+        </button>
+      </div>
+      <div className="mt-3 grid grid-cols-4 gap-3">
+        {Array.from({ length: ONBOARDING_SURVEY_TOTAL_STEPS }, (_, index) => (
+          <div
+            className={cn(
+              "h-1 rounded-full",
+              index < state.currentStep ? "bg-brand-primary" : "bg-muted"
+            )}
+            // biome-ignore lint/suspicious/noArrayIndexKey: fixed-size ordinal track
+            key={index}
+          />
+        ))}
+      </div>
+      {/* Plain heading: the dialog context is optional for the card so the
+          frame stays testable in a plain DOM; the shell labels the dialog. */}
+      <h2 className="mt-12 font-bold text-3xl text-foreground">
+        Tell us <span className="text-brand-primary">a bit about you.</span>
+      </h2>
+      <p className="mt-2 text-muted-foreground text-sm">
+        This helps us tailor your workspace experience.
+      </p>
+      <fieldset className="mt-9 grid gap-4 border-0 sm:grid-cols-2">
+        <legend className="sr-only">Your role</legend>
+        {ROLE_OPTIONS.map((option) => {
+          const selected = state.roleType === option.value;
+          return (
+            <button
+              aria-pressed={selected}
+              className={cn(
+                "flex h-12 items-center justify-between gap-3 rounded-lg border px-4 text-left text-sm transition-colors",
+                selected
+                  ? "border-brand-primary bg-input/50 text-foreground"
+                  : "border-transparent bg-input/30 text-foreground hover:bg-input/50"
+              )}
+              key={option.value}
+              onClick={() =>
+                dispatch({ role: option.value, type: "toggle-role" })
+              }
+              type="button"
+            >
+              <span className="truncate">{option.label}</span>
+              <span
+                aria-hidden
+                className={cn(
+                  "flex size-4 shrink-0 items-center justify-center rounded-xs border",
+                  selected
+                    ? "border-brand-primary bg-brand-primary text-brand-primary-foreground"
+                    : "border-brand-primary/60"
+                )}
+              >
+                {selected ? <Check className="size-3" /> : null}
+              </span>
+            </button>
+          );
+        })}
+        {state.roleType === "other" ? (
+          <AppInput
+            aria-label="Describe your role"
+            onChange={(event) =>
+              dispatch({
+                text: event.target.value,
+                type: "set-role-other-text",
+              })
+            }
+            placeholder="Tell us more (optional)"
+            value={state.roleOtherText}
+          />
+        ) : null}
+      </fieldset>
+      <div className="mt-auto flex justify-end pt-9">
+        {/* No auto-advance: the explicit Next unlocks with a selection.
+            Steps 2–4 land in follow-up tickets; until then the button
+            only gates. */}
+        <AppButton disabled={!canAdvanceOnboardingStep(state)} type="button">
+          Next
+          <ArrowRight aria-hidden data-icon="inline-end" />
+        </AppButton>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Non-dismissible by design (spec): `open` is fully controlled by the Gate
+ * and this handler ignores every close request — escape-key and
+ * outside-press included — so the weakened Skip link is the only exit until
+ * the final submit exists.
+ */
+export function refuseOnboardingDialogClose(): void {
+  // Controlled `open` never flips here.
+}
+
+export interface OnboardingDialogProps extends OnboardingSurveyCardProps {
+  open: boolean;
+}
+
+/**
+ * The sampling dialog (spec: first-entry user-understanding survey): the
+ * full-size modal shell around the Step 1 frame. Hook-free so structural
+ * tests can walk the element tree without rendering the dialog primitive.
+ */
+export function OnboardingDialog({ onSkip, open }: OnboardingDialogProps) {
+  return (
+    <AppDialog.Root onOpenChange={refuseOnboardingDialogClose} open={open}>
+      <AppDialog.Content
+        aria-label="Onboarding survey"
+        overlayClassName="bg-black/60"
+        size="xl"
+      >
+        <OnboardingSurveyCard onSkip={onSkip} />
+      </AppDialog.Content>
+    </AppDialog.Root>
+  );
+}

--- a/apps/ui/src/features/onboarding/onboarding-dialog.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.tsx
@@ -229,7 +229,7 @@ function progressSegmentClass(index: number, currentStep: number): string {
     return "bg-input";
   }
   return index === 0
-    ? "bg-gradient-to-r from-foreground to-blue-500"
+    ? "bg-linear-to-r/srgb from-foreground to-blue-500"
     : "bg-blue-500";
 }
 
@@ -242,7 +242,9 @@ function StepHeading({
 }) {
   return (
     <div className="flex flex-col gap-2.5">
-      <h2 className="bg-gradient-to-r from-foreground to-onboarding-heading-accent bg-clip-text font-semibold text-4xl text-transparent">
+      {/* w-fit: the ramp spans the text itself, so the last word lands on
+          the accent endpoint; /srgb matches Figma's gradient interpolation. */}
+      <h2 className="w-fit bg-linear-to-r/srgb from-white to-onboarding-heading-accent bg-clip-text font-semibold text-4xl text-transparent">
         {title}
       </h2>
       {subtitle == null ? null : (

--- a/apps/ui/src/features/onboarding/onboarding-dialog.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.tsx
@@ -266,6 +266,13 @@ function progressSegmentClass(index: number, currentStep: number): string {
     : "bg-blue-500";
 }
 
+/**
+ * One step's heading and inputs travel as a group: the tight gap binds the
+ * heading to what it introduces, and the min-height pins the frame so the
+ * footer button holds still across steps of different heights.
+ */
+const stepGroupClass = "flex min-h-[22rem] flex-col gap-6";
+
 function StepHeading({
   subtitle,
   title,
@@ -274,7 +281,7 @@ function StepHeading({
   title: string;
 }) {
   return (
-    <div className="flex flex-col gap-2.5">
+    <div className="flex flex-col gap-1.5">
       {/* w-fit: the ramp spans the text itself, so the last word lands on
           the accent endpoint; /srgb matches Figma's gradient interpolation. */}
       <h2 className="w-fit bg-linear-to-r/srgb from-white to-onboarding-heading-accent bg-clip-text font-semibold text-4xl text-transparent">
@@ -397,7 +404,7 @@ export function OnboardingSurveyCard({
     <div className="flex flex-col gap-10 p-9">
       <div className="flex flex-col gap-4">
         <div className="flex items-center justify-between">
-          <span className="text-base text-muted-foreground">
+          <span className="text-muted-foreground text-sm">
             Step {state.currentStep} of {ONBOARDING_SURVEY_TOTAL_STEPS}
           </span>
           <button
@@ -424,12 +431,12 @@ export function OnboardingSurveyCard({
       {/* Plain headings: the dialog context is optional for the card so the
           frame stays testable in a plain DOM; the shell labels the dialog. */}
       {state.currentStep === 1 ? (
-        <>
+        <div className={stepGroupClass}>
           <StepHeading
             subtitle="This helps us tailor your workspace experience."
             title="Tell us a bit about you."
           />
-          <fieldset className="grid gap-5 border-0 sm:grid-cols-2">
+          <fieldset className="grid gap-x-3 gap-y-3 border-0 sm:grid-cols-2">
             <legend className="sr-only">Your role</legend>
             {ROLE_OPTIONS.map((option) =>
               option.value === "other" && state.roleType === "other" ? (
@@ -461,15 +468,15 @@ export function OnboardingSurveyCard({
               )
             )}
           </fieldset>
-        </>
+        </div>
       ) : null}
       {state.currentStep === 2 ? (
-        <>
+        <div className={stepGroupClass}>
           <StepHeading
             subtitle="Let us know what stage your project is in."
             title="What are you using Sealos for?"
           />
-          <fieldset className="grid gap-5 border-0 sm:grid-cols-2">
+          <fieldset className="grid gap-x-3 gap-y-3 border-0 sm:grid-cols-2">
             <legend className="sr-only">Your usage context</legend>
             {USAGE_OPTIONS.map((option) =>
               option.value === "other" && state.usageContext === "other" ? (
@@ -501,15 +508,15 @@ export function OnboardingSurveyCard({
               )
             )}
           </fieldset>
-        </>
+        </div>
       ) : null}
       {state.currentStep === 3 ? (
-        <>
+        <div className={stepGroupClass}>
           <StepHeading
             subtitle="Choose up to 3."
             title="Which factors are most important to you?"
           />
-          <fieldset className="grid gap-5 border-0 sm:grid-cols-2">
+          <fieldset className="grid gap-x-3 gap-y-3 border-0 sm:grid-cols-2">
             <legend className="sr-only">Your top priorities</legend>
             {state.priorityDisplayOrder.map((tag) => {
               if (tag === "other" && state.priorityTags.includes("other")) {
@@ -556,10 +563,10 @@ export function OnboardingSurveyCard({
               );
             })}
           </fieldset>
-        </>
+        </div>
       ) : null}
       {state.currentStep === 4 ? (
-        <>
+        <div className={stepGroupClass}>
           <StepHeading title="Anything specific you're trying to achieve?" />
           <AppInput
             aria-label="Anything specific you're trying to achieve?"
@@ -573,7 +580,7 @@ export function OnboardingSurveyCard({
             placeholder="e.g. deploy an AI agent, move from VPS, test a product idea…"
             value={state.openGoalText}
           />
-        </>
+        </div>
       ) : null}
       <div className="flex justify-end">
         {state.currentStep === ONBOARDING_SURVEY_TOTAL_STEPS ? (

--- a/apps/ui/src/features/onboarding/onboarding-dialog.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.tsx
@@ -10,10 +10,12 @@ import { useReducer } from "react";
 import {
   canAdvanceOnboardingStep,
   initialOnboardingSurveyState,
+  onboardingRoleAnswerPayload,
   onboardingSkipPayload,
   onboardingSurveyReducer,
 } from "./survey-state";
 import {
+  type AnswerOnboardingStepRequest,
   ONBOARDING_SURVEY_TOTAL_STEPS,
   type OnboardingRoleType,
 } from "./types";
@@ -29,19 +31,40 @@ const ROLE_OPTIONS: readonly { label: string; value: OnboardingRoleType }[] = [
 ];
 
 export interface OnboardingSurveyCardProps {
-  /** Skip: the single exit on this slice; the owner closes and persists. */
+  /**
+   * Fired once per step at the moment Next advances, with that step's answer
+   * payload. The owner persists it fire-and-forget — advancing never waits.
+   */
+  onAnswerStep: (payload: AnswerOnboardingStepRequest) => void;
+  /** Skip: the single exit short of the final submit; the owner persists. */
   onSkip: (payload: { dismissedAtStep: number }) => void;
 }
 
 /**
- * The survey's Step 1 frame: all interactive content of the sampling dialog,
- * kept free of the dialog primitive so behavior is testable in a plain DOM.
+ * The survey frame: all interactive content of the sampling dialog, kept
+ * free of the dialog primitive so behavior is testable in a plain DOM.
+ * Step 1 is the real role question; Step 2 is still a placeholder.
  */
-export function OnboardingSurveyCard({ onSkip }: OnboardingSurveyCardProps) {
+export function OnboardingSurveyCard({
+  onAnswerStep,
+  onSkip,
+}: OnboardingSurveyCardProps) {
   const [state, dispatch] = useReducer(
     onboardingSurveyReducer,
     initialOnboardingSurveyState
   );
+
+  const handleNext = () => {
+    // Persist-then-advance, both synchronous from the click: the payload is
+    // assembled from the state being left, and the write is the owner's
+    // fire-and-forget concern — Next never blocks on it.
+    const payload =
+      state.currentStep === 1 ? onboardingRoleAnswerPayload(state) : null;
+    if (payload != null) {
+      onAnswerStep(payload);
+    }
+    dispatch({ type: "advance-step" });
+  };
 
   return (
     <div className="flex min-h-144 flex-col p-9">
@@ -69,67 +92,80 @@ export function OnboardingSurveyCard({ onSkip }: OnboardingSurveyCardProps) {
           />
         ))}
       </div>
-      {/* Plain heading: the dialog context is optional for the card so the
+      {/* Plain headings: the dialog context is optional for the card so the
           frame stays testable in a plain DOM; the shell labels the dialog. */}
-      <h2 className="mt-12 font-bold text-3xl text-foreground">
-        Tell us <span className="text-brand-primary">a bit about you.</span>
-      </h2>
-      <p className="mt-2 text-muted-foreground text-sm">
-        This helps us tailor your workspace experience.
-      </p>
-      <fieldset className="mt-9 grid gap-4 border-0 sm:grid-cols-2">
-        <legend className="sr-only">Your role</legend>
-        {ROLE_OPTIONS.map((option) => {
-          const selected = state.roleType === option.value;
-          return (
-            <button
-              aria-pressed={selected}
-              className={cn(
-                "flex h-12 items-center justify-between gap-3 rounded-lg border px-4 text-left text-sm transition-colors",
-                selected
-                  ? "border-brand-primary bg-input/50 text-foreground"
-                  : "border-transparent bg-input/30 text-foreground hover:bg-input/50"
-              )}
-              key={option.value}
-              onClick={() =>
-                dispatch({ role: option.value, type: "toggle-role" })
-              }
-              type="button"
-            >
-              <span className="truncate">{option.label}</span>
-              <span
-                aria-hidden
-                className={cn(
-                  "flex size-4 shrink-0 items-center justify-center rounded-xs border",
-                  selected
-                    ? "border-brand-primary bg-brand-primary text-brand-primary-foreground"
-                    : "border-brand-primary/60"
-                )}
-              >
-                {selected ? <Check className="size-3" /> : null}
-              </span>
-            </button>
-          );
-        })}
-        {state.roleType === "other" ? (
-          <AppInput
-            aria-label="Describe your role"
-            onChange={(event) =>
-              dispatch({
-                text: event.target.value,
-                type: "set-role-other-text",
-              })
-            }
-            placeholder="Tell us more (optional)"
-            value={state.roleOtherText}
-          />
-        ) : null}
-      </fieldset>
+      {state.currentStep === 1 ? (
+        <>
+          <h2 className="mt-12 font-bold text-3xl text-foreground">
+            Tell us <span className="text-brand-primary">a bit about you.</span>
+          </h2>
+          <p className="mt-2 text-muted-foreground text-sm">
+            This helps us tailor your workspace experience.
+          </p>
+          <fieldset className="mt-9 grid gap-4 border-0 sm:grid-cols-2">
+            <legend className="sr-only">Your role</legend>
+            {ROLE_OPTIONS.map((option) => {
+              const selected = state.roleType === option.value;
+              return (
+                <button
+                  aria-pressed={selected}
+                  className={cn(
+                    "flex h-12 items-center justify-between gap-3 rounded-lg border px-4 text-left text-sm transition-colors",
+                    selected
+                      ? "border-brand-primary bg-input/50 text-foreground"
+                      : "border-transparent bg-input/30 text-foreground hover:bg-input/50"
+                  )}
+                  key={option.value}
+                  onClick={() =>
+                    dispatch({ role: option.value, type: "toggle-role" })
+                  }
+                  type="button"
+                >
+                  <span className="truncate">{option.label}</span>
+                  <span
+                    aria-hidden
+                    className={cn(
+                      "flex size-4 shrink-0 items-center justify-center rounded-xs border",
+                      selected
+                        ? "border-brand-primary bg-brand-primary text-brand-primary-foreground"
+                        : "border-brand-primary/60"
+                    )}
+                  >
+                    {selected ? <Check className="size-3" /> : null}
+                  </span>
+                </button>
+              );
+            })}
+            {state.roleType === "other" ? (
+              <AppInput
+                aria-label="Describe your role"
+                onChange={(event) =>
+                  dispatch({
+                    text: event.target.value,
+                    type: "set-role-other-text",
+                  })
+                }
+                placeholder="Tell us more (optional)"
+                value={state.roleOtherText}
+              />
+            ) : null}
+          </fieldset>
+        </>
+      ) : (
+        // Step 2 placeholder: the usage-context question lands in the next
+        // ticket; until then the gate stays closed and Skip is the way on.
+        <p className="mt-12 text-muted-foreground text-sm">
+          The next question is on its way.
+        </p>
+      )}
       <div className="mt-auto flex justify-end pt-9">
-        {/* No auto-advance: the explicit Next unlocks with a selection.
-            Steps 2–4 land in follow-up tickets; until then the button
-            only gates. */}
-        <AppButton disabled={!canAdvanceOnboardingStep(state)} type="button">
+        {/* No auto-advance: the explicit Next unlocks with the current
+            step's answer and persists it fire-and-forget on the way. */}
+        <AppButton
+          disabled={!canAdvanceOnboardingStep(state)}
+          onClick={handleNext}
+          type="button"
+        >
           Next
           <ArrowRight aria-hidden data-icon="inline-end" />
         </AppButton>
@@ -157,7 +193,11 @@ export interface OnboardingDialogProps extends OnboardingSurveyCardProps {
  * full-size modal shell around the Step 1 frame. Hook-free so structural
  * tests can walk the element tree without rendering the dialog primitive.
  */
-export function OnboardingDialog({ onSkip, open }: OnboardingDialogProps) {
+export function OnboardingDialog({
+  onAnswerStep,
+  onSkip,
+  open,
+}: OnboardingDialogProps) {
   return (
     <AppDialog.Root onOpenChange={refuseOnboardingDialogClose} open={open}>
       <AppDialog.Content
@@ -165,7 +205,7 @@ export function OnboardingDialog({ onSkip, open }: OnboardingDialogProps) {
         overlayClassName="bg-black/60"
         size="xl"
       >
-        <OnboardingSurveyCard onSkip={onSkip} />
+        <OnboardingSurveyCard onAnswerStep={onAnswerStep} onSkip={onSkip} />
       </AppDialog.Content>
     </AppDialog.Root>
   );

--- a/apps/ui/src/features/onboarding/onboarding-dialog.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.tsx
@@ -4,20 +4,28 @@ import { AppButton } from "@workspace/ui/components/app-button";
 import { AppDialog } from "@workspace/ui/components/app-dialog";
 import { AppInput } from "@workspace/ui/components/app-input";
 import { cn } from "@workspace/ui/lib/utils";
-import { ArrowRight, Check } from "lucide-react";
-import { useReducer } from "react";
+import { ArrowRight, Check, Send } from "lucide-react";
+import { type ReactNode, useReducer } from "react";
 
 import {
   canAdvanceOnboardingStep,
-  initialOnboardingSurveyState,
+  createInitialOnboardingSurveyState,
+  type OnboardingSurveyState,
+  onboardingCompletePayload,
+  onboardingPriorityAnswerPayload,
   onboardingRoleAnswerPayload,
   onboardingSkipPayload,
   onboardingSurveyReducer,
+  onboardingUsageAnswerPayload,
 } from "./survey-state";
 import {
   type AnswerOnboardingStepRequest,
+  type CompleteOnboardingProfileRequest,
+  ONBOARDING_PRIORITY_TAGS_MAX,
   ONBOARDING_SURVEY_TOTAL_STEPS,
+  type OnboardingPriorityTag,
   type OnboardingRoleType,
+  type OnboardingUsageContext,
 } from "./types";
 
 const ROLE_OPTIONS: readonly { label: string; value: OnboardingRoleType }[] = [
@@ -30,36 +38,171 @@ const ROLE_OPTIONS: readonly { label: string; value: OnboardingRoleType }[] = [
   { label: "Other", value: "other" },
 ];
 
+const USAGE_OPTIONS: readonly {
+  label: string;
+  value: OnboardingUsageContext;
+}[] = [
+  { label: "Just exploring Sealos", value: "exploring" },
+  { label: "Testing a demo or prototype", value: "demo_or_prototype" },
+  { label: "Shipping an AI-built app", value: "ai_built_app" },
+  { label: "Building a side project", value: "side_project" },
+  { label: "Launching a new product", value: "new_product_launch" },
+  { label: "Running a real business project", value: "real_business" },
+  { label: "Supporting a team or client project", value: "team_or_client" },
+  { label: "Other", value: "other" },
+];
+
+/**
+ * Step 3 copy keyed by Cohort Tag: the cards render in the session's
+ * shuffled display order, so the copy cannot live in an ordered list.
+ */
+const PRIORITY_OPTIONS: Record<
+  OnboardingPriorityTag,
+  { description?: string; label: string }
+> = {
+  ease_of_use: {
+    description: "I want minimal configuration & zero DevOps.",
+    label: "Ease of use",
+  },
+  fast_launch: {
+    description: "I just want to get a live URL as quickly as possible.",
+    label: "Fast launch",
+  },
+  low_cost: {
+    description: "I am highly sensitive to pricing & resource efficiency.",
+    label: "Low cost",
+  },
+  other: { label: "Other" },
+  performance: {
+    description: "I need maximum speed & computational power.",
+    label: "Performance",
+  },
+  scalability: {
+    description: "I need an architecture that grows with my user base.",
+    label: "Scalability",
+  },
+  stability: {
+    description: "I need a highly reliable environment for a real business.",
+    label: "Stability",
+  },
+};
+
+function OptionCard({
+  children,
+  disabled = false,
+  onToggle,
+  selected,
+}: {
+  children: ReactNode;
+  disabled?: boolean;
+  onToggle: () => void;
+  selected: boolean;
+}) {
+  return (
+    <button
+      aria-pressed={selected}
+      className={cn(
+        // min-h, not h: the Step 3 descriptions must stay readable, so a
+        // card grows and wraps rather than truncating its one-liner.
+        "flex min-h-12 items-center justify-between gap-3 rounded-lg border px-4 py-2 text-left text-sm transition-colors",
+        selected
+          ? "border-brand-primary bg-input/50 text-foreground"
+          : "border-transparent bg-input/30 text-foreground hover:bg-input/50",
+        disabled && "cursor-not-allowed opacity-50 hover:bg-input/30"
+      )}
+      disabled={disabled}
+      onClick={onToggle}
+      type="button"
+    >
+      <span className="min-w-0">{children}</span>
+      <span
+        aria-hidden
+        className={cn(
+          "flex size-4 shrink-0 items-center justify-center rounded-xs border",
+          selected
+            ? "border-brand-primary bg-brand-primary text-brand-primary-foreground"
+            : "border-brand-primary/60"
+        )}
+      >
+        {selected ? <Check className="size-3" /> : null}
+      </span>
+    </button>
+  );
+}
+
+function StepHeading({
+  head,
+  subtitle,
+  tail,
+}: {
+  head: string;
+  subtitle?: string;
+  tail: string;
+}) {
+  return (
+    <>
+      <h2 className="mt-12 font-bold text-3xl text-foreground">
+        {head} <span className="text-brand-primary">{tail}</span>
+      </h2>
+      {subtitle == null ? null : (
+        <p className="mt-2 text-muted-foreground text-sm">{subtitle}</p>
+      )}
+    </>
+  );
+}
+
 export interface OnboardingSurveyCardProps {
   /**
    * Fired once per step at the moment Next advances, with that step's answer
    * payload. The owner persists it fire-and-forget — advancing never waits.
    */
   onAnswerStep: (payload: AnswerOnboardingStepRequest) => void;
+  /**
+   * Submit & Enter Console: the terminal completion, carrying the optional
+   * Step 4 open goal. The owner closes the dialog and persists.
+   */
+  onComplete: (payload: CompleteOnboardingProfileRequest) => void;
   /** Skip: the single exit short of the final submit; the owner persists. */
   onSkip: (payload: { dismissedAtStep: number }) => void;
+}
+
+function stepAnswerPayload(
+  state: OnboardingSurveyState
+): AnswerOnboardingStepRequest | null {
+  switch (state.currentStep) {
+    case 1:
+      return onboardingRoleAnswerPayload(state);
+    case 2:
+      return onboardingUsageAnswerPayload(state);
+    case 3:
+      return onboardingPriorityAnswerPayload(state);
+    default:
+      return null;
+  }
 }
 
 /**
  * The survey frame: all interactive content of the sampling dialog, kept
  * free of the dialog primitive so behavior is testable in a plain DOM.
- * Step 1 is the real role question; Step 2 is still a placeholder.
  */
 export function OnboardingSurveyCard({
   onAnswerStep,
+  onComplete,
   onSkip,
 }: OnboardingSurveyCardProps) {
   const [state, dispatch] = useReducer(
     onboardingSurveyReducer,
-    initialOnboardingSurveyState
+    undefined,
+    // The card mounts when the dialog opens, so the lazy initializer is the
+    // once-per-session seat of the Step 3 display-order shuffle.
+    () => createInitialOnboardingSurveyState()
   );
 
   const handleNext = () => {
     // Persist-then-advance, both synchronous from the click: the payload is
     // assembled from the state being left, and the write is the owner's
     // fire-and-forget concern — Next never blocks on it.
-    const payload =
-      state.currentStep === 1 ? onboardingRoleAnswerPayload(state) : null;
+    const payload = stepAnswerPayload(state);
     if (payload != null) {
       onAnswerStep(payload);
     }
@@ -96,46 +239,24 @@ export function OnboardingSurveyCard({
           frame stays testable in a plain DOM; the shell labels the dialog. */}
       {state.currentStep === 1 ? (
         <>
-          <h2 className="mt-12 font-bold text-3xl text-foreground">
-            Tell us <span className="text-brand-primary">a bit about you.</span>
-          </h2>
-          <p className="mt-2 text-muted-foreground text-sm">
-            This helps us tailor your workspace experience.
-          </p>
+          <StepHeading
+            head="Tell us"
+            subtitle="This helps us tailor your workspace experience."
+            tail="a bit about you."
+          />
           <fieldset className="mt-9 grid gap-4 border-0 sm:grid-cols-2">
             <legend className="sr-only">Your role</legend>
-            {ROLE_OPTIONS.map((option) => {
-              const selected = state.roleType === option.value;
-              return (
-                <button
-                  aria-pressed={selected}
-                  className={cn(
-                    "flex h-12 items-center justify-between gap-3 rounded-lg border px-4 text-left text-sm transition-colors",
-                    selected
-                      ? "border-brand-primary bg-input/50 text-foreground"
-                      : "border-transparent bg-input/30 text-foreground hover:bg-input/50"
-                  )}
-                  key={option.value}
-                  onClick={() =>
-                    dispatch({ role: option.value, type: "toggle-role" })
-                  }
-                  type="button"
-                >
-                  <span className="truncate">{option.label}</span>
-                  <span
-                    aria-hidden
-                    className={cn(
-                      "flex size-4 shrink-0 items-center justify-center rounded-xs border",
-                      selected
-                        ? "border-brand-primary bg-brand-primary text-brand-primary-foreground"
-                        : "border-brand-primary/60"
-                    )}
-                  >
-                    {selected ? <Check className="size-3" /> : null}
-                  </span>
-                </button>
-              );
-            })}
+            {ROLE_OPTIONS.map((option) => (
+              <OptionCard
+                key={option.value}
+                onToggle={() =>
+                  dispatch({ role: option.value, type: "toggle-role" })
+                }
+                selected={state.roleType === option.value}
+              >
+                {option.label}
+              </OptionCard>
+            ))}
             {state.roleType === "other" ? (
               <AppInput
                 aria-label="Describe your role"
@@ -151,24 +272,135 @@ export function OnboardingSurveyCard({
             ) : null}
           </fieldset>
         </>
-      ) : (
-        // Step 2 placeholder: the usage-context question lands in the next
-        // ticket; until then the gate stays closed and Skip is the way on.
-        <p className="mt-12 text-muted-foreground text-sm">
-          The next question is on its way.
-        </p>
-      )}
+      ) : null}
+      {state.currentStep === 2 ? (
+        <>
+          <StepHeading
+            head="What are"
+            subtitle="Let us know what stage your project is in."
+            tail="you using Sealos for?"
+          />
+          <fieldset className="mt-9 grid gap-4 border-0 sm:grid-cols-2">
+            <legend className="sr-only">Your usage context</legend>
+            {USAGE_OPTIONS.map((option) => (
+              <OptionCard
+                key={option.value}
+                onToggle={() =>
+                  dispatch({ type: "toggle-usage", usage: option.value })
+                }
+                selected={state.usageContext === option.value}
+              >
+                {option.label}
+              </OptionCard>
+            ))}
+            {state.usageContext === "other" ? (
+              <AppInput
+                aria-label="Describe your usage"
+                onChange={(event) =>
+                  dispatch({
+                    text: event.target.value,
+                    type: "set-usage-other-text",
+                  })
+                }
+                placeholder="Tell us more (optional)"
+                value={state.usageOtherText}
+              />
+            ) : null}
+          </fieldset>
+        </>
+      ) : null}
+      {state.currentStep === 3 ? (
+        <>
+          <StepHeading
+            head="Which factors are"
+            subtitle="Choose up to 3."
+            tail="most important to you?"
+          />
+          <fieldset className="mt-9 grid gap-4 border-0 sm:grid-cols-2">
+            <legend className="sr-only">Your top priorities</legend>
+            {state.priorityDisplayOrder.map((tag) => {
+              const option = PRIORITY_OPTIONS[tag];
+              const selected = state.priorityTags.includes(tag);
+              return (
+                <OptionCard
+                  // Multi-select capped at 3: at the cap, unpicked options
+                  // lock until a slot reopens (the reducer refuses anyway).
+                  disabled={
+                    !selected &&
+                    state.priorityTags.length >= ONBOARDING_PRIORITY_TAGS_MAX
+                  }
+                  key={tag}
+                  onToggle={() => dispatch({ tag, type: "toggle-priority" })}
+                  selected={selected}
+                >
+                  {option.label}
+                  {option.description == null ? null : (
+                    <span className="text-muted-foreground">
+                      : {option.description}
+                    </span>
+                  )}
+                </OptionCard>
+              );
+            })}
+            {state.priorityTags.includes("other") ? (
+              <AppInput
+                aria-label="Describe your priority"
+                onChange={(event) =>
+                  dispatch({
+                    text: event.target.value,
+                    type: "set-priority-other-text",
+                  })
+                }
+                placeholder="Tell us more (optional)"
+                value={state.priorityOtherText}
+              />
+            ) : null}
+          </fieldset>
+        </>
+      ) : null}
+      {state.currentStep === 4 ? (
+        <>
+          <StepHeading
+            head="Anything specific"
+            tail="you’re trying to achieve?"
+          />
+          <AppInput
+            aria-label="Anything specific you’re trying to achieve?"
+            className="mt-9"
+            onChange={(event) =>
+              dispatch({
+                text: event.target.value,
+                type: "set-open-goal-text",
+              })
+            }
+            placeholder="e.g. deploy an AI agent, move from VPS, test a product idea…"
+            value={state.openGoalText}
+          />
+        </>
+      ) : null}
       <div className="mt-auto flex justify-end pt-9">
-        {/* No auto-advance: the explicit Next unlocks with the current
-            step's answer and persists it fire-and-forget on the way. */}
-        <AppButton
-          disabled={!canAdvanceOnboardingStep(state)}
-          onClick={handleNext}
-          type="button"
-        >
-          Next
-          <ArrowRight aria-hidden data-icon="inline-end" />
-        </AppButton>
+        {state.currentStep === ONBOARDING_SURVEY_TOTAL_STEPS ? (
+          // The terminal submit: never gated (the open goal is optional) and
+          // never awaited — the owner closes the dialog into the console.
+          <AppButton
+            onClick={() => onComplete(onboardingCompletePayload(state))}
+            type="button"
+          >
+            Submit & Enter Console
+            <Send aria-hidden data-icon="inline-end" />
+          </AppButton>
+        ) : (
+          // No auto-advance: the explicit Next unlocks with the current
+          // step's answer and persists it fire-and-forget on the way.
+          <AppButton
+            disabled={!canAdvanceOnboardingStep(state)}
+            onClick={handleNext}
+            type="button"
+          >
+            Next
+            <ArrowRight aria-hidden data-icon="inline-end" />
+          </AppButton>
+        )}
       </div>
     </div>
   );
@@ -177,8 +409,8 @@ export function OnboardingSurveyCard({
 /**
  * Non-dismissible by design (spec): `open` is fully controlled by the Gate
  * and this handler ignores every close request — escape-key and
- * outside-press included — so the weakened Skip link is the only exit until
- * the final submit exists.
+ * outside-press included — so the weakened Skip link and the final submit
+ * are the only exits.
  */
 export function refuseOnboardingDialogClose(): void {
   // Controlled `open` never flips here.
@@ -190,11 +422,12 @@ export interface OnboardingDialogProps extends OnboardingSurveyCardProps {
 
 /**
  * The sampling dialog (spec: first-entry user-understanding survey): the
- * full-size modal shell around the Step 1 frame. Hook-free so structural
+ * full-size modal shell around the survey frame. Hook-free so structural
  * tests can walk the element tree without rendering the dialog primitive.
  */
 export function OnboardingDialog({
   onAnswerStep,
+  onComplete,
   onSkip,
   open,
 }: OnboardingDialogProps) {
@@ -205,7 +438,11 @@ export function OnboardingDialog({
         overlayClassName="bg-black/60"
         size="xl"
       >
-        <OnboardingSurveyCard onAnswerStep={onAnswerStep} onSkip={onSkip} />
+        <OnboardingSurveyCard
+          onAnswerStep={onAnswerStep}
+          onComplete={onComplete}
+          onSkip={onSkip}
+        />
       </AppDialog.Content>
     </AppDialog.Root>
   );

--- a/apps/ui/src/features/onboarding/onboarding-dialog.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.tsx
@@ -371,7 +371,8 @@ export function OnboardingSurveyCard({
                   {option.label}
                   {option.description == null ? null : (
                     <span className="text-muted-foreground">
-                      : {option.description}
+                      {" — "}
+                      {option.description}
                     </span>
                   )}
                 </OptionCard>
@@ -397,10 +398,10 @@ export function OnboardingSurveyCard({
         <>
           <StepHeading
             head="Anything specific"
-            tail="you’re trying to achieve?"
+            tail="you're trying to achieve?"
           />
           <AppInput
-            aria-label="Anything specific you’re trying to achieve?"
+            aria-label="Anything specific you're trying to achieve?"
             className="mt-9"
             onChange={(event) =>
               dispatch({

--- a/apps/ui/src/features/onboarding/onboarding-dialog.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.tsx
@@ -268,10 +268,10 @@ function progressSegmentClass(index: number, currentStep: number): string {
 
 /**
  * One step's heading and inputs travel as a group: the tight gap binds the
- * heading to what it introduces, and the min-height pins the frame so the
- * footer button holds still across steps of different heights.
+ * heading to what it introduces while keeping the step frame compact enough
+ * that the options do not end in a large unused gap.
  */
-const stepGroupClass = "flex min-h-[22rem] flex-col gap-6";
+const stepGroupClass = "flex min-h-[20rem] flex-col gap-6";
 
 function StepHeading({
   subtitle,

--- a/apps/ui/src/features/onboarding/onboarding-dialog.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.tsx
@@ -5,7 +5,14 @@ import { AppDialog } from "@workspace/ui/components/app-dialog";
 import { AppInput } from "@workspace/ui/components/app-input";
 import { cn } from "@workspace/ui/lib/utils";
 import { ArrowRight, Check, Send } from "lucide-react";
-import { type ReactNode, useEffect, useReducer, useRef, useState } from "react";
+import {
+  type ReactNode,
+  type RefObject,
+  useEffect,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 
 import { trackBrainGtmEvent } from "@/features/analytics/brain-gtm";
 
@@ -147,7 +154,7 @@ function OptionCard({
       className={cn(
         // min-h, not h: the Step 3 descriptions must stay readable, so a
         // card grows and wraps rather than truncating its one-liner.
-        "flex min-h-12 items-center justify-between gap-3 rounded-lg border border-transparent bg-input/30 px-4 py-2.5 text-left text-foreground text-sm transition-colors hover:border-border",
+        "flex min-h-12 cursor-pointer items-center justify-between gap-3 rounded-lg border border-transparent bg-input/30 px-4 py-2.5 text-left text-foreground text-sm transition-colors hover:border-border",
         disabled && "cursor-not-allowed opacity-50 hover:border-transparent"
       )}
       disabled={disabled}
@@ -169,6 +176,7 @@ function OptionCard({
  */
 function OtherOptionField({
   error,
+  inputRef,
   label,
   onTextChange,
   onUnselect,
@@ -176,12 +184,19 @@ function OtherOptionField({
   text,
 }: {
   error: boolean;
+  inputRef: RefObject<HTMLInputElement | null>;
   label: string;
   onTextChange: (text: string) => void;
   onUnselect: () => void;
   shape: "checkbox" | "radio";
   text: string;
 }) {
+  // The field only ever mounts because the user just selected Other (no back
+  // navigation, no pre-selected initial state), so it claims focus on mount:
+  // typing starts without a second click.
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, [inputRef]);
   return (
     <>
       <div
@@ -193,6 +208,23 @@ function OtherOptionField({
             ? "border-destructive ring-[1px] ring-destructive/50"
             : "focus-within:border-blue-400 focus-within:ring-[1px] focus-within:ring-blue-400/50"
         )}
+        onPointerDown={(event) => {
+          // The whole card reads as one input, so its padding focuses the
+          // input too; the input itself and the unselect glyph keep their
+          // native pointer behavior.
+          if (
+            !(event.target instanceof Element) ||
+            event.target.closest("button, input")
+          ) {
+            return;
+          }
+          event.preventDefault();
+          const input = inputRef.current;
+          if (input) {
+            input.focus();
+            input.setSelectionRange(input.value.length, input.value.length);
+          }
+        }}
       >
         <input
           aria-invalid={error || undefined}
@@ -200,6 +232,7 @@ function OtherOptionField({
           className="min-w-0 flex-1 bg-transparent text-foreground text-sm outline-none placeholder:text-muted-foreground"
           onChange={(event) => onTextChange(event.target.value)}
           placeholder="Tell us more"
+          ref={inputRef}
           value={text}
         />
         <button
@@ -304,6 +337,9 @@ export function OnboardingSurveyCard({
   // be missing, so typing or unselecting Other clears it without a reset.
   const [otherErrorArmed, setOtherErrorArmed] = useState(false);
   const otherError = otherErrorArmed && onboardingOtherTextMissing(state);
+  // At most one Other field renders at a time, so the steps share one ref;
+  // the card holds it to send focus into the field on a refused Next.
+  const otherInputRef = useRef<HTMLInputElement>(null);
 
   // The funnel view events: one per step shown, the mount itself being the
   // dialog's appearance (step 1). With no back navigation the step only
@@ -326,6 +362,9 @@ export function OnboardingSurveyCard({
     // instead (the reducer's advance gate refuses too); nothing persists.
     if (onboardingOtherTextMissing(state)) {
       setOtherErrorArmed(true);
+      // The error message alone would leave the user re-aiming at the field;
+      // focus lands in the empty input so typing can start immediately.
+      otherInputRef.current?.focus();
       return;
     }
     setOtherErrorArmed(false);
@@ -362,7 +401,7 @@ export function OnboardingSurveyCard({
             Step {state.currentStep} of {ONBOARDING_SURVEY_TOTAL_STEPS}
           </span>
           <button
-            className="text-muted-foreground text-sm transition-colors hover:text-foreground"
+            className="cursor-pointer text-muted-foreground text-sm transition-colors hover:text-foreground"
             onClick={handleSkip}
             type="button"
           >
@@ -396,6 +435,7 @@ export function OnboardingSurveyCard({
               option.value === "other" && state.roleType === "other" ? (
                 <OtherOptionField
                   error={otherError}
+                  inputRef={otherInputRef}
                   key={option.value}
                   label="Describe your role"
                   onTextChange={(text) =>
@@ -435,6 +475,7 @@ export function OnboardingSurveyCard({
               option.value === "other" && state.usageContext === "other" ? (
                 <OtherOptionField
                   error={otherError}
+                  inputRef={otherInputRef}
                   key={option.value}
                   label="Describe your usage"
                   onTextChange={(text) =>
@@ -475,6 +516,7 @@ export function OnboardingSurveyCard({
                 return (
                   <OtherOptionField
                     error={otherError}
+                    inputRef={otherInputRef}
                     key={tag}
                     label="Describe your priority"
                     onTextChange={(text) =>

--- a/apps/ui/src/features/onboarding/onboarding-dialog.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.tsx
@@ -33,6 +33,7 @@ import {
 import {
   type AnswerOnboardingStepRequest,
   type CompleteOnboardingProfileRequest,
+  type DismissOnboardingProfileRequest,
   ONBOARDING_OPEN_GOAL_TEXT_MAX_LENGTH,
   ONBOARDING_OTHER_TEXT_MAX_LENGTH,
   ONBOARDING_PRIORITY_TAGS_MAX,
@@ -330,12 +331,13 @@ export interface OnboardingSurveyCardProps {
    */
   onAnswerStep: (payload: AnswerOnboardingStepRequest) => void;
   /**
-   * Submit & Enter Console: the terminal completion, carrying the optional
-   * Step 4 open goal. The owner closes the dialog and persists.
+   * Submit & Enter Console: the terminal completion, carrying the Terminal
+   * Snapshot and the optional Step 4 open goal. The owner closes the dialog
+   * and persists.
    */
   onComplete: (payload: CompleteOnboardingProfileRequest) => void;
   /** Skip: the single exit short of the final submit; the owner persists. */
-  onSkip: (payload: { dismissedAtStep: number }) => void;
+  onSkip: (payload: DismissOnboardingProfileRequest) => void;
 }
 
 function stepAnswerPayload(

--- a/apps/ui/src/features/onboarding/onboarding-dialog.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.tsx
@@ -5,7 +5,7 @@ import { AppDialog } from "@workspace/ui/components/app-dialog";
 import { AppInput } from "@workspace/ui/components/app-input";
 import { cn } from "@workspace/ui/lib/utils";
 import { ArrowRight, Check, Send } from "lucide-react";
-import { type ReactNode, useEffect, useReducer, useRef } from "react";
+import { type ReactNode, useEffect, useReducer, useRef, useState } from "react";
 
 import { trackBrainGtmEvent } from "@/features/analytics/brain-gtm";
 
@@ -14,6 +14,7 @@ import {
   createInitialOnboardingSurveyState,
   type OnboardingSurveyState,
   onboardingCompletePayload,
+  onboardingOtherTextMissing,
   onboardingPriorityAnswerPayload,
   onboardingRoleAnswerPayload,
   onboardingSkipEvent,
@@ -91,16 +92,54 @@ const PRIORITY_OPTIONS: Record<
   },
 };
 
+/**
+ * The selection glyph pairs shape with the step's semantics — a deliberate
+ * correction over the design file, which draws squares everywhere: the
+ * single-select steps show a round radio dot, the multi-select step a square
+ * check. The blue border on the unselected glyph is the design's accent.
+ */
+function SelectionIndicator({
+  selected,
+  shape,
+}: {
+  selected: boolean;
+  shape: "checkbox" | "radio";
+}) {
+  let glyph: ReactNode = null;
+  if (selected) {
+    glyph =
+      shape === "radio" ? (
+        <span className="size-1.5 rounded-full bg-white" />
+      ) : (
+        <Check className="size-3" />
+      );
+  }
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "flex size-4 shrink-0 items-center justify-center border border-blue-500",
+        shape === "radio" ? "rounded-full" : "rounded-xs",
+        selected && "bg-blue-500 text-white"
+      )}
+    >
+      {glyph}
+    </span>
+  );
+}
+
 function OptionCard({
   children,
   disabled = false,
   onToggle,
   selected,
+  shape,
 }: {
   children: ReactNode;
   disabled?: boolean;
   onToggle: () => void;
   selected: boolean;
+  shape: "checkbox" | "radio";
 }) {
   return (
     <button
@@ -108,50 +147,108 @@ function OptionCard({
       className={cn(
         // min-h, not h: the Step 3 descriptions must stay readable, so a
         // card grows and wraps rather than truncating its one-liner.
-        "flex min-h-12 items-center justify-between gap-3 rounded-lg border px-4 py-2 text-left text-sm transition-colors",
-        selected
-          ? "border-brand-primary bg-input/50 text-foreground"
-          : "border-transparent bg-input/30 text-foreground hover:bg-input/50",
-        disabled && "cursor-not-allowed opacity-50 hover:bg-input/30"
+        "flex min-h-12 items-center justify-between gap-3 rounded-lg border border-transparent bg-input/30 px-4 py-2.5 text-left text-foreground text-sm transition-colors hover:border-border",
+        disabled && "cursor-not-allowed opacity-50 hover:border-transparent"
       )}
       disabled={disabled}
       onClick={onToggle}
       type="button"
     >
       <span className="min-w-0">{children}</span>
-      <span
-        aria-hidden
-        className={cn(
-          "flex size-4 shrink-0 items-center justify-center rounded-xs border",
-          selected
-            ? "border-brand-primary bg-brand-primary text-brand-primary-foreground"
-            : "border-brand-primary/60"
-        )}
-      >
-        {selected ? <Check className="size-3" /> : null}
-      </span>
+      <SelectionIndicator selected={selected} shape={shape} />
     </button>
   );
 }
 
-function StepHeading({
-  head,
-  subtitle,
-  tail,
+/**
+ * The Other slot after selection (design annotation: clicking Other turns
+ * the card into an input in place; an empty Next surfaces the inline
+ * required error). The container keeps the card footprint and hosts the
+ * free text plus the still-toggleable selection glyph — without that glyph
+ * the multi-select step could never release Other's cap slot.
+ */
+function OtherOptionField({
+  error,
+  label,
+  onTextChange,
+  onUnselect,
+  shape,
+  text,
 }: {
-  head: string;
-  subtitle?: string;
-  tail: string;
+  error: boolean;
+  label: string;
+  onTextChange: (text: string) => void;
+  onUnselect: () => void;
+  shape: "checkbox" | "radio";
+  text: string;
 }) {
   return (
     <>
-      <h2 className="mt-12 font-bold text-3xl text-foreground">
-        {head} <span className="text-brand-primary">{tail}</span>
+      <div
+        className={cn(
+          // A focus-within field wrapper: matches appFieldFocusClass's blue
+          // by eye, per the field-state outlier note.
+          "flex min-h-12 items-center gap-3 rounded-lg border border-input bg-input/30 px-4 py-2.5 transition-colors",
+          error
+            ? "border-destructive ring-[1px] ring-destructive/50"
+            : "focus-within:border-blue-400 focus-within:ring-[1px] focus-within:ring-blue-400/50"
+        )}
+      >
+        <input
+          aria-invalid={error || undefined}
+          aria-label={label}
+          className="min-w-0 flex-1 bg-transparent text-foreground text-sm outline-none placeholder:text-muted-foreground"
+          onChange={(event) => onTextChange(event.target.value)}
+          placeholder="Tell us more"
+          value={text}
+        />
+        <button
+          aria-label="Unselect Other"
+          className="cursor-pointer"
+          onClick={onUnselect}
+          type="button"
+        >
+          <SelectionIndicator selected shape={shape} />
+        </button>
+      </div>
+      {error ? (
+        <p className="self-center text-destructive text-sm">
+          This field is required.
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * The filled track reads as one white→blue ramp: its leading segment carries
+ * the gradient, later filled segments hold the solid endpoint color.
+ */
+function progressSegmentClass(index: number, currentStep: number): string {
+  if (index >= currentStep) {
+    return "bg-input";
+  }
+  return index === 0
+    ? "bg-gradient-to-r from-foreground to-blue-500"
+    : "bg-blue-500";
+}
+
+function StepHeading({
+  subtitle,
+  title,
+}: {
+  subtitle?: string;
+  title: string;
+}) {
+  return (
+    <div className="flex flex-col gap-2.5">
+      <h2 className="bg-gradient-to-r from-foreground to-onboarding-heading-accent bg-clip-text font-semibold text-4xl text-transparent">
+        {title}
       </h2>
       {subtitle == null ? null : (
-        <p className="mt-2 text-muted-foreground text-sm">{subtitle}</p>
+        <p className="text-base text-muted-foreground">{subtitle}</p>
       )}
-    </>
+    </div>
   );
 }
 
@@ -201,6 +298,10 @@ export function OnboardingSurveyCard({
     // once-per-session seat of the Step 3 display-order shuffle.
     () => createInitialOnboardingSurveyState()
   );
+  // Armed by a refused Next; the visible error also needs the text to still
+  // be missing, so typing or unselecting Other clears it without a reset.
+  const [otherErrorArmed, setOtherErrorArmed] = useState(false);
+  const otherError = otherErrorArmed && onboardingOtherTextMissing(state);
 
   // The funnel view events: one per step shown, the mount itself being the
   // dialog's appearance (step 1). With no back navigation the step only
@@ -219,6 +320,13 @@ export function OnboardingSurveyCard({
   }, [state.currentStep]);
 
   const handleNext = () => {
+    // Other with no text refuses to advance and surfaces the inline error
+    // instead (the reducer's advance gate refuses too); nothing persists.
+    if (onboardingOtherTextMissing(state)) {
+      setOtherErrorArmed(true);
+      return;
+    }
+    setOtherErrorArmed(false);
     // Persist-then-advance, both synchronous from the click: the payload is
     // assembled from the state being left, and the write is the owner's
     // fire-and-forget concern — Next never blocks on it.
@@ -245,115 +353,139 @@ export function OnboardingSurveyCard({
   };
 
   return (
-    <div className="flex min-h-144 flex-col p-9">
-      <div className="flex items-center justify-between">
-        <span className="text-muted-foreground text-sm">
-          Step {state.currentStep} of {ONBOARDING_SURVEY_TOTAL_STEPS}
-        </span>
-        <button
-          className="text-muted-foreground text-sm transition-colors hover:text-foreground"
-          onClick={handleSkip}
-          type="button"
-        >
-          Skip
-        </button>
-      </div>
-      <div className="mt-3 grid grid-cols-4 gap-3">
-        {Array.from({ length: ONBOARDING_SURVEY_TOTAL_STEPS }, (_, index) => (
-          <div
-            className={cn(
-              "h-1 rounded-full",
-              index < state.currentStep ? "bg-brand-primary" : "bg-muted"
-            )}
-            // biome-ignore lint/suspicious/noArrayIndexKey: fixed-size ordinal track
-            key={index}
-          />
-        ))}
+    <div className="flex flex-col gap-10 p-9">
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <span className="text-base text-muted-foreground">
+            Step {state.currentStep} of {ONBOARDING_SURVEY_TOTAL_STEPS}
+          </span>
+          <button
+            className="text-muted-foreground text-sm transition-colors hover:text-foreground"
+            onClick={handleSkip}
+            type="button"
+          >
+            Skip
+          </button>
+        </div>
+        <div className="grid grid-cols-4 gap-1.5">
+          {Array.from({ length: ONBOARDING_SURVEY_TOTAL_STEPS }, (_, index) => (
+            <div
+              className={cn(
+                "h-2 rounded-full",
+                progressSegmentClass(index, state.currentStep)
+              )}
+              // biome-ignore lint/suspicious/noArrayIndexKey: fixed-size ordinal track
+              key={index}
+            />
+          ))}
+        </div>
       </div>
       {/* Plain headings: the dialog context is optional for the card so the
           frame stays testable in a plain DOM; the shell labels the dialog. */}
       {state.currentStep === 1 ? (
         <>
           <StepHeading
-            head="Tell us"
             subtitle="This helps us tailor your workspace experience."
-            tail="a bit about you."
+            title="Tell us a bit about you."
           />
-          <fieldset className="mt-9 grid gap-4 border-0 sm:grid-cols-2">
+          <fieldset className="grid gap-5 border-0 sm:grid-cols-2">
             <legend className="sr-only">Your role</legend>
-            {ROLE_OPTIONS.map((option) => (
-              <OptionCard
-                key={option.value}
-                onToggle={() =>
-                  dispatch({ role: option.value, type: "toggle-role" })
-                }
-                selected={state.roleType === option.value}
-              >
-                {option.label}
-              </OptionCard>
-            ))}
-            {state.roleType === "other" ? (
-              <AppInput
-                aria-label="Describe your role"
-                onChange={(event) =>
-                  dispatch({
-                    text: event.target.value,
-                    type: "set-role-other-text",
-                  })
-                }
-                placeholder="Tell us more (optional)"
-                value={state.roleOtherText}
-              />
-            ) : null}
+            {ROLE_OPTIONS.map((option) =>
+              option.value === "other" && state.roleType === "other" ? (
+                <OtherOptionField
+                  error={otherError}
+                  key={option.value}
+                  label="Describe your role"
+                  onTextChange={(text) =>
+                    dispatch({ text, type: "set-role-other-text" })
+                  }
+                  onUnselect={() =>
+                    dispatch({ role: "other", type: "toggle-role" })
+                  }
+                  shape="radio"
+                  text={state.roleOtherText}
+                />
+              ) : (
+                <OptionCard
+                  key={option.value}
+                  onToggle={() =>
+                    dispatch({ role: option.value, type: "toggle-role" })
+                  }
+                  selected={state.roleType === option.value}
+                  shape="radio"
+                >
+                  {option.label}
+                </OptionCard>
+              )
+            )}
           </fieldset>
         </>
       ) : null}
       {state.currentStep === 2 ? (
         <>
           <StepHeading
-            head="What are"
             subtitle="Let us know what stage your project is in."
-            tail="you using Sealos for?"
+            title="What are you using Sealos for?"
           />
-          <fieldset className="mt-9 grid gap-4 border-0 sm:grid-cols-2">
+          <fieldset className="grid gap-5 border-0 sm:grid-cols-2">
             <legend className="sr-only">Your usage context</legend>
-            {USAGE_OPTIONS.map((option) => (
-              <OptionCard
-                key={option.value}
-                onToggle={() =>
-                  dispatch({ type: "toggle-usage", usage: option.value })
-                }
-                selected={state.usageContext === option.value}
-              >
-                {option.label}
-              </OptionCard>
-            ))}
-            {state.usageContext === "other" ? (
-              <AppInput
-                aria-label="Describe your usage"
-                onChange={(event) =>
-                  dispatch({
-                    text: event.target.value,
-                    type: "set-usage-other-text",
-                  })
-                }
-                placeholder="Tell us more (optional)"
-                value={state.usageOtherText}
-              />
-            ) : null}
+            {USAGE_OPTIONS.map((option) =>
+              option.value === "other" && state.usageContext === "other" ? (
+                <OtherOptionField
+                  error={otherError}
+                  key={option.value}
+                  label="Describe your usage"
+                  onTextChange={(text) =>
+                    dispatch({ text, type: "set-usage-other-text" })
+                  }
+                  onUnselect={() =>
+                    dispatch({ type: "toggle-usage", usage: "other" })
+                  }
+                  shape="radio"
+                  text={state.usageOtherText}
+                />
+              ) : (
+                <OptionCard
+                  key={option.value}
+                  onToggle={() =>
+                    dispatch({ type: "toggle-usage", usage: option.value })
+                  }
+                  selected={state.usageContext === option.value}
+                  shape="radio"
+                >
+                  {option.label}
+                </OptionCard>
+              )
+            )}
           </fieldset>
         </>
       ) : null}
       {state.currentStep === 3 ? (
         <>
           <StepHeading
-            head="Which factors are"
             subtitle="Choose up to 3."
-            tail="most important to you?"
+            title="Which factors are most important to you?"
           />
-          <fieldset className="mt-9 grid gap-4 border-0 sm:grid-cols-2">
+          <fieldset className="grid gap-5 border-0 sm:grid-cols-2">
             <legend className="sr-only">Your top priorities</legend>
             {state.priorityDisplayOrder.map((tag) => {
+              if (tag === "other" && state.priorityTags.includes("other")) {
+                return (
+                  <OtherOptionField
+                    error={otherError}
+                    key={tag}
+                    label="Describe your priority"
+                    onTextChange={(text) =>
+                      dispatch({ text, type: "set-priority-other-text" })
+                    }
+                    onUnselect={() =>
+                      dispatch({ tag: "other", type: "toggle-priority" })
+                    }
+                    shape="checkbox"
+                    text={state.priorityOtherText}
+                  />
+                );
+              }
               const option = PRIORITY_OPTIONS[tag];
               const selected = state.priorityTags.includes(tag);
               return (
@@ -367,42 +499,27 @@ export function OnboardingSurveyCard({
                   key={tag}
                   onToggle={() => dispatch({ tag, type: "toggle-priority" })}
                   selected={selected}
+                  shape="checkbox"
                 >
-                  {option.label}
+                  <span className="font-medium">{option.label}</span>
                   {option.description == null ? null : (
                     <span className="text-muted-foreground">
-                      {" — "}
+                      {": "}
                       {option.description}
                     </span>
                   )}
                 </OptionCard>
               );
             })}
-            {state.priorityTags.includes("other") ? (
-              <AppInput
-                aria-label="Describe your priority"
-                onChange={(event) =>
-                  dispatch({
-                    text: event.target.value,
-                    type: "set-priority-other-text",
-                  })
-                }
-                placeholder="Tell us more (optional)"
-                value={state.priorityOtherText}
-              />
-            ) : null}
           </fieldset>
         </>
       ) : null}
       {state.currentStep === 4 ? (
         <>
-          <StepHeading
-            head="Anything specific"
-            tail="you're trying to achieve?"
-          />
+          <StepHeading title="Anything specific you're trying to achieve?" />
           <AppInput
             aria-label="Anything specific you're trying to achieve?"
-            className="mt-9"
+            className="h-12 rounded-lg bg-input/30 px-4 dark:bg-input/30"
             onChange={(event) =>
               dispatch({
                 text: event.target.value,
@@ -414,7 +531,7 @@ export function OnboardingSurveyCard({
           />
         </>
       ) : null}
-      <div className="mt-auto flex justify-end pt-9">
+      <div className="flex justify-end">
         {state.currentStep === ONBOARDING_SURVEY_TOTAL_STEPS ? (
           // The terminal submit: never gated (the open goal is optional) and
           // never awaited — the owner closes the dialog into the console.
@@ -468,6 +585,7 @@ export function OnboardingDialog({
     <AppDialog.Root onOpenChange={refuseOnboardingDialogClose} open={open}>
       <AppDialog.Content
         aria-label="Onboarding survey"
+        className="rounded-xl bg-[color:var(--project-chrome-surface-base)] bg-[image:var(--onboarding-survey-surface-overlay)]"
         overlayClassName="bg-black/60"
         size="xl"
       >

--- a/apps/ui/src/features/onboarding/onboarding-dialog.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { AppButton } from "@workspace/ui/components/app-button";
 import { AppDialog } from "@workspace/ui/components/app-dialog";
-import { AppInput } from "@workspace/ui/components/app-input";
+import { AppTextarea } from "@workspace/ui/components/app-textarea";
 import { cn } from "@workspace/ui/lib/utils";
 import { ArrowRight, Check, Send } from "lucide-react";
 import {
@@ -33,6 +33,8 @@ import {
 import {
   type AnswerOnboardingStepRequest,
   type CompleteOnboardingProfileRequest,
+  ONBOARDING_OPEN_GOAL_TEXT_MAX_LENGTH,
+  ONBOARDING_OTHER_TEXT_MAX_LENGTH,
   ONBOARDING_PRIORITY_TAGS_MAX,
   ONBOARDING_SURVEY_TOTAL_STEPS,
   type OnboardingPriorityTag,
@@ -172,6 +174,21 @@ function OptionCard({
   );
 }
 
+/** The length allowance at a free-text field's tail: current/max, muted. */
+function LengthHint({ max, value }: { max: number; value: string }) {
+  return (
+    <span className="shrink-0 text-muted-foreground text-xs tabular-nums">
+      {value.length}/{max}
+    </span>
+  );
+}
+
+/**
+ * At most one Other field mounts at a time, so its error message can hold a
+ * fixed id for the input's `aria-describedby`.
+ */
+const OTHER_ERROR_ID = "onboarding-other-error";
+
 /**
  * The Other slot after selection (design annotation: clicking Other turns
  * the card into an input in place; an empty Next surfaces the inline
@@ -232,14 +249,17 @@ function OtherOptionField({
         }}
       >
         <input
+          aria-describedby={error ? OTHER_ERROR_ID : undefined}
           aria-invalid={error || undefined}
           aria-label={label}
           className="min-w-0 flex-1 bg-transparent text-foreground text-sm outline-none placeholder:text-muted-foreground"
+          maxLength={ONBOARDING_OTHER_TEXT_MAX_LENGTH}
           onChange={(event) => onTextChange(event.target.value)}
           placeholder="Tell us more"
           ref={inputRef}
           value={text}
         />
+        <LengthHint max={ONBOARDING_OTHER_TEXT_MAX_LENGTH} value={text} />
         <button
           aria-label="Unselect Other"
           className="cursor-pointer"
@@ -250,7 +270,11 @@ function OtherOptionField({
         </button>
       </div>
       {error ? (
-        <p className="self-center text-destructive text-sm">
+        <p
+          className="self-center text-destructive text-sm"
+          id={OTHER_ERROR_ID}
+          role="alert"
+        >
           This field is required.
         </p>
       ) : null}
@@ -573,18 +597,29 @@ export function OnboardingSurveyCard({
       {state.currentStep === 4 ? (
         <div className={stepGroupClass}>
           <StepHeading title="Anything specific you're trying to achieve?" />
-          <AppInput
-            aria-label="Anything specific you're trying to achieve?"
-            className="h-12 rounded-lg bg-input/30 px-4 dark:bg-input/30"
-            onChange={(event) =>
-              dispatch({
-                text: event.target.value,
-                type: "set-open-goal-text",
-              })
-            }
-            placeholder="e.g. deploy an AI agent, move from VPS, test a product idea…"
-            value={state.openGoalText}
-          />
+          <div className="flex flex-col gap-1.5">
+            {/* Auto-growing (field-sizing-content via AppTextarea): the open
+                goal allows 2000 characters, far past one input line. */}
+            <AppTextarea
+              aria-label="Anything specific you're trying to achieve?"
+              className="min-h-12 rounded-lg bg-input/30 px-4 py-3.5 dark:bg-input/30"
+              maxLength={ONBOARDING_OPEN_GOAL_TEXT_MAX_LENGTH}
+              onChange={(event) =>
+                dispatch({
+                  text: event.target.value,
+                  type: "set-open-goal-text",
+                })
+              }
+              placeholder="e.g. deploy an AI agent, move from VPS, test a product idea…"
+              value={state.openGoalText}
+            />
+            <div className="flex justify-end">
+              <LengthHint
+                max={ONBOARDING_OPEN_GOAL_TEXT_MAX_LENGTH}
+                value={state.openGoalText}
+              />
+            </div>
+          </div>
         </div>
       ) : null}
       <div className="flex justify-end">
@@ -645,11 +680,16 @@ export function OnboardingDialog({
         overlayClassName="bg-black/60"
         size="xl"
       >
-        <OnboardingSurveyCard
-          onAnswerStep={onAnswerStep}
-          onComplete={onComplete}
-          onSkip={onSkip}
-        />
+        {/* The dialog content clamps to the viewport with overflow-hidden,
+            so the survey scrolls inside it: on short viewports the step
+            body pans while Next/Submit stays reachable at the frame's end. */}
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <OnboardingSurveyCard
+            onAnswerStep={onAnswerStep}
+            onComplete={onComplete}
+            onSkip={onSkip}
+          />
+        </div>
       </AppDialog.Content>
     </AppDialog.Root>
   );

--- a/apps/ui/src/features/onboarding/onboarding-dialog.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.tsx
@@ -599,10 +599,14 @@ export function OnboardingSurveyCard({
           <StepHeading title="Anything specific you're trying to achieve?" />
           <div className="flex flex-col gap-1.5">
             {/* Auto-growing (field-sizing-content via AppTextarea): the open
-                goal allows 2000 characters, far past one input line. */}
+                goal allows 2000 characters, far past one input line. The
+                min-height equals the three-row empty state exactly (3×20px
+                lines + 28px padding + 2px border), so the first keystroke —
+                which flips field-sizing from fixed to content — cannot
+                shrink the field; past three lines it grows. */}
             <AppTextarea
               aria-label="Anything specific you're trying to achieve?"
-              className="min-h-12 rounded-lg bg-input/30 px-4 py-3.5 dark:bg-input/30"
+              className="min-h-22.5 resize-none rounded-lg bg-input/30 px-4 py-3.5 dark:bg-input/30"
               maxLength={ONBOARDING_OPEN_GOAL_TEXT_MAX_LENGTH}
               onChange={(event) =>
                 dispatch({
@@ -611,6 +615,7 @@ export function OnboardingSurveyCard({
                 })
               }
               placeholder="e.g. deploy an AI agent, move from VPS, test a product idea…"
+              rows={3}
               value={state.openGoalText}
             />
             <div className="flex justify-end">

--- a/apps/ui/src/features/onboarding/onboarding-dialog.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.tsx
@@ -600,13 +600,13 @@ export function OnboardingSurveyCard({
           <div className="flex flex-col gap-1.5">
             {/* Auto-growing (field-sizing-content via AppTextarea): the open
                 goal allows 2000 characters, far past one input line. The
-                min-height equals the three-row empty state exactly (3×20px
+                min-height equals the four-row empty state exactly (4×20px
                 lines + 28px padding + 2px border), so the first keystroke —
                 which flips field-sizing from fixed to content — cannot
-                shrink the field; past three lines it grows. */}
+                shrink the field; past four lines it grows. */}
             <AppTextarea
               aria-label="Anything specific you're trying to achieve?"
-              className="min-h-22.5 resize-none rounded-lg bg-input/30 px-4 py-3.5 dark:bg-input/30"
+              className="min-h-27.5 resize-none rounded-lg bg-input/30 px-4 py-3.5 dark:bg-input/30"
               maxLength={ONBOARDING_OPEN_GOAL_TEXT_MAX_LENGTH}
               onChange={(event) =>
                 dispatch({
@@ -615,7 +615,7 @@ export function OnboardingSurveyCard({
                 })
               }
               placeholder="e.g. deploy an AI agent, move from VPS, test a product idea…"
-              rows={3}
+              rows={4}
               value={state.openGoalText}
             />
             <div className="flex justify-end">

--- a/apps/ui/src/features/onboarding/onboarding-dialog.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.tsx
@@ -5,7 +5,9 @@ import { AppDialog } from "@workspace/ui/components/app-dialog";
 import { AppInput } from "@workspace/ui/components/app-input";
 import { cn } from "@workspace/ui/lib/utils";
 import { ArrowRight, Check, Send } from "lucide-react";
-import { type ReactNode, useReducer } from "react";
+import { type ReactNode, useEffect, useReducer, useRef } from "react";
+
+import { trackBrainGtmEvent } from "@/features/analytics/brain-gtm";
 
 import {
   canAdvanceOnboardingStep,
@@ -14,7 +16,9 @@ import {
   onboardingCompletePayload,
   onboardingPriorityAnswerPayload,
   onboardingRoleAnswerPayload,
+  onboardingSkipEvent,
   onboardingSkipPayload,
+  onboardingStepViewEvent,
   onboardingSurveyReducer,
   onboardingUsageAnswerPayload,
 } from "./survey-state";
@@ -198,6 +202,22 @@ export function OnboardingSurveyCard({
     () => createInitialOnboardingSurveyState()
   );
 
+  // The funnel view events: one per step shown, the mount itself being the
+  // dialog's appearance (step 1). With no back navigation the step only
+  // grows, so the monotonic ref guard means exactly once per step — a
+  // dev-mode remount replaying the effect cannot double-fire.
+  const lastViewedStepRef = useRef(0);
+  useEffect(() => {
+    if (lastViewedStepRef.current >= state.currentStep) {
+      return;
+    }
+    lastViewedStepRef.current = state.currentStep;
+    const viewEvent = onboardingStepViewEvent(state.currentStep);
+    if (viewEvent !== null) {
+      trackBrainGtmEvent(viewEvent);
+    }
+  }, [state.currentStep]);
+
   const handleNext = () => {
     // Persist-then-advance, both synchronous from the click: the payload is
     // assembled from the state being left, and the write is the owner's
@@ -209,6 +229,21 @@ export function OnboardingSurveyCard({
     dispatch({ type: "advance-step" });
   };
 
+  const handleSkip = () => {
+    // The funnel event fires at click time, before the owner's terminal
+    // write — analytics is best-effort and never awaits persistence.
+    const skipEvent = onboardingSkipEvent(state.currentStep);
+    if (skipEvent !== null) {
+      trackBrainGtmEvent(skipEvent);
+    }
+    onSkip(onboardingSkipPayload(state));
+  };
+
+  const handleComplete = () => {
+    trackBrainGtmEvent({ event: "onboarding_complete" });
+    onComplete(onboardingCompletePayload(state));
+  };
+
   return (
     <div className="flex min-h-144 flex-col p-9">
       <div className="flex items-center justify-between">
@@ -217,7 +252,7 @@ export function OnboardingSurveyCard({
         </span>
         <button
           className="text-muted-foreground text-sm transition-colors hover:text-foreground"
-          onClick={() => onSkip(onboardingSkipPayload(state))}
+          onClick={handleSkip}
           type="button"
         >
           Skip
@@ -382,10 +417,7 @@ export function OnboardingSurveyCard({
         {state.currentStep === ONBOARDING_SURVEY_TOTAL_STEPS ? (
           // The terminal submit: never gated (the open goal is optional) and
           // never awaited — the owner closes the dialog into the console.
-          <AppButton
-            onClick={() => onComplete(onboardingCompletePayload(state))}
-            type="button"
-          >
+          <AppButton onClick={handleComplete} type="button">
             Submit & Enter Console
             <Send aria-hidden data-icon="inline-end" />
           </AppButton>

--- a/apps/ui/src/features/onboarding/onboarding-dialog.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.tsx
@@ -102,8 +102,10 @@ const PRIORITY_OPTIONS: Record<
 /**
  * The selection glyph pairs shape with the step's semantics — a deliberate
  * correction over the design file, which draws squares everywhere: the
- * single-select steps show a round radio dot, the multi-select step a square
- * check. The blue border on the unselected glyph is the design's accent.
+ * single-select steps show a ring radio (blue inner dot, unfilled), the
+ * multi-select step a filled square check — the conventional pairing, and
+ * the one the shared checkbox already uses. The blue border on the
+ * unselected glyph is the design's accent.
  */
 function SelectionIndicator({
   selected,
@@ -116,7 +118,7 @@ function SelectionIndicator({
   if (selected) {
     glyph =
       shape === "radio" ? (
-        <span className="size-1.5 rounded-full bg-white" />
+        <span className="size-2 rounded-full bg-blue-500" />
       ) : (
         <Check className="size-3" />
       );
@@ -127,7 +129,7 @@ function SelectionIndicator({
       className={cn(
         "flex size-4 shrink-0 items-center justify-center border border-blue-500",
         shape === "radio" ? "rounded-full" : "rounded-xs",
-        selected && "bg-blue-500 text-white"
+        selected && shape === "checkbox" && "bg-blue-500 text-white"
       )}
     >
       {glyph}
@@ -154,7 +156,10 @@ function OptionCard({
       className={cn(
         // min-h, not h: the Step 3 descriptions must stay readable, so a
         // card grows and wraps rather than truncating its one-liner.
-        "flex min-h-12 cursor-pointer items-center justify-between gap-3 rounded-lg border border-transparent bg-input/30 px-4 py-2.5 text-left text-foreground text-sm transition-colors hover:border-border",
+        "flex min-h-12 cursor-pointer items-center justify-between gap-3 rounded-lg border border-transparent px-4 py-2.5 text-left text-foreground text-sm transition-colors",
+        // The deepened wash carries the selected state so it never rides on
+        // the 16px glyph alone.
+        selected ? "bg-input" : "bg-input/30 hover:border-border",
         disabled && "cursor-not-allowed opacity-50 hover:border-transparent"
       )}
       disabled={disabled}

--- a/apps/ui/src/features/onboarding/onboarding-gate-core.test.ts
+++ b/apps/ui/src/features/onboarding/onboarding-gate-core.test.ts
@@ -8,6 +8,7 @@ import {
   onboardingCredentialsKey,
   onboardingCredentialsReady,
   resetOnboardingGateSessionForTesting,
+  settleOnboardingSessionJudgmentSampled,
 } from "./onboarding-gate-core";
 
 test("the gate does nothing until every credential has hydrated", () => {
@@ -66,6 +67,52 @@ test("a mid-session credential change discards the old judgment and re-judges", 
   assert.equal(judged, 2);
   assert.notEqual(first.promise, swapped.promise);
   assert.equal(swapped.rekeyed, true, "the identity swap is reported");
+  resetOnboardingGateSessionForTesting();
+});
+
+test("a terminal action settles the judgment so a remount cannot reopen", async () => {
+  resetOnboardingGateSessionForTesting();
+  const key = onboardingCredentialsKey({
+    appToken: "token-a",
+    kubeconfig: "kc-a",
+    namespace: "ns-a",
+  });
+  let judged = 0;
+  const judge = () => {
+    judged += 1;
+    return Promise.resolve(true);
+  };
+
+  obtainOnboardingSessionJudgment({ judge, key });
+  settleOnboardingSessionJudgmentSampled(key);
+  const remount = obtainOnboardingSessionJudgment({ judge, key });
+
+  assert.equal(judged, 1, "the settled judgment is reused, not re-judged");
+  assert.equal(remount.rekeyed, false);
+  assert.equal(await remount.promise, false, "the survey stays closed");
+  resetOnboardingGateSessionForTesting();
+});
+
+test("settling never clobbers a different identity's judgment", async () => {
+  resetOnboardingGateSessionForTesting();
+  const currentKey = onboardingCredentialsKey({
+    appToken: "token-b",
+    kubeconfig: "kc-b",
+    namespace: "ns-b",
+  });
+  const staleKey = onboardingCredentialsKey({
+    appToken: "token-a",
+    kubeconfig: "kc-a",
+    namespace: "ns-a",
+  });
+  const judge = () => Promise.resolve(true);
+
+  obtainOnboardingSessionJudgment({ judge, key: currentKey });
+  settleOnboardingSessionJudgmentSampled(staleKey);
+  const held = obtainOnboardingSessionJudgment({ judge, key: currentKey });
+
+  assert.equal(held.rekeyed, false);
+  assert.equal(await held.promise, true, "the live judgment is untouched");
   resetOnboardingGateSessionForTesting();
 });
 

--- a/apps/ui/src/features/onboarding/onboarding-gate-core.test.ts
+++ b/apps/ui/src/features/onboarding/onboarding-gate-core.test.ts
@@ -51,6 +51,25 @@ test("failures retry on the backoff schedule before a verdict lands", async () =
   assert.deepEqual(delays, [...ONBOARDING_GATE_RETRY_DELAYS_MS]);
 });
 
+test("an authorization refusal fails closed without retries", async () => {
+  const delays: number[] = [];
+  let attempts = 0;
+  const opened = await judgeOnboardingSampling({
+    delay: (ms) => {
+      delays.push(ms);
+      return Promise.resolve();
+    },
+    fetchVerdict: () => {
+      attempts += 1;
+      return Promise.resolve("unauthorized" as const);
+    },
+  });
+
+  assert.equal(opened, false);
+  assert.equal(attempts, 1);
+  assert.deepEqual(delays, []);
+});
+
 test("after two failed retries the gate silently stands down", async () => {
   let attempts = 0;
   const opened = await judgeOnboardingSampling({

--- a/apps/ui/src/features/onboarding/onboarding-gate-core.test.ts
+++ b/apps/ui/src/features/onboarding/onboarding-gate-core.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  judgeOnboardingSampling,
+  ONBOARDING_GATE_RETRY_DELAYS_MS,
+  onboardingCredentialsReady,
+} from "./onboarding-gate-core";
+
+test("the gate does nothing until every credential has hydrated", () => {
+  const ready = { appToken: "token", kubeconfig: "kc", namespace: "ns-user" };
+  assert.equal(onboardingCredentialsReady(ready), true);
+  assert.equal(onboardingCredentialsReady({ ...ready, appToken: " " }), false);
+  assert.equal(onboardingCredentialsReady({ ...ready, kubeconfig: "" }), false);
+  assert.equal(onboardingCredentialsReady({ ...ready, namespace: "" }), false);
+});
+
+test("only a definitive Unsampled verdict opens the dialog", async () => {
+  assert.equal(
+    await judgeOnboardingSampling({
+      fetchVerdict: () => Promise.resolve({ sampled: false }),
+    }),
+    true
+  );
+  assert.equal(
+    await judgeOnboardingSampling({
+      fetchVerdict: () => Promise.resolve({ sampled: true }),
+    }),
+    false
+  );
+});
+
+test("failures retry on the backoff schedule before a verdict lands", async () => {
+  const delays: number[] = [];
+  let attempts = 0;
+  const opened = await judgeOnboardingSampling({
+    delay: (ms) => {
+      delays.push(ms);
+      return Promise.resolve();
+    },
+    fetchVerdict: () => {
+      attempts += 1;
+      return attempts < 3
+        ? Promise.resolve(null)
+        : Promise.resolve({ sampled: false });
+    },
+  });
+
+  assert.equal(opened, true);
+  assert.equal(attempts, 3);
+  assert.deepEqual(delays, [...ONBOARDING_GATE_RETRY_DELAYS_MS]);
+});
+
+test("after two failed retries the gate silently stands down", async () => {
+  let attempts = 0;
+  const opened = await judgeOnboardingSampling({
+    delay: () => Promise.resolve(),
+    fetchVerdict: () => {
+      attempts += 1;
+      return Promise.reject(new Error("network down"));
+    },
+  });
+
+  assert.equal(opened, false);
+  assert.equal(attempts, 1 + ONBOARDING_GATE_RETRY_DELAYS_MS.length);
+});

--- a/apps/ui/src/features/onboarding/onboarding-gate-core.test.ts
+++ b/apps/ui/src/features/onboarding/onboarding-gate-core.test.ts
@@ -4,7 +4,10 @@ import { test } from "node:test";
 import {
   judgeOnboardingSampling,
   ONBOARDING_GATE_RETRY_DELAYS_MS,
+  obtainOnboardingSessionJudgment,
+  onboardingCredentialsKey,
   onboardingCredentialsReady,
+  resetOnboardingGateSessionForTesting,
 } from "./onboarding-gate-core";
 
 test("the gate does nothing until every credential has hydrated", () => {
@@ -13,6 +16,72 @@ test("the gate does nothing until every credential has hydrated", () => {
   assert.equal(onboardingCredentialsReady({ ...ready, appToken: " " }), false);
   assert.equal(onboardingCredentialsReady({ ...ready, kubeconfig: "" }), false);
   assert.equal(onboardingCredentialsReady({ ...ready, namespace: "" }), false);
+});
+
+test("remounts under the same credential identity reuse the one judgment", () => {
+  resetOnboardingGateSessionForTesting();
+  const key = onboardingCredentialsKey({
+    appToken: "token-a",
+    kubeconfig: "kc-a",
+    namespace: "ns-a",
+  });
+  let judged = 0;
+  const judge = () => {
+    judged += 1;
+    return Promise.resolve(true);
+  };
+
+  const first = obtainOnboardingSessionJudgment({ judge, key });
+  const second = obtainOnboardingSessionJudgment({ judge, key });
+
+  assert.equal(judged, 1);
+  assert.equal(first.promise, second.promise);
+  assert.equal(first.rekeyed, false);
+  assert.equal(second.rekeyed, false);
+  resetOnboardingGateSessionForTesting();
+});
+
+test("a mid-session credential change discards the old judgment and re-judges", () => {
+  resetOnboardingGateSessionForTesting();
+  const credentials = {
+    appToken: "token-a",
+    kubeconfig: "kc-a",
+    namespace: "ns-a",
+  };
+  let judged = 0;
+  const judge = () => {
+    judged += 1;
+    return Promise.resolve(true);
+  };
+
+  const first = obtainOnboardingSessionJudgment({
+    judge,
+    key: onboardingCredentialsKey(credentials),
+  });
+  const swapped = obtainOnboardingSessionJudgment({
+    judge,
+    key: onboardingCredentialsKey({ ...credentials, appToken: "token-b" }),
+  });
+
+  assert.equal(judged, 2);
+  assert.notEqual(first.promise, swapped.promise);
+  assert.equal(swapped.rekeyed, true, "the identity swap is reported");
+  resetOnboardingGateSessionForTesting();
+});
+
+test("the credential fingerprint separates fields unambiguously", () => {
+  // A field boundary shift ("a b" + "c" vs "a" + "b c") must not collide.
+  const one = onboardingCredentialsKey({
+    appToken: "t",
+    kubeconfig: "a b",
+    namespace: "c",
+  });
+  const other = onboardingCredentialsKey({
+    appToken: "t",
+    kubeconfig: "a",
+    namespace: "b c",
+  });
+  assert.notEqual(one, other);
 });
 
 test("only a definitive Unsampled verdict opens the dialog", async () => {

--- a/apps/ui/src/features/onboarding/onboarding-gate-core.ts
+++ b/apps/ui/src/features/onboarding/onboarding-gate-core.ts
@@ -1,0 +1,53 @@
+import type { OnboardingFetcherCredentials } from "./client";
+import type { OnboardingSamplingVerdict } from "./types";
+
+/**
+ * The Onboarding Gate's failure policy: silent, with at most 2 backoff
+ * retries per session, then stand down — sampling is opportunistic and never
+ * bought at the cost of console access.
+ */
+export const ONBOARDING_GATE_RETRY_DELAYS_MS = [1000, 3000] as const;
+
+/** Credentials the Gate needs before it can judge anything this session. */
+export function onboardingCredentialsReady(
+  input: OnboardingFetcherCredentials
+): boolean {
+  return (
+    input.appToken.trim() !== "" &&
+    input.kubeconfig.trim() !== "" &&
+    input.namespace.trim() !== ""
+  );
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Judges the sampling predicate once per session: `true` only on a definitive
+ * Unsampled verdict — the single outcome that opens the dialog. A `null`
+ * verdict (network failure, unauthorized, parse failure) is retried on the
+ * backoff schedule and then silently stands down; the person is simply
+ * re-judged on their next entry.
+ */
+export async function judgeOnboardingSampling(input: {
+  fetchVerdict: () => Promise<OnboardingSamplingVerdict | null>;
+  /** Test seam; defaults to a real timer. */
+  delay?: (ms: number) => Promise<void>;
+}): Promise<boolean> {
+  const delay = input.delay ?? wait;
+  for (
+    let attempt = 0;
+    attempt <= ONBOARDING_GATE_RETRY_DELAYS_MS.length;
+    attempt += 1
+  ) {
+    if (attempt > 0) {
+      await delay(ONBOARDING_GATE_RETRY_DELAYS_MS[attempt - 1] ?? 0);
+    }
+    const verdict = await input.fetchVerdict().catch(() => null);
+    if (verdict != null) {
+      return !verdict.sampled;
+    }
+  }
+  return false;
+}

--- a/apps/ui/src/features/onboarding/onboarding-gate-core.ts
+++ b/apps/ui/src/features/onboarding/onboarding-gate-core.ts
@@ -59,6 +59,20 @@ export function obtainOnboardingSessionJudgment(input: {
   return { promise: sessionJudgment.promise, rekeyed };
 }
 
+/**
+ * Overrides `key`'s session judgment with Sampled the moment a terminal
+ * complete/dismiss fires: without this, a Gate remount under the same
+ * credentials (client-side navigation away from and back to the console)
+ * would re-attach to the stale Unsampled verdict and reopen the survey the
+ * person just finished. A judgment held by a different identity is not
+ * touched — the terminal action wasn't theirs.
+ */
+export function settleOnboardingSessionJudgmentSampled(key: string): void {
+  if (sessionJudgment === null || sessionJudgment.key === key) {
+    sessionJudgment = { key, promise: Promise.resolve(false) };
+  }
+}
+
 function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/apps/ui/src/features/onboarding/onboarding-gate-core.ts
+++ b/apps/ui/src/features/onboarding/onboarding-gate-core.ts
@@ -25,13 +25,16 @@ function wait(ms: number): Promise<void> {
 
 /**
  * Judges the sampling predicate once per session: `true` only on a definitive
- * Unsampled verdict — the single outcome that opens the dialog. A `null`
- * verdict (network failure, unauthorized, parse failure) is retried on the
- * backoff schedule and then silently stands down; the person is simply
- * re-judged on their next entry.
+ * Unsampled verdict — the single outcome that opens the dialog. An
+ * `"unauthorized"` outcome fails closed at once — retrying the same
+ * credentials cannot change that answer. A `null` verdict (network failure,
+ * parse failure) is retried on the backoff schedule and then silently stands
+ * down; the person is simply re-judged on their next entry.
  */
 export async function judgeOnboardingSampling(input: {
-  fetchVerdict: () => Promise<OnboardingSamplingVerdict | null>;
+  fetchVerdict: () => Promise<
+    OnboardingSamplingVerdict | "unauthorized" | null
+  >;
   /** Test seam; defaults to a real timer. */
   delay?: (ms: number) => Promise<void>;
 }): Promise<boolean> {
@@ -45,6 +48,9 @@ export async function judgeOnboardingSampling(input: {
       await delay(ONBOARDING_GATE_RETRY_DELAYS_MS[attempt - 1] ?? 0);
     }
     const verdict = await input.fetchVerdict().catch(() => null);
+    if (verdict === "unauthorized") {
+      return false;
+    }
     if (verdict != null) {
       return !verdict.sampled;
     }

--- a/apps/ui/src/features/onboarding/onboarding-gate-core.ts
+++ b/apps/ui/src/features/onboarding/onboarding-gate-core.ts
@@ -19,6 +19,46 @@ export function onboardingCredentialsReady(
   );
 }
 
+/**
+ * One sampling judgment per session (page load) and credential identity:
+ * remounts re-attach to the same promise instead of re-querying. Identity
+ * swaps normally arrive via a fresh page load (the Desktop reloads the
+ * iframe on account/region/workspace switches), but that is a Desktop
+ * contract this app cannot enforce — so a changed credential key defensively
+ * discards the old judgment rather than letting it speak for a new identity.
+ */
+let sessionJudgment: { key: string; promise: Promise<boolean> } | null = null;
+
+/** Test seam. */
+export function resetOnboardingGateSessionForTesting(): void {
+  sessionJudgment = null;
+}
+
+/** Fingerprint of the credential identity a judgment is made for. */
+export function onboardingCredentialsKey(
+  input: OnboardingFetcherCredentials
+): string {
+  return [input.appToken.trim(), input.kubeconfig, input.namespace.trim()].join(
+    "\u0000"
+  );
+}
+
+/**
+ * Returns the session judgment for `key`, starting one when none exists or
+ * the key changed. `rekeyed` is true only on a mid-session identity change —
+ * the caller must then drop any UI state the discarded judgment produced.
+ */
+export function obtainOnboardingSessionJudgment(input: {
+  key: string;
+  judge: () => Promise<boolean>;
+}): { promise: Promise<boolean>; rekeyed: boolean } {
+  const rekeyed = sessionJudgment !== null && sessionJudgment.key !== input.key;
+  if (sessionJudgment === null || rekeyed) {
+    sessionJudgment = { key: input.key, promise: input.judge() };
+  }
+  return { promise: sessionJudgment.promise, rekeyed };
+}
+
 function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/apps/ui/src/features/onboarding/onboarding-gate-core.ts
+++ b/apps/ui/src/features/onboarding/onboarding-gate-core.ts
@@ -64,8 +64,12 @@ export function obtainOnboardingSessionJudgment(input: {
  * complete/dismiss fires: without this, a Gate remount under the same
  * credentials (client-side navigation away from and back to the console)
  * would re-attach to the stale Unsampled verdict and reopen the survey the
- * person just finished. A judgment held by a different identity is not
- * touched — the terminal action wasn't theirs.
+ * person just finished. Deliberately settled at the action, not at the
+ * write's success — the judgment records "this person terminated the survey
+ * this session", and re-asking someone who just declined would be worse
+ * than a lost write, whose recovery is the database re-judgment on the next
+ * page load. A judgment held by a different identity is not touched — the
+ * terminal action wasn't theirs.
  */
 export function settleOnboardingSessionJudgmentSampled(key: string): void {
   if (sessionJudgment === null || sessionJudgment.key === key) {

--- a/apps/ui/src/features/onboarding/onboarding-gate.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-gate.tsx
@@ -19,6 +19,7 @@ import {
   obtainOnboardingSessionJudgment,
   onboardingCredentialsKey,
   onboardingCredentialsReady,
+  settleOnboardingSessionJudgmentSampled,
 } from "./onboarding-gate-core";
 import type {
   AnswerOnboardingStepRequest,
@@ -123,18 +124,26 @@ export function OnboardingGate() {
     // Submit & Enter Console drops the person into the console immediately;
     // the terminal write never blocks the exit.
     setOpen(false);
-    fireWrite((credentials) =>
-      completeOnboardingProfile(credentials, payload.openGoalText)
-    );
+    fireWrite((credentials) => {
+      completeOnboardingProfile(credentials, payload.openGoalText);
+      // The session judgment must flip to Sampled with the write, or a Gate
+      // remount would re-attach to the stale verdict and reopen the survey.
+      settleOnboardingSessionJudgmentSampled(
+        onboardingCredentialsKey(credentials)
+      );
+    });
   };
 
   const handleSkip = (payload: { dismissedAtStep: number }) => {
     // Skip drops the person into the console immediately; the terminal
     // write never blocks the exit.
     setOpen(false);
-    fireWrite((credentials) =>
-      dismissOnboardingProfile(credentials, payload.dismissedAtStep)
-    );
+    fireWrite((credentials) => {
+      dismissOnboardingProfile(credentials, payload.dismissedAtStep);
+      settleOnboardingSessionJudgmentSampled(
+        onboardingCredentialsKey(credentials)
+      );
+    });
   };
 
   return (

--- a/apps/ui/src/features/onboarding/onboarding-gate.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-gate.tsx
@@ -16,6 +16,8 @@ import {
 import { OnboardingDialog } from "./onboarding-dialog";
 import {
   judgeOnboardingSampling,
+  obtainOnboardingSessionJudgment,
+  onboardingCredentialsKey,
   onboardingCredentialsReady,
 } from "./onboarding-gate-core";
 import type {
@@ -39,18 +41,6 @@ const ONBOARDING_TWEAKS = {
     },
   },
 } as const;
-
-/**
- * One sampling judgment per session (page load): remounts re-attach to the
- * same promise instead of re-querying, and a failed or exhausted judgment
- * silently stands down until the next entry.
- */
-let sessionJudgment: Promise<boolean> | null = null;
-
-/** Test seam. */
-export function resetOnboardingGateSessionForTesting(): void {
-  sessionJudgment = null;
-}
 
 /**
  * The Onboarding Gate (ADR-0061): opportunistic and non-blocking. The console
@@ -78,11 +68,20 @@ export function OnboardingGate() {
       kubeconfig,
       namespace: namespace.trim(),
     };
-    sessionJudgment ??= judgeOnboardingSampling({
-      fetchVerdict: () => fetchOnboardingSamplingVerdict(credentials),
+    const { promise, rekeyed } = obtainOnboardingSessionJudgment({
+      judge: () =>
+        judgeOnboardingSampling({
+          fetchVerdict: () => fetchOnboardingSamplingVerdict(credentials),
+        }),
+      key: onboardingCredentialsKey(credentials),
     });
+    if (rekeyed) {
+      // Whatever the discarded identity's judgment opened must not survive
+      // it; the new judgment below reopens the dialog if it should.
+      setOpen(false);
+    }
     let disposed = false;
-    sessionJudgment.then(
+    promise.then(
       (shouldOpen) => {
         if (!disposed && shouldOpen) {
           setOpen(true);

--- a/apps/ui/src/features/onboarding/onboarding-gate.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-gate.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useAtomValue } from "jotai";
+import { useEffect, useState } from "react";
+
+import { useDevTweaks } from "@/features/dev-tweaks/use-dev-tweaks";
+import { appTokenAtom, kubeconfigAtom, namespaceAtom } from "@/lib/auth-store";
+
+import {
+  dismissOnboardingProfile,
+  fetchOnboardingSamplingVerdict,
+} from "./client";
+import { OnboardingDialog } from "./onboarding-dialog";
+import {
+  judgeOnboardingSampling,
+  onboardingCredentialsReady,
+} from "./onboarding-gate-core";
+
+const ONBOARDING_TWEAKS = {
+  note: "Opens the dialog unconditionally; Skip is inert while forced, so sampling state stays untouched.",
+  title: "Onboarding · sampling dialog",
+  tweaks: {
+    forceModal: {
+      label: "Force onboarding modal (0 off · 1 on)",
+      max: 1,
+      min: 0,
+      step: 1,
+      value: 0,
+    },
+  },
+} as const;
+
+/**
+ * One sampling judgment per session (page load): remounts re-attach to the
+ * same promise instead of re-querying, and a failed or exhausted judgment
+ * silently stands down until the next entry.
+ */
+let sessionJudgment: Promise<boolean> | null = null;
+
+/** Test seam. */
+export function resetOnboardingGateSessionForTesting(): void {
+  sessionJudgment = null;
+}
+
+/**
+ * The Onboarding Gate (ADR-0061): opportunistic and non-blocking. The console
+ * always renders — this component mounts nothing visible until a definitive
+ * Unsampled verdict opens the sampling dialog, and every failure on the way
+ * is silent.
+ */
+export function OnboardingGate() {
+  const appToken = useAtomValue(appTokenAtom);
+  const kubeconfig = useAtomValue(kubeconfigAtom);
+  const namespace = useAtomValue(namespaceAtom);
+  const [open, setOpen] = useState(false);
+  const { values } = useDevTweaks("onboarding", ONBOARDING_TWEAKS);
+  const forceOpen =
+    process.env.NODE_ENV === "development" && values.forceModal >= 0.5;
+
+  useEffect(() => {
+    // The app token arrives asynchronously from the Desktop SDK; with no
+    // token this session, the gate does nothing (fail closed, no dialog).
+    if (!onboardingCredentialsReady({ appToken, kubeconfig, namespace })) {
+      return;
+    }
+    const credentials = {
+      appToken: appToken.trim(),
+      kubeconfig,
+      namespace: namespace.trim(),
+    };
+    sessionJudgment ??= judgeOnboardingSampling({
+      fetchVerdict: () => fetchOnboardingSamplingVerdict(credentials),
+    });
+    let disposed = false;
+    sessionJudgment.then(
+      (shouldOpen) => {
+        if (!disposed && shouldOpen) {
+          setOpen(true);
+        }
+      },
+      () => undefined
+    );
+    return () => {
+      disposed = true;
+    };
+  }, [appToken, kubeconfig, namespace]);
+
+  const handleSkip = (payload: { dismissedAtStep: number }) => {
+    // Skip drops the person into the console immediately; the terminal write
+    // is fire-and-forget and never blocks the exit (terminal-wins keeps
+    // retries harmless server-side).
+    setOpen(false);
+    if (forceOpen) {
+      // Forced-open preview: the knob keeps the dialog up and must never
+      // mutate the developer's real sampling state.
+      return;
+    }
+    if (onboardingCredentialsReady({ appToken, kubeconfig, namespace })) {
+      dismissOnboardingProfile(
+        { appToken: appToken.trim(), kubeconfig, namespace: namespace.trim() },
+        payload.dismissedAtStep
+      );
+    }
+  };
+
+  return <OnboardingDialog onSkip={handleSkip} open={open || forceOpen} />;
+}

--- a/apps/ui/src/features/onboarding/onboarding-gate.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-gate.tsx
@@ -24,6 +24,7 @@ import {
 import type {
   AnswerOnboardingStepRequest,
   CompleteOnboardingProfileRequest,
+  DismissOnboardingProfileRequest,
 } from "./types";
 
 // While forced, every write is inert and `open || forceOpen` keeps the
@@ -125,21 +126,29 @@ export function OnboardingGate() {
     // the terminal write never blocks the exit.
     setOpen(false);
     fireWrite((credentials) => {
-      completeOnboardingProfile(credentials, payload.openGoalText);
-      // The session judgment must flip to Sampled with the write, or a Gate
-      // remount would re-attach to the stale verdict and reopen the survey.
+      completeOnboardingProfile(credentials, payload);
+      // Settled at the action, deliberately not at the write's success: the
+      // session judgment records "this person terminated the survey this
+      // session", so a Gate remount (client-side navigation away and back)
+      // never reopens a survey the person just finished — even if the write
+      // fails. Durability doesn't ride on this cache: the next full page
+      // load re-judges from the database, and a lost terminal write means
+      // re-asking then, with the stepwise-persisted answers still in place.
       settleOnboardingSessionJudgmentSampled(
         onboardingCredentialsKey(credentials)
       );
     });
   };
 
-  const handleSkip = (payload: { dismissedAtStep: number }) => {
+  const handleSkip = (payload: DismissOnboardingProfileRequest) => {
     // Skip drops the person into the console immediately; the terminal
     // write never blocks the exit.
     setOpen(false);
     fireWrite((credentials) => {
-      dismissOnboardingProfile(credentials, payload.dismissedAtStep);
+      dismissOnboardingProfile(credentials, payload);
+      // Same action-time settle as complete: never re-ask in the same
+      // session someone just declined; the database re-judgment on the next
+      // page load is the recovery path for a lost write.
       settleOnboardingSessionJudgmentSampled(
         onboardingCredentialsKey(credentials)
       );

--- a/apps/ui/src/features/onboarding/onboarding-gate.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-gate.tsx
@@ -23,8 +23,11 @@ import type {
   CompleteOnboardingProfileRequest,
 } from "./types";
 
+// While forced, every write is inert and `open || forceOpen` keeps the
+// dialog up — it cannot be closed from inside; switching the knob off is
+// the only exit. This protects the developer's real sampling state.
 const ONBOARDING_TWEAKS = {
-  note: "Opens the dialog unconditionally; Skip is inert while forced, so sampling state stays untouched.",
+  note: "Opens the dialog unconditionally; Skip/Submit are inert while forced and the dialog stays open until the knob is switched off, so sampling state stays untouched.",
   title: "Onboarding · sampling dialog",
   tweaks: {
     forceModal: {

--- a/apps/ui/src/features/onboarding/onboarding-gate.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-gate.tsx
@@ -8,15 +8,20 @@ import { appTokenAtom, kubeconfigAtom, namespaceAtom } from "@/lib/auth-store";
 
 import {
   answerOnboardingStep,
+  completeOnboardingProfile,
   dismissOnboardingProfile,
   fetchOnboardingSamplingVerdict,
+  type OnboardingFetcherCredentials,
 } from "./client";
 import { OnboardingDialog } from "./onboarding-dialog";
 import {
   judgeOnboardingSampling,
   onboardingCredentialsReady,
 } from "./onboarding-gate-core";
-import type { AnswerOnboardingStepRequest } from "./types";
+import type {
+  AnswerOnboardingStepRequest,
+  CompleteOnboardingProfileRequest,
+} from "./types";
 
 const ONBOARDING_TWEAKS = {
   note: "Opens the dialog unconditionally; Skip is inert while forced, so sampling state stays untouched.",
@@ -87,42 +92,53 @@ export function OnboardingGate() {
     };
   }, [appToken, kubeconfig, namespace]);
 
-  const handleAnswerStep = (payload: AnswerOnboardingStepRequest) => {
-    // Stepwise writes are fire-and-forget: the dialog advances on its own
-    // and a silent failure just leaves the person Unsampled for next entry.
+  // The shared tail of every dialog write, all fire-and-forget: the
+  // forced-open preview knob must never mutate the developer's real sampling
+  // state, and missing credentials fail silently (terminal-wins keeps
+  // retries harmless server-side).
+  const fireWrite = (
+    write: (credentials: OnboardingFetcherCredentials) => void
+  ) => {
     if (forceOpen) {
-      // Forced-open preview: the knob must never mutate real sampling state.
       return;
     }
     if (onboardingCredentialsReady({ appToken, kubeconfig, namespace })) {
-      answerOnboardingStep(
-        { appToken: appToken.trim(), kubeconfig, namespace: namespace.trim() },
-        payload
-      );
+      write({
+        appToken: appToken.trim(),
+        kubeconfig,
+        namespace: namespace.trim(),
+      });
     }
   };
 
-  const handleSkip = (payload: { dismissedAtStep: number }) => {
-    // Skip drops the person into the console immediately; the terminal write
-    // is fire-and-forget and never blocks the exit (terminal-wins keeps
-    // retries harmless server-side).
+  const handleAnswerStep = (payload: AnswerOnboardingStepRequest) => {
+    // Stepwise writes never block Next: the dialog advances on its own and
+    // a silent failure just leaves the person Unsampled for next entry.
+    fireWrite((credentials) => answerOnboardingStep(credentials, payload));
+  };
+
+  const handleComplete = (payload: CompleteOnboardingProfileRequest) => {
+    // Submit & Enter Console drops the person into the console immediately;
+    // the terminal write never blocks the exit.
     setOpen(false);
-    if (forceOpen) {
-      // Forced-open preview: the knob keeps the dialog up and must never
-      // mutate the developer's real sampling state.
-      return;
-    }
-    if (onboardingCredentialsReady({ appToken, kubeconfig, namespace })) {
-      dismissOnboardingProfile(
-        { appToken: appToken.trim(), kubeconfig, namespace: namespace.trim() },
-        payload.dismissedAtStep
-      );
-    }
+    fireWrite((credentials) =>
+      completeOnboardingProfile(credentials, payload.openGoalText)
+    );
+  };
+
+  const handleSkip = (payload: { dismissedAtStep: number }) => {
+    // Skip drops the person into the console immediately; the terminal
+    // write never blocks the exit.
+    setOpen(false);
+    fireWrite((credentials) =>
+      dismissOnboardingProfile(credentials, payload.dismissedAtStep)
+    );
   };
 
   return (
     <OnboardingDialog
       onAnswerStep={handleAnswerStep}
+      onComplete={handleComplete}
       onSkip={handleSkip}
       open={open || forceOpen}
     />

--- a/apps/ui/src/features/onboarding/onboarding-gate.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-gate.tsx
@@ -7,6 +7,7 @@ import { useDevTweaks } from "@/features/dev-tweaks/use-dev-tweaks";
 import { appTokenAtom, kubeconfigAtom, namespaceAtom } from "@/lib/auth-store";
 
 import {
+  answerOnboardingStep,
   dismissOnboardingProfile,
   fetchOnboardingSamplingVerdict,
 } from "./client";
@@ -15,6 +16,7 @@ import {
   judgeOnboardingSampling,
   onboardingCredentialsReady,
 } from "./onboarding-gate-core";
+import type { AnswerOnboardingStepRequest } from "./types";
 
 const ONBOARDING_TWEAKS = {
   note: "Opens the dialog unconditionally; Skip is inert while forced, so sampling state stays untouched.",
@@ -85,6 +87,21 @@ export function OnboardingGate() {
     };
   }, [appToken, kubeconfig, namespace]);
 
+  const handleAnswerStep = (payload: AnswerOnboardingStepRequest) => {
+    // Stepwise writes are fire-and-forget: the dialog advances on its own
+    // and a silent failure just leaves the person Unsampled for next entry.
+    if (forceOpen) {
+      // Forced-open preview: the knob must never mutate real sampling state.
+      return;
+    }
+    if (onboardingCredentialsReady({ appToken, kubeconfig, namespace })) {
+      answerOnboardingStep(
+        { appToken: appToken.trim(), kubeconfig, namespace: namespace.trim() },
+        payload
+      );
+    }
+  };
+
   const handleSkip = (payload: { dismissedAtStep: number }) => {
     // Skip drops the person into the console immediately; the terminal write
     // is fire-and-forget and never blocks the exit (terminal-wins keeps
@@ -103,5 +120,11 @@ export function OnboardingGate() {
     }
   };
 
-  return <OnboardingDialog onSkip={handleSkip} open={open || forceOpen} />;
+  return (
+    <OnboardingDialog
+      onAnswerStep={handleAnswerStep}
+      onSkip={handleSkip}
+      open={open || forceOpen}
+    />
+  );
 }

--- a/apps/ui/src/features/onboarding/profile-http-handlers.test.ts
+++ b/apps/ui/src/features/onboarding/profile-http-handlers.test.ts
@@ -141,10 +141,36 @@ async function dismissRequest(
   );
 }
 
+async function stepRequest(
+  workspaceActor: string,
+  body: unknown,
+  options: { appToken?: string | null; namespace?: string } = {}
+): Promise<Request> {
+  const namespace = options.namespace ?? "shared";
+  return new Request(
+    `https://brain.test/api/onboarding-profile/step?namespace=${namespace}`,
+    {
+      body: JSON.stringify(body),
+      headers: {
+        Authorization: `Bearer ${encodedKubeconfig("shared", workspaceActor)}`,
+        "content-type": "application/json",
+        ...(options.appToken === null
+          ? {}
+          : {
+              "X-Sealos-App-Token":
+                options.appToken ?? (await mintAppToken(workspaceActor)),
+            }),
+      },
+      method: "POST",
+    }
+  );
+}
+
 function handlers(
   overrides: Partial<OnboardingProfileHandlerDependencies> = {}
 ) {
   return createOnboardingProfileHandlers({
+    answerStep: store.answerStep,
     appTokenConfig: APP_TOKEN_CONFIG,
     dismiss: store.dismiss,
     isSampled: store.isSampled,
@@ -192,6 +218,91 @@ test("the sampling verdict pins all four row shapes", async () => {
     "shape-none-cr": { sampled: false },
     "shape-progress-cr": { sampled: false },
   });
+});
+
+test("answering Step 1 upserts an in_progress row that still counts as Unsampled", async () => {
+  const { answerStep, sampling } = handlers();
+
+  const response = await answerStep(
+    await stepRequest("step1-cr", {
+      roleOtherText: null,
+      roleType: "founder",
+      step: 1,
+    })
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { status: "in_progress" });
+  const row = await profileRow("step1-cr-uid");
+  assert.equal(row?.status, "in_progress");
+  assert.equal(row?.roleType, "founder");
+  assert.equal(row?.roleOtherText, null);
+  assert.equal(row?.dismissedAtStep, null);
+
+  // Abandoning the tab here leaves exactly this row — the person is still
+  // Unsampled, so the dialog shows again on the next entry.
+  const verdict = await sampling(await samplingRequest("step1-cr"));
+  assert.deepEqual(await verdict.json(), { sampled: false });
+});
+
+test("re-answering Step 1 after an abandoned attempt replaces the whole Other pair", async () => {
+  const { answerStep } = handlers();
+
+  // First visit: Other with free text, then the tab dies mid-survey.
+  await answerStep(
+    await stepRequest("redo-cr", {
+      roleOtherText: "platform team lead",
+      roleType: "other",
+      step: 1,
+    })
+  );
+  const abandoned = await profileRow("redo-cr-uid");
+  assert.equal(abandoned?.roleType, "other");
+  assert.equal(abandoned?.roleOtherText, "platform team lead");
+
+  // Next entry restarts cleanly from Step 1; the new answer overwrites the
+  // pair — no stale Other text can survive a non-Other pick.
+  const response = await answerStep(
+    await stepRequest("redo-cr", {
+      roleOtherText: null,
+      roleType: "student",
+      step: 1,
+    })
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { status: "in_progress" });
+  const row = await profileRow("redo-cr-uid");
+  assert.equal(row?.roleType, "student");
+  assert.equal(row?.roleOtherText, null);
+});
+
+test("Skip after answering Step 1 keeps the role answer on the dismissed row", async () => {
+  const { answerStep, dismiss, sampling } = handlers();
+
+  await answerStep(
+    await stepRequest("answer-skip-cr", {
+      roleOtherText: "solo consultant",
+      roleType: "other",
+      step: 1,
+    })
+  );
+  const response = await dismiss(
+    await dismissRequest("answer-skip-cr", { dismissedAtStep: 2 })
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    dismissedAtStep: 2,
+    status: "dismissed",
+  });
+  const row = await profileRow("answer-skip-cr-uid");
+  assert.equal(row?.status, "dismissed");
+  assert.equal(row?.roleType, "other");
+  assert.equal(row?.roleOtherText, "solo consultant");
+
+  const verdict = await sampling(await samplingRequest("answer-skip-cr"));
+  assert.deepEqual(await verdict.json(), { sampled: true });
 });
 
 test("Skip records a terminal dismissed profile with the step number", async () => {
@@ -258,6 +369,38 @@ test("terminal wins: a later dismiss is a no-op returning the current state", as
   assert.deepEqual(await profileRow("terminal-cr-uid"), rowAfterFirst);
 });
 
+test("terminal wins: a step answer against a terminal row is a no-op reporting that status", async () => {
+  const { answerStep } = handlers();
+  await db.insert(onboardingProfiles).values([
+    { dismissedAtStep: 1, status: "dismissed", userUid: "late-skip-cr-uid" },
+    { roleType: "founder", status: "completed", userUid: "late-done-cr-uid" },
+  ]);
+  const dismissedBefore = await profileRow("late-skip-cr-uid");
+  const completedBefore = await profileRow("late-done-cr-uid");
+
+  const ontoDismissed = await answerStep(
+    await stepRequest("late-skip-cr", {
+      roleOtherText: null,
+      roleType: "student",
+      step: 1,
+    })
+  );
+  assert.equal(ontoDismissed.status, 200);
+  assert.deepEqual(await ontoDismissed.json(), { status: "dismissed" });
+  assert.deepEqual(await profileRow("late-skip-cr-uid"), dismissedBefore);
+
+  const ontoCompleted = await answerStep(
+    await stepRequest("late-done-cr", {
+      roleOtherText: null,
+      roleType: "student",
+      step: 1,
+    })
+  );
+  assert.equal(ontoCompleted.status, 200);
+  assert.deepEqual(await ontoCompleted.json(), { status: "completed" });
+  assert.deepEqual(await profileRow("late-done-cr-uid"), completedBefore);
+});
+
 test("a dismiss against a completed profile reports the completed state untouched", async () => {
   const { dismiss } = handlers();
   await db.insert(onboardingProfiles).values({
@@ -293,6 +436,72 @@ test("an out-of-range or malformed dismiss body is refused before any write", as
   }
 
   assert.equal(await profileRow("invalid-cr-uid"), undefined);
+});
+
+test("a malformed step answer is refused before any write", async () => {
+  const { answerStep } = handlers();
+
+  for (const body of [
+    // Unknown Cohort Tag.
+    { roleOtherText: null, roleType: "wizard", step: 1 },
+    // Loose text: Other text without the `other` tag.
+    { roleOtherText: "platform team lead", roleType: "founder", step: 1 },
+    // Blank text must be normalized to null by the client, not stored.
+    { roleOtherText: "   ", roleType: "other", step: 1 },
+    // Over the length bound.
+    { roleOtherText: "x".repeat(501), roleType: "other", step: 1 },
+    // A step that does not exist on this surface yet.
+    { step: 2, usageContext: "exploring" },
+    { roleType: "founder" },
+    {},
+    null,
+  ]) {
+    const response = await answerStep(await stepRequest("bad-step-cr", body));
+    assert.equal(response.status, 400);
+  }
+
+  assert.equal(await profileRow("bad-step-cr-uid"), undefined);
+});
+
+test("the step answer fails closed without the app token", async () => {
+  const { answerStep } = handlers();
+
+  const response = await answerStep(
+    await stepRequest(
+      "closed-step-cr",
+      { roleOtherText: null, roleType: "founder", step: 1 },
+      { appToken: null }
+    )
+  );
+
+  assert.equal(response.status, 401);
+  assert.equal(await profileRow("closed-step-cr-uid"), undefined);
+});
+
+test("the step answer's in-transaction binding re-check refuses a merge-swept actor", async () => {
+  const { answerStep } = handlers({
+    observeFingerprint: () => Promise.resolve({ outcome: "match" }),
+  });
+  await db.insert(identityFingerprints).values({
+    crName: "swept-step-cr",
+    mintedAt: APP_TOKEN_MINTED_AT + 100,
+    userUid: "surviving-uid",
+  });
+
+  const response = await answerStep(
+    await stepRequest("swept-step-cr", {
+      roleOtherText: null,
+      roleType: "founder",
+      step: 1,
+    })
+  );
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), {
+    code: "app_token_superseded",
+    error: "Authentication is required.",
+  });
+  assert.equal(await profileRow("swept-step-cr-uid"), undefined);
 });
 
 test("both routes fail closed without the app token", async () => {

--- a/apps/ui/src/features/onboarding/profile-http-handlers.test.ts
+++ b/apps/ui/src/features/onboarding/profile-http-handlers.test.ts
@@ -1,0 +1,414 @@
+import { afterAll, test } from "bun:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+import { migrate } from "drizzle-orm/pglite/migrator";
+import { SignJWT } from "jose";
+
+import {
+  assistantChatMessages,
+  assistantChats,
+  assistantEntitlements,
+  githubAppInstallSessions,
+  githubConnections,
+  githubOauthConnections,
+  identityFingerprints,
+} from "@/features/chat/persistence/schema";
+import { createIdentityFingerprintStore } from "@/lib/identity-fingerprint-core";
+
+import {
+  createOnboardingProfileHandlers,
+  type OnboardingProfileHandlerDependencies,
+} from "./profile-http-handlers";
+import { createOnboardingProfileStore } from "./profile-store";
+import { onboardingProfiles } from "./schema";
+
+const testSchema = {
+  assistantChatMessages,
+  assistantChats,
+  assistantEntitlements,
+  githubAppInstallSessions,
+  githubConnections,
+  githubOauthConnections,
+  identityFingerprints,
+  onboardingProfiles,
+};
+
+const pglite = new PGlite();
+const db = drizzle(pglite, { schema: testSchema });
+await migrate(db, {
+  migrationsFolder: path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../drizzle"
+  ),
+});
+
+const store = createOnboardingProfileStore(() => db);
+const observeFingerprint = createIdentityFingerprintStore(() => db);
+
+afterAll(() => pglite.close());
+
+const APP_TOKEN_SECRET = "cluster-shared-jwt-internal";
+const APP_TOKEN_CONFIG = { secret: APP_TOKEN_SECRET };
+const APP_TOKEN_MINTED_AT = 1_753_600_000;
+
+function mintAppToken(crName: string, secret = APP_TOKEN_SECRET) {
+  return new SignJWT({
+    userCrName: crName,
+    userUid: `${crName}-uid`,
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt(APP_TOKEN_MINTED_AT)
+    .sign(new TextEncoder().encode(secret));
+}
+
+function jwt(subject: string): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "RS256", typ: "JWT" })
+  ).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ sub: subject })).toString(
+    "base64url"
+  );
+  return `${header}.${payload}.test-signature`;
+}
+
+function encodedKubeconfig(namespace: string, workspaceActor: string): string {
+  return encodeURIComponent(`
+apiVersion: v1
+clusters:
+  - name: cluster
+    cluster:
+      server: https://example.test
+contexts:
+  - name: current
+    context:
+      cluster: cluster
+      namespace: ${namespace}
+      user: active-user
+current-context: current
+users:
+  - name: active-user
+    user:
+      token: ${jwt(`system:serviceaccount:user-system:${workspaceActor}`)}
+`);
+}
+
+async function samplingRequest(
+  workspaceActor: string,
+  appToken?: string | null
+): Promise<Request> {
+  return new Request(
+    "https://brain.test/api/onboarding-profile/sampling?namespace=shared",
+    {
+      headers: {
+        Authorization: `Bearer ${encodedKubeconfig("shared", workspaceActor)}`,
+        ...(appToken === null
+          ? {}
+          : {
+              "X-Sealos-App-Token":
+                appToken ?? (await mintAppToken(workspaceActor)),
+            }),
+      },
+    }
+  );
+}
+
+async function dismissRequest(
+  workspaceActor: string,
+  body: unknown,
+  options: { appToken?: string | null; namespace?: string } = {}
+): Promise<Request> {
+  const namespace = options.namespace ?? "shared";
+  return new Request(
+    `https://brain.test/api/onboarding-profile/dismiss?namespace=${namespace}`,
+    {
+      body: JSON.stringify(body),
+      headers: {
+        Authorization: `Bearer ${encodedKubeconfig("shared", workspaceActor)}`,
+        "content-type": "application/json",
+        ...(options.appToken === null
+          ? {}
+          : {
+              "X-Sealos-App-Token":
+                options.appToken ?? (await mintAppToken(workspaceActor)),
+            }),
+      },
+      method: "POST",
+    }
+  );
+}
+
+function handlers(
+  overrides: Partial<OnboardingProfileHandlerDependencies> = {}
+) {
+  return createOnboardingProfileHandlers({
+    appTokenConfig: APP_TOKEN_CONFIG,
+    dismiss: store.dismiss,
+    isSampled: store.isSampled,
+    observeFingerprint,
+    verify: () => Promise.resolve({ ok: true }),
+    ...overrides,
+  });
+}
+
+async function profileRow(userUid: string) {
+  const [row] = await db
+    .select()
+    .from(onboardingProfiles)
+    .where(eq(onboardingProfiles.userUid, userUid));
+  return row;
+}
+
+test("the sampling verdict pins all four row shapes", async () => {
+  const { sampling } = handlers();
+  await db.insert(onboardingProfiles).values([
+    { status: "in_progress", userUid: "shape-progress-cr-uid" },
+    { status: "completed", userUid: "shape-completed-cr-uid" },
+    {
+      dismissedAtStep: 3,
+      status: "dismissed",
+      userUid: "shape-dismissed-cr-uid",
+    },
+  ]);
+
+  const verdicts: Record<string, unknown> = {};
+  for (const crName of [
+    "shape-none-cr",
+    "shape-progress-cr",
+    "shape-completed-cr",
+    "shape-dismissed-cr",
+  ]) {
+    const response = await sampling(await samplingRequest(crName));
+    assert.equal(response.status, 200);
+    verdicts[crName] = await response.json();
+  }
+
+  assert.deepEqual(verdicts, {
+    "shape-completed-cr": { sampled: true },
+    "shape-dismissed-cr": { sampled: true },
+    "shape-none-cr": { sampled: false },
+    "shape-progress-cr": { sampled: false },
+  });
+});
+
+test("Skip records a terminal dismissed profile with the step number", async () => {
+  const { dismiss, sampling } = handlers();
+
+  const response = await dismiss(
+    await dismissRequest("skip-cr", { dismissedAtStep: 1 })
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    dismissedAtStep: 1,
+    status: "dismissed",
+  });
+  const row = await profileRow("skip-cr-uid");
+  assert.equal(row?.status, "dismissed");
+  assert.equal(row?.dismissedAtStep, 1);
+  assert.equal(row?.roleType, null);
+
+  const verdict = await sampling(await samplingRequest("skip-cr"));
+  assert.deepEqual(await verdict.json(), { sampled: true });
+});
+
+test("dismiss finalizes an abandoned in_progress row without clobbering answers", async () => {
+  const { dismiss } = handlers();
+  await db.insert(onboardingProfiles).values({
+    roleType: "founder",
+    status: "in_progress",
+    userUid: "resume-cr-uid",
+  });
+
+  const response = await dismiss(
+    await dismissRequest("resume-cr", { dismissedAtStep: 2 })
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    dismissedAtStep: 2,
+    status: "dismissed",
+  });
+  const row = await profileRow("resume-cr-uid");
+  assert.equal(row?.status, "dismissed");
+  assert.equal(row?.dismissedAtStep, 2);
+  assert.equal(row?.roleType, "founder");
+});
+
+test("terminal wins: a later dismiss is a no-op returning the current state", async () => {
+  const { dismiss } = handlers();
+
+  const first = await dismiss(
+    await dismissRequest("terminal-cr", { dismissedAtStep: 1 })
+  );
+  assert.equal(first.status, 200);
+  const rowAfterFirst = await profileRow("terminal-cr-uid");
+
+  const second = await dismiss(
+    await dismissRequest("terminal-cr", { dismissedAtStep: 3 })
+  );
+  assert.equal(second.status, 200);
+  assert.deepEqual(await second.json(), {
+    dismissedAtStep: 1,
+    status: "dismissed",
+  });
+  assert.deepEqual(await profileRow("terminal-cr-uid"), rowAfterFirst);
+});
+
+test("a dismiss against a completed profile reports the completed state untouched", async () => {
+  const { dismiss } = handlers();
+  await db.insert(onboardingProfiles).values({
+    status: "completed",
+    userUid: "done-cr-uid",
+  });
+  const rowBefore = await profileRow("done-cr-uid");
+
+  const response = await dismiss(
+    await dismissRequest("done-cr", { dismissedAtStep: 4 })
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    dismissedAtStep: null,
+    status: "completed",
+  });
+  assert.deepEqual(await profileRow("done-cr-uid"), rowBefore);
+});
+
+test("an out-of-range or malformed dismiss body is refused before any write", async () => {
+  const { dismiss } = handlers();
+
+  for (const body of [
+    { dismissedAtStep: 0 },
+    { dismissedAtStep: 5 },
+    { dismissedAtStep: 1.5 },
+    {},
+    null,
+  ]) {
+    const response = await dismiss(await dismissRequest("invalid-cr", body));
+    assert.equal(response.status, 400);
+  }
+
+  assert.equal(await profileRow("invalid-cr-uid"), undefined);
+});
+
+test("both routes fail closed without the app token", async () => {
+  const { dismiss, sampling } = handlers();
+
+  const samplingResponse = await sampling(
+    await samplingRequest("closed-cr", null)
+  );
+  assert.deepEqual(
+    { body: await samplingResponse.json(), status: samplingResponse.status },
+    {
+      body: {
+        code: "app_token_required",
+        error: "Authentication is required.",
+      },
+      status: 401,
+    }
+  );
+
+  const dismissResponse = await dismiss(
+    await dismissRequest(
+      "closed-cr",
+      { dismissedAtStep: 1 },
+      { appToken: null }
+    )
+  );
+  assert.equal(dismissResponse.status, 401);
+  assert.equal(await profileRow("closed-cr-uid"), undefined);
+});
+
+test("an app token bound to another actor is refused with 403 and writes nothing", async () => {
+  const { dismiss } = handlers();
+
+  const response = await dismiss(
+    await dismissRequest(
+      "victim-cr",
+      { dismissedAtStep: 1 },
+      { appToken: await mintAppToken("attacker-cr") }
+    )
+  );
+
+  assert.equal(response.status, 403);
+  assert.deepEqual(await response.json(), {
+    code: "app_token_mismatch",
+    error: "App token does not match the authenticated actor.",
+  });
+  assert.equal(await profileRow("victim-cr-uid"), undefined);
+  assert.equal(await profileRow("attacker-cr-uid"), undefined);
+});
+
+test("an app token signed with the wrong secret is refused with 401", async () => {
+  const { sampling } = handlers();
+
+  const response = await sampling(
+    await samplingRequest(
+      "forged-cr",
+      await mintAppToken("forged-cr", "attacker-secret")
+    )
+  );
+
+  assert.equal(response.status, 401);
+});
+
+test("a cross-namespace request is forbidden before any read", async () => {
+  const { dismiss } = handlers();
+
+  const response = await dismiss(
+    await dismissRequest(
+      "cross-ns-cr",
+      { dismissedAtStep: 1 },
+      { namespace: "another-workspace" }
+    )
+  );
+
+  assert.equal(response.status, 403);
+  assert.equal(await profileRow("cross-ns-cr-uid"), undefined);
+});
+
+test("a binding superseded at authorization time never reaches the store", async () => {
+  const { dismiss } = handlers({
+    observeFingerprint: () =>
+      Promise.resolve({
+        observedMintedAt: APP_TOKEN_MINTED_AT + 100,
+        observedUserUid: "surviving-uid",
+        outcome: "superseded",
+      }),
+  });
+
+  const response = await dismiss(
+    await dismissRequest("stale-cr", { dismissedAtStep: 1 })
+  );
+
+  assert.equal(response.status, 401);
+  assert.equal(await profileRow("stale-cr-uid"), undefined);
+});
+
+test("the in-transaction binding re-check refuses a merge-swept actor with 401", async () => {
+  // Authorization observes a match, but by write time the crName has been
+  // re-pointed to a surviving uid — the transactional re-check must refuse.
+  const { dismiss } = handlers({
+    observeFingerprint: () => Promise.resolve({ outcome: "match" }),
+  });
+  await db.insert(identityFingerprints).values({
+    crName: "swept-cr",
+    mintedAt: APP_TOKEN_MINTED_AT + 100,
+    userUid: "surviving-uid",
+  });
+
+  const response = await dismiss(
+    await dismissRequest("swept-cr", { dismissedAtStep: 1 })
+  );
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), {
+    code: "app_token_superseded",
+    error: "Authentication is required.",
+  });
+  assert.equal(await profileRow("swept-cr-uid"), undefined);
+});

--- a/apps/ui/src/features/onboarding/profile-http-handlers.test.ts
+++ b/apps/ui/src/features/onboarding/profile-http-handlers.test.ts
@@ -476,6 +476,96 @@ test("Submit & Enter Console completes the accumulated row terminally", async ()
   assert.deepEqual(await verdict.json(), { sampled: true });
 });
 
+test("the Terminal Snapshot makes a completed row whole when every step write was lost", async () => {
+  // The P1 scenario: all three fire-and-forget step writes failed (none is
+  // sent here), yet the one terminal write must still capture everything —
+  // a completed row is never re-sampled, so this is the last chance.
+  const { complete, sampling } = handlers();
+
+  const response = await complete(
+    await completeRequest("snapshot-cr", {
+      answers: [
+        { roleOtherText: null, roleType: "founder", step: 1 },
+        { step: 2, usageContext: "real_business", usageOtherText: null },
+        {
+          priorityDisplayOrder: [...FULL_DISPLAY_ORDER],
+          priorityOtherText: "fair pricing",
+          priorityTags: ["stability", "other"],
+          step: 3,
+        },
+      ],
+      openGoalText: "deploy an AI agent",
+    })
+  );
+
+  assert.equal(response.status, 200);
+  const row = await profileRow("snapshot-cr-uid");
+  assert.equal(row?.status, "completed");
+  assert.equal(row?.roleType, "founder");
+  assert.equal(row?.usageContext, "real_business");
+  assert.deepEqual(row?.priorityTags, ["stability", "other"]);
+  assert.equal(row?.priorityOtherText, "fair pricing");
+  assert.equal(row?.openGoalText, "deploy an AI agent");
+
+  const verdict = await sampling(await samplingRequest("snapshot-cr"));
+  assert.deepEqual(await verdict.json(), { sampled: true });
+});
+
+test("a dismiss snapshot lands its steps but never clears steps it doesn't carry", async () => {
+  // An earlier session persisted Step 1 stepwise and was abandoned; this
+  // session confirmed only Step 2 before skipping. The snapshot must land
+  // Step 2 and leave the earlier Step 1 answer untouched.
+  const { dismiss } = handlers();
+  await db.insert(onboardingProfiles).values({
+    roleOtherText: "platform team lead",
+    roleType: "other",
+    status: "in_progress",
+    userUid: "partial-snapshot-cr-uid",
+  });
+
+  const response = await dismiss(
+    await dismissRequest("partial-snapshot-cr", {
+      answers: [{ step: 2, usageContext: "exploring", usageOtherText: null }],
+      dismissedAtStep: 3,
+    })
+  );
+
+  assert.equal(response.status, 200);
+  const row = await profileRow("partial-snapshot-cr-uid");
+  assert.equal(row?.status, "dismissed");
+  assert.equal(row?.dismissedAtStep, 3);
+  assert.equal(row?.usageContext, "exploring");
+  assert.equal(row?.roleType, "other");
+  assert.equal(row?.roleOtherText, "platform team lead");
+});
+
+test("a malformed Terminal Snapshot is refused before any write", async () => {
+  const { complete, dismiss } = handlers();
+
+  const step1 = { roleOtherText: null, roleType: "founder", step: 1 } as const;
+  for (const answers of [
+    // Duplicate steps are not a snapshot.
+    [step1, step1],
+    // Each member must be a valid step answer.
+    [{ roleOtherText: null, roleType: "wizard", step: 1 }],
+    // Loose text: the pair rules hold inside the snapshot too.
+    [{ roleOtherText: "platform team lead", roleType: "founder", step: 1 }],
+    // Step 4 has no snapshot member — its answer is `openGoalText`.
+    [{ openGoalText: "ship it", step: 4 }],
+  ]) {
+    const completeResponse = await complete(
+      await completeRequest("bad-snapshot-cr", { answers, openGoalText: null })
+    );
+    assert.equal(completeResponse.status, 400);
+    const dismissResponse = await dismiss(
+      await dismissRequest("bad-snapshot-cr", { answers, dismissedAtStep: 2 })
+    );
+    assert.equal(dismissResponse.status, 400);
+  }
+
+  assert.equal(await profileRow("bad-snapshot-cr-uid"), undefined);
+});
+
 test("the Step 4 text is optional: an empty submit completes cleanly", async () => {
   const { complete, sampling } = handlers();
 

--- a/apps/ui/src/features/onboarding/profile-http-handlers.test.ts
+++ b/apps/ui/src/features/onboarding/profile-http-handlers.test.ts
@@ -166,12 +166,38 @@ async function stepRequest(
   );
 }
 
+async function completeRequest(
+  workspaceActor: string,
+  body: unknown,
+  options: { appToken?: string | null; namespace?: string } = {}
+): Promise<Request> {
+  const namespace = options.namespace ?? "shared";
+  return new Request(
+    `https://brain.test/api/onboarding-profile/complete?namespace=${namespace}`,
+    {
+      body: JSON.stringify(body),
+      headers: {
+        Authorization: `Bearer ${encodedKubeconfig("shared", workspaceActor)}`,
+        "content-type": "application/json",
+        ...(options.appToken === null
+          ? {}
+          : {
+              "X-Sealos-App-Token":
+                options.appToken ?? (await mintAppToken(workspaceActor)),
+            }),
+      },
+      method: "POST",
+    }
+  );
+}
+
 function handlers(
   overrides: Partial<OnboardingProfileHandlerDependencies> = {}
 ) {
   return createOnboardingProfileHandlers({
     answerStep: store.answerStep,
     appTokenConfig: APP_TOKEN_CONFIG,
+    complete: store.complete,
     dismiss: store.dismiss,
     isSampled: store.isSampled,
     observeFingerprint,
@@ -242,6 +268,65 @@ test("answering Step 1 upserts an in_progress row that still counts as Unsampled
   // Abandoning the tab here leaves exactly this row — the person is still
   // Unsampled, so the dialog shows again on the next entry.
   const verdict = await sampling(await samplingRequest("step1-cr"));
+  assert.deepEqual(await verdict.json(), { sampled: false });
+});
+
+test("Steps 1-3 accumulate answers on the person's single row", async () => {
+  const { answerStep, sampling } = handlers();
+
+  await answerStep(
+    await stepRequest("accumulate-cr", {
+      roleOtherText: null,
+      roleType: "founder",
+      step: 1,
+    })
+  );
+  await answerStep(
+    await stepRequest("accumulate-cr", {
+      step: 2,
+      usageContext: "real_business",
+      usageOtherText: null,
+    })
+  );
+  const response = await answerStep(
+    await stepRequest("accumulate-cr", {
+      priorityDisplayOrder: [
+        "stability",
+        "low_cost",
+        "ease_of_use",
+        "performance",
+        "fast_launch",
+        "scalability",
+        "other",
+      ],
+      priorityOtherText: null,
+      priorityTags: ["low_cost", "stability"],
+      step: 3,
+    })
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { status: "in_progress" });
+  const row = await profileRow("accumulate-cr-uid");
+  // Every step's answer is on the one row; no step write clobbers another.
+  assert.equal(row?.roleType, "founder");
+  assert.equal(row?.usageContext, "real_business");
+  assert.equal(row?.usageOtherText, null);
+  // Array order = click order, distinct from the displayed order.
+  assert.deepEqual(row?.priorityTags, ["low_cost", "stability"]);
+  assert.deepEqual(row?.priorityDisplayOrder, [
+    "stability",
+    "low_cost",
+    "ease_of_use",
+    "performance",
+    "fast_launch",
+    "scalability",
+    "other",
+  ]);
+  assert.equal(row?.status, "in_progress");
+
+  // Short of terminal, three answered steps still mean Unsampled.
+  const verdict = await sampling(await samplingRequest("accumulate-cr"));
   assert.deepEqual(await verdict.json(), { sampled: false });
 });
 
@@ -349,6 +434,100 @@ test("dismiss finalizes an abandoned in_progress row without clobbering answers"
   assert.equal(row?.roleType, "founder");
 });
 
+test("Submit & Enter Console completes the accumulated row terminally", async () => {
+  const { answerStep, complete, sampling } = handlers();
+
+  await answerStep(
+    await stepRequest("finish-cr", {
+      roleOtherText: null,
+      roleType: "individual_developer",
+      step: 1,
+    })
+  );
+  await answerStep(
+    await stepRequest("finish-cr", {
+      step: 2,
+      usageContext: "side_project",
+      usageOtherText: null,
+    })
+  );
+  const response = await complete(
+    await completeRequest("finish-cr", {
+      openGoalText: "deploy an AI agent",
+    })
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    dismissedAtStep: null,
+    status: "completed",
+  });
+  const row = await profileRow("finish-cr-uid");
+  assert.equal(row?.status, "completed");
+  assert.equal(row?.openGoalText, "deploy an AI agent");
+  // Completing finalizes the row; every answered step stays on it.
+  assert.equal(row?.roleType, "individual_developer");
+  assert.equal(row?.usageContext, "side_project");
+  assert.equal(row?.dismissedAtStep, null);
+
+  // Completed is terminal: the person is Sampled and the dialog never
+  // shows again.
+  const verdict = await sampling(await samplingRequest("finish-cr"));
+  assert.deepEqual(await verdict.json(), { sampled: true });
+});
+
+test("the Step 4 text is optional: an empty submit completes cleanly", async () => {
+  const { complete, sampling } = handlers();
+
+  const response = await complete(
+    await completeRequest("finish-empty-cr", { openGoalText: null })
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    dismissedAtStep: null,
+    status: "completed",
+  });
+  const row = await profileRow("finish-empty-cr-uid");
+  assert.equal(row?.status, "completed");
+  assert.equal(row?.openGoalText, null);
+
+  const verdict = await sampling(await samplingRequest("finish-empty-cr"));
+  assert.deepEqual(await verdict.json(), { sampled: true });
+});
+
+test("terminal wins: complete against a terminal row is a no-op returning the current state", async () => {
+  const { complete, dismiss } = handlers();
+
+  // Against a dismissed row: the dismissal stands untouched.
+  await dismiss(await dismissRequest("late-finish-cr", { dismissedAtStep: 2 }));
+  const dismissedBefore = await profileRow("late-finish-cr-uid");
+  const ontoDismissed = await complete(
+    await completeRequest("late-finish-cr", { openGoalText: "too late" })
+  );
+  assert.equal(ontoDismissed.status, 200);
+  assert.deepEqual(await ontoDismissed.json(), {
+    dismissedAtStep: 2,
+    status: "dismissed",
+  });
+  assert.deepEqual(await profileRow("late-finish-cr-uid"), dismissedBefore);
+
+  // Against a completed row: a fire-and-forget retry changes nothing.
+  await complete(
+    await completeRequest("twice-finish-cr", { openGoalText: "first goal" })
+  );
+  const completedBefore = await profileRow("twice-finish-cr-uid");
+  const again = await complete(
+    await completeRequest("twice-finish-cr", { openGoalText: "second goal" })
+  );
+  assert.equal(again.status, 200);
+  assert.deepEqual(await again.json(), {
+    dismissedAtStep: null,
+    status: "completed",
+  });
+  assert.deepEqual(await profileRow("twice-finish-cr-uid"), completedBefore);
+});
+
 test("terminal wins: a later dismiss is a no-op returning the current state", async () => {
   const { dismiss } = handlers();
 
@@ -450,8 +629,12 @@ test("a malformed step answer is refused before any write", async () => {
     { roleOtherText: "   ", roleType: "other", step: 1 },
     // Over the length bound.
     { roleOtherText: "x".repeat(501), roleType: "other", step: 1 },
-    // A step that does not exist on this surface yet.
+    // Step 2 without its full column pair.
     { step: 2, usageContext: "exploring" },
+    // Step 2 loose text: Other text without the `other` tag.
+    { step: 2, usageContext: "exploring", usageOtherText: "just looking" },
+    // Step 4 has no stepwise member — its answer travels on complete.
+    { openGoalText: "ship it", step: 4 },
     { roleType: "founder" },
     {},
     null,
@@ -461,6 +644,94 @@ test("a malformed step answer is refused before any write", async () => {
   }
 
   assert.equal(await profileRow("bad-step-cr-uid"), undefined);
+});
+
+const FULL_DISPLAY_ORDER = [
+  "ease_of_use",
+  "stability",
+  "low_cost",
+  "performance",
+  "scalability",
+  "fast_launch",
+  "other",
+] as const;
+
+test("a malformed Step 3 answer is refused before any write", async () => {
+  const { answerStep } = handlers();
+
+  const valid = {
+    priorityDisplayOrder: [...FULL_DISPLAY_ORDER],
+    priorityOtherText: null,
+    priorityTags: ["ease_of_use"],
+    step: 3,
+  };
+  for (const body of [
+    // A fourth tag is over the cap.
+    {
+      ...valid,
+      priorityTags: ["ease_of_use", "stability", "low_cost", "performance"],
+    },
+    // Zero tags: Next is gated on at least one.
+    { ...valid, priorityTags: [] },
+    // Duplicate tags are not distinct picks.
+    { ...valid, priorityTags: ["stability", "stability"] },
+    // Loose text: Other text without the `other` tag among the picks.
+    { ...valid, priorityOtherText: "fair pricing" },
+    // The display order must be the full vocabulary…
+    { ...valid, priorityDisplayOrder: FULL_DISPLAY_ORDER.slice(0, 6) },
+    // …with every tag exactly once…
+    {
+      ...valid,
+      priorityDisplayOrder: [
+        ...FULL_DISPLAY_ORDER.slice(0, 5),
+        "other",
+        "other",
+      ],
+    },
+    // …and Other pinned last.
+    { ...valid, priorityDisplayOrder: [...FULL_DISPLAY_ORDER].reverse() },
+  ]) {
+    const response = await answerStep(await stepRequest("bad-three-cr", body));
+    assert.equal(response.status, 400);
+  }
+
+  assert.equal(await profileRow("bad-three-cr-uid"), undefined);
+});
+
+test("a malformed complete body is refused before any write", async () => {
+  const { complete } = handlers();
+
+  for (const body of [
+    // The key is required even though the text is optional.
+    {},
+    // Blank text must be normalized to null by the client, not stored.
+    { openGoalText: "   " },
+    // Over the length bound.
+    { openGoalText: "x".repeat(2001) },
+    null,
+  ]) {
+    const response = await complete(
+      await completeRequest("bad-finish-cr", body)
+    );
+    assert.equal(response.status, 400);
+  }
+
+  assert.equal(await profileRow("bad-finish-cr-uid"), undefined);
+});
+
+test("complete fails closed without the app token", async () => {
+  const { complete } = handlers();
+
+  const response = await complete(
+    await completeRequest(
+      "closed-finish-cr",
+      { openGoalText: null },
+      { appToken: null }
+    )
+  );
+
+  assert.equal(response.status, 401);
+  assert.equal(await profileRow("closed-finish-cr-uid"), undefined);
 });
 
 test("the step answer fails closed without the app token", async () => {

--- a/apps/ui/src/features/onboarding/profile-http-handlers.ts
+++ b/apps/ui/src/features/onboarding/profile-http-handlers.ts
@@ -23,6 +23,7 @@ import type {
 import {
   type AnswerOnboardingStepRequest,
   answerOnboardingStepRequestSchema,
+  completeOnboardingProfileRequestSchema,
   dismissOnboardingProfileRequestSchema,
 } from "./types";
 
@@ -30,6 +31,7 @@ export interface OnboardingProfileHandlerDependencies {
   answerStep: OnboardingProfileStore["answerStep"];
   /** Test seam; defaults to `JWT_INTERNAL` from the env. */
   appTokenConfig?: AppTokenVerificationConfig | null;
+  complete: OnboardingProfileStore["complete"];
   dismiss: OnboardingProfileStore["dismiss"];
   isSampled: OnboardingProfileStore["isSampled"];
   /** Test seam; defaults to the region-local Identity Fingerprint store. */
@@ -48,14 +50,30 @@ function jsonError(input: {
   );
 }
 
-/** Maps one step's request onto the columns it owns (Step 1 only, today). */
+/** Maps one step's request onto the columns it owns. */
 function stepAnswerColumns(
   request: AnswerOnboardingStepRequest
 ): OnboardingStepAnswerColumns {
-  return {
-    roleOtherText: request.roleOtherText,
-    roleType: request.roleType,
-  };
+  switch (request.step) {
+    case 1:
+      return {
+        roleOtherText: request.roleOtherText,
+        roleType: request.roleType,
+      };
+    case 2:
+      return {
+        usageContext: request.usageContext,
+        usageOtherText: request.usageOtherText,
+      };
+    case 3:
+      return {
+        priorityDisplayOrder: request.priorityDisplayOrder,
+        priorityOtherText: request.priorityOtherText,
+        priorityTags: request.priorityTags,
+      };
+    default:
+      return request satisfies never;
+  }
 }
 
 /** The write found the binding superseded by a concurrent merge (ADR-0059). */
@@ -136,6 +154,44 @@ export function createOnboardingProfileHandlers(
           return superseded;
         }
         console.error("[api/onboarding-profile/step] persistence unavailable");
+        return jsonError({
+          code: "onboarding_profile_unavailable",
+          message: "Onboarding profile persistence is unavailable.",
+          status: 503,
+        });
+      }
+    },
+    complete: async (request: Request): Promise<Response> => {
+      const authorization = await authorize(request);
+      if (!authorization.ok) {
+        return authorization.response;
+      }
+      const body = await request.json().catch(() => null);
+      const parsed = completeOnboardingProfileRequestSchema.safeParse(body);
+      if (!parsed.success) {
+        return jsonError({
+          code: "invalid_request",
+          message: "Invalid onboarding complete request.",
+          status: 400,
+        });
+      }
+      try {
+        const state = await dependencies.complete({
+          actor: {
+            legacyWorkspaceActor: authorization.actor.legacyWorkspaceActor,
+            userUid: authorization.actor.owner.userUid,
+          },
+          openGoalText: parsed.data.openGoalText,
+        });
+        return Response.json(state);
+      } catch (error) {
+        const superseded = supersededBindingResponse(error);
+        if (superseded != null) {
+          return superseded;
+        }
+        console.error(
+          "[api/onboarding-profile/complete] persistence unavailable"
+        );
         return jsonError({
           code: "onboarding_profile_unavailable",
           message: "Onboarding profile persistence is unavailable.",

--- a/apps/ui/src/features/onboarding/profile-http-handlers.ts
+++ b/apps/ui/src/features/onboarding/profile-http-handlers.ts
@@ -1,0 +1,152 @@
+import {
+  type AppTokenVerificationConfig,
+  appTokenFromRequest,
+} from "@/lib/app-token";
+import {
+  IdentityBindingSupersededError,
+  type ObserveIdentityFingerprint,
+} from "@/lib/identity-fingerprint-core";
+import {
+  authorizeWorkspaceActor,
+  encodedKubeconfigFromRequest,
+  type VerifyKubeconfigNamespace,
+} from "@/lib/request-kubeconfig-auth";
+import {
+  type VerifiedPersonalResourceActor,
+  verifiedPersonalResourceActor,
+} from "@/lib/verified-personal-actor";
+
+import type { OnboardingProfileStore } from "./profile-store";
+import { dismissOnboardingProfileRequestSchema } from "./types";
+
+export interface OnboardingProfileHandlerDependencies {
+  /** Test seam; defaults to `JWT_INTERNAL` from the env. */
+  appTokenConfig?: AppTokenVerificationConfig | null;
+  dismiss: OnboardingProfileStore["dismiss"];
+  isSampled: OnboardingProfileStore["isSampled"];
+  /** Test seam; defaults to the region-local Identity Fingerprint store. */
+  observeFingerprint?: ObserveIdentityFingerprint;
+  verify?: VerifyKubeconfigNamespace;
+}
+
+function jsonError(input: {
+  code: string;
+  message: string;
+  status: number;
+}): Response {
+  return Response.json(
+    { code: input.code, error: input.message },
+    { status: input.status }
+  );
+}
+
+/** The write found the binding superseded by a concurrent merge (ADR-0059). */
+function supersededBindingResponse(error: unknown): Response | null {
+  return error instanceof IdentityBindingSupersededError
+    ? jsonError({
+        code: "app_token_superseded",
+        message: "Authentication is required.",
+        status: 401,
+      })
+    : null;
+}
+
+/**
+ * The Onboarding Profile's HTTP surface (ADR-0061). Both handlers travel the
+ * verified-personal-actor choke point unchanged — no lighter uid-only path,
+ * no dev bypass — and fail closed: an unauthorized or failing request yields
+ * an error the Onboarding Gate silently treats as "no dialog".
+ */
+export function createOnboardingProfileHandlers(
+  dependencies: OnboardingProfileHandlerDependencies
+) {
+  const authorize = async (
+    request: Request
+  ): Promise<
+    | { ok: true; actor: VerifiedPersonalResourceActor }
+    | { ok: false; response: Response }
+  > => {
+    const clientNamespace = new URL(request.url).searchParams.get("namespace");
+    const authorization = await authorizeWorkspaceActor({
+      appToken: appTokenFromRequest(request),
+      appTokenConfig: dependencies.appTokenConfig,
+      encodedKubeconfig: encodedKubeconfigFromRequest(request),
+      expectedNamespace: clientNamespace?.trim() || undefined,
+      observeFingerprint: dependencies.observeFingerprint,
+      verify: dependencies.verify,
+    });
+    if (!authorization.ok) {
+      return {
+        ok: false,
+        response: jsonError({
+          code: authorization.code,
+          message: authorization.message,
+          status: authorization.status,
+        }),
+      };
+    }
+    return { actor: verifiedPersonalResourceActor(authorization), ok: true };
+  };
+
+  return {
+    dismiss: async (request: Request): Promise<Response> => {
+      const authorization = await authorize(request);
+      if (!authorization.ok) {
+        return authorization.response;
+      }
+      const body = await request.json().catch(() => null);
+      const parsed = dismissOnboardingProfileRequestSchema.safeParse(body);
+      if (!parsed.success) {
+        return jsonError({
+          code: "invalid_request",
+          message: "Invalid onboarding dismiss request.",
+          status: 400,
+        });
+      }
+      try {
+        const state = await dependencies.dismiss({
+          actor: {
+            legacyWorkspaceActor: authorization.actor.legacyWorkspaceActor,
+            userUid: authorization.actor.owner.userUid,
+          },
+          dismissedAtStep: parsed.data.dismissedAtStep,
+        });
+        return Response.json(state);
+      } catch (error) {
+        const superseded = supersededBindingResponse(error);
+        if (superseded != null) {
+          return superseded;
+        }
+        console.error(
+          "[api/onboarding-profile/dismiss] persistence unavailable"
+        );
+        return jsonError({
+          code: "onboarding_profile_unavailable",
+          message: "Onboarding profile persistence is unavailable.",
+          status: 503,
+        });
+      }
+    },
+    sampling: async (request: Request): Promise<Response> => {
+      const authorization = await authorize(request);
+      if (!authorization.ok) {
+        return authorization.response;
+      }
+      try {
+        const sampled = await dependencies.isSampled(
+          authorization.actor.owner.userUid
+        );
+        return Response.json({ sampled });
+      } catch {
+        console.error(
+          "[api/onboarding-profile/sampling] persistence unavailable"
+        );
+        return jsonError({
+          code: "onboarding_profile_unavailable",
+          message: "Onboarding sampling is unavailable.",
+          status: 503,
+        });
+      }
+    },
+  };
+}

--- a/apps/ui/src/features/onboarding/profile-http-handlers.ts
+++ b/apps/ui/src/features/onboarding/profile-http-handlers.ts
@@ -16,10 +16,18 @@ import {
   verifiedPersonalResourceActor,
 } from "@/lib/verified-personal-actor";
 
-import type { OnboardingProfileStore } from "./profile-store";
-import { dismissOnboardingProfileRequestSchema } from "./types";
+import type {
+  OnboardingProfileStore,
+  OnboardingStepAnswerColumns,
+} from "./profile-store";
+import {
+  type AnswerOnboardingStepRequest,
+  answerOnboardingStepRequestSchema,
+  dismissOnboardingProfileRequestSchema,
+} from "./types";
 
 export interface OnboardingProfileHandlerDependencies {
+  answerStep: OnboardingProfileStore["answerStep"];
   /** Test seam; defaults to `JWT_INTERNAL` from the env. */
   appTokenConfig?: AppTokenVerificationConfig | null;
   dismiss: OnboardingProfileStore["dismiss"];
@@ -38,6 +46,16 @@ function jsonError(input: {
     { code: input.code, error: input.message },
     { status: input.status }
   );
+}
+
+/** Maps one step's request onto the columns it owns (Step 1 only, today). */
+function stepAnswerColumns(
+  request: AnswerOnboardingStepRequest
+): OnboardingStepAnswerColumns {
+  return {
+    roleOtherText: request.roleOtherText,
+    roleType: request.roleType,
+  };
 }
 
 /** The write found the binding superseded by a concurrent merge (ADR-0059). */
@@ -89,6 +107,42 @@ export function createOnboardingProfileHandlers(
   };
 
   return {
+    answerStep: async (request: Request): Promise<Response> => {
+      const authorization = await authorize(request);
+      if (!authorization.ok) {
+        return authorization.response;
+      }
+      const body = await request.json().catch(() => null);
+      const parsed = answerOnboardingStepRequestSchema.safeParse(body);
+      if (!parsed.success) {
+        return jsonError({
+          code: "invalid_request",
+          message: "Invalid onboarding step answer.",
+          status: 400,
+        });
+      }
+      try {
+        const state = await dependencies.answerStep({
+          actor: {
+            legacyWorkspaceActor: authorization.actor.legacyWorkspaceActor,
+            userUid: authorization.actor.owner.userUid,
+          },
+          answers: stepAnswerColumns(parsed.data),
+        });
+        return Response.json(state);
+      } catch (error) {
+        const superseded = supersededBindingResponse(error);
+        if (superseded != null) {
+          return superseded;
+        }
+        console.error("[api/onboarding-profile/step] persistence unavailable");
+        return jsonError({
+          code: "onboarding_profile_unavailable",
+          message: "Onboarding profile persistence is unavailable.",
+          status: 503,
+        });
+      }
+    },
     dismiss: async (request: Request): Promise<Response> => {
       const authorization = await authorize(request);
       if (!authorization.ok) {

--- a/apps/ui/src/features/onboarding/profile-http-handlers.ts
+++ b/apps/ui/src/features/onboarding/profile-http-handlers.ts
@@ -61,6 +61,21 @@ function stepAnswerColumns(
   }
 }
 
+/**
+ * Flattens a Terminal Snapshot onto the answer columns it carries. Steps are
+ * schema-guaranteed distinct and each step owns disjoint columns, so the
+ * merge order cannot matter.
+ */
+function snapshotAnswerColumns(
+  answers: readonly AnswerOnboardingStepRequest[]
+): OnboardingStepAnswerColumns {
+  const columns: OnboardingStepAnswerColumns = {};
+  for (const answer of answers) {
+    Object.assign(columns, stepAnswerColumns(answer));
+  }
+  return columns;
+}
+
 /** Maps the verified actor onto the store's bare-uid + re-check pair. */
 function profileActor(
   actor: VerifiedPersonalResourceActor
@@ -147,6 +162,7 @@ export function createOnboardingProfileHandlers(
       try {
         const state = await dependencies.complete({
           actor: profileActor(authorization.actor),
+          answers: snapshotAnswerColumns(parsed.data.answers),
           openGoalText: parsed.data.openGoalText,
         });
         return Response.json(state);
@@ -182,6 +198,7 @@ export function createOnboardingProfileHandlers(
       try {
         const state = await dependencies.dismiss({
           actor: profileActor(authorization.actor),
+          answers: snapshotAnswerColumns(parsed.data.answers),
           dismissedAtStep: parsed.data.dismissedAtStep,
         });
         return Response.json(state);

--- a/apps/ui/src/features/onboarding/profile-http-handlers.ts
+++ b/apps/ui/src/features/onboarding/profile-http-handlers.ts
@@ -1,22 +1,18 @@
+import type { AppTokenVerificationConfig } from "@/lib/app-token";
+import type { ObserveIdentityFingerprint } from "@/lib/identity-fingerprint-core";
 import {
-  type AppTokenVerificationConfig,
-  appTokenFromRequest,
-} from "@/lib/app-token";
-import {
-  IdentityBindingSupersededError,
-  type ObserveIdentityFingerprint,
-} from "@/lib/identity-fingerprint-core";
-import {
-  authorizeWorkspaceActor,
-  encodedKubeconfigFromRequest,
-  type VerifyKubeconfigNamespace,
-} from "@/lib/request-kubeconfig-auth";
+  authorizePersonalResourceRequest,
+  jsonError,
+  supersededBindingResponse,
+} from "@/lib/personal-resource-http";
+import type { VerifyKubeconfigNamespace } from "@/lib/request-kubeconfig-auth";
 import {
   type VerifiedPersonalResourceActor,
   verifiedPersonalResourceActor,
 } from "@/lib/verified-personal-actor";
 
 import type {
+  OnboardingProfileActor,
   OnboardingProfileStore,
   OnboardingStepAnswerColumns,
 } from "./profile-store";
@@ -37,17 +33,6 @@ export interface OnboardingProfileHandlerDependencies {
   /** Test seam; defaults to the region-local Identity Fingerprint store. */
   observeFingerprint?: ObserveIdentityFingerprint;
   verify?: VerifyKubeconfigNamespace;
-}
-
-function jsonError(input: {
-  code: string;
-  message: string;
-  status: number;
-}): Response {
-  return Response.json(
-    { code: input.code, error: input.message },
-    { status: input.status }
-  );
 }
 
 /** Maps one step's request onto the columns it owns. */
@@ -76,15 +61,14 @@ function stepAnswerColumns(
   }
 }
 
-/** The write found the binding superseded by a concurrent merge (ADR-0059). */
-function supersededBindingResponse(error: unknown): Response | null {
-  return error instanceof IdentityBindingSupersededError
-    ? jsonError({
-        code: "app_token_superseded",
-        message: "Authentication is required.",
-        status: 401,
-      })
-    : null;
+/** Maps the verified actor onto the store's bare-uid + re-check pair. */
+function profileActor(
+  actor: VerifiedPersonalResourceActor
+): OnboardingProfileActor {
+  return {
+    legacyWorkspaceActor: actor.legacyWorkspaceActor,
+    userUid: actor.owner.userUid,
+  };
 }
 
 /**
@@ -102,26 +86,14 @@ export function createOnboardingProfileHandlers(
     | { ok: true; actor: VerifiedPersonalResourceActor }
     | { ok: false; response: Response }
   > => {
-    const clientNamespace = new URL(request.url).searchParams.get("namespace");
-    const authorization = await authorizeWorkspaceActor({
-      appToken: appTokenFromRequest(request),
+    const result = await authorizePersonalResourceRequest(request, {
       appTokenConfig: dependencies.appTokenConfig,
-      encodedKubeconfig: encodedKubeconfigFromRequest(request),
-      expectedNamespace: clientNamespace?.trim() || undefined,
       observeFingerprint: dependencies.observeFingerprint,
       verify: dependencies.verify,
     });
-    if (!authorization.ok) {
-      return {
-        ok: false,
-        response: jsonError({
-          code: authorization.code,
-          message: authorization.message,
-          status: authorization.status,
-        }),
-      };
-    }
-    return { actor: verifiedPersonalResourceActor(authorization), ok: true };
+    return result.ok
+      ? { actor: verifiedPersonalResourceActor(result.authorization), ok: true }
+      : result;
   };
 
   return {
@@ -141,10 +113,7 @@ export function createOnboardingProfileHandlers(
       }
       try {
         const state = await dependencies.answerStep({
-          actor: {
-            legacyWorkspaceActor: authorization.actor.legacyWorkspaceActor,
-            userUid: authorization.actor.owner.userUid,
-          },
+          actor: profileActor(authorization.actor),
           answers: stepAnswerColumns(parsed.data),
         });
         return Response.json(state);
@@ -177,10 +146,7 @@ export function createOnboardingProfileHandlers(
       }
       try {
         const state = await dependencies.complete({
-          actor: {
-            legacyWorkspaceActor: authorization.actor.legacyWorkspaceActor,
-            userUid: authorization.actor.owner.userUid,
-          },
+          actor: profileActor(authorization.actor),
           openGoalText: parsed.data.openGoalText,
         });
         return Response.json(state);
@@ -215,10 +181,7 @@ export function createOnboardingProfileHandlers(
       }
       try {
         const state = await dependencies.dismiss({
-          actor: {
-            legacyWorkspaceActor: authorization.actor.legacyWorkspaceActor,
-            userUid: authorization.actor.owner.userUid,
-          },
+          actor: profileActor(authorization.actor),
           dismissedAtStep: parsed.data.dismissedAtStep,
         });
         return Response.json(state);

--- a/apps/ui/src/features/onboarding/profile-route-handlers.ts
+++ b/apps/ui/src/features/onboarding/profile-route-handlers.ts
@@ -9,6 +9,7 @@ const store = createOnboardingProfileStore(getAssistantDb);
 
 /** Production wiring for the Onboarding Profile routes (ADR-0061). */
 export const onboardingProfileRouteHandlers = createOnboardingProfileHandlers({
+  answerStep: store.answerStep,
   dismiss: store.dismiss,
   isSampled: store.isSampled,
 });

--- a/apps/ui/src/features/onboarding/profile-route-handlers.ts
+++ b/apps/ui/src/features/onboarding/profile-route-handlers.ts
@@ -10,6 +10,7 @@ const store = createOnboardingProfileStore(getAssistantDb);
 /** Production wiring for the Onboarding Profile routes (ADR-0061). */
 export const onboardingProfileRouteHandlers = createOnboardingProfileHandlers({
   answerStep: store.answerStep,
+  complete: store.complete,
   dismiss: store.dismiss,
   isSampled: store.isSampled,
 });

--- a/apps/ui/src/features/onboarding/profile-route-handlers.ts
+++ b/apps/ui/src/features/onboarding/profile-route-handlers.ts
@@ -1,0 +1,14 @@
+import "server-only";
+
+import { getAssistantDb } from "@/features/chat/persistence/db";
+
+import { createOnboardingProfileHandlers } from "./profile-http-handlers";
+import { createOnboardingProfileStore } from "./profile-store";
+
+const store = createOnboardingProfileStore(getAssistantDb);
+
+/** Production wiring for the Onboarding Profile routes (ADR-0061). */
+export const onboardingProfileRouteHandlers = createOnboardingProfileHandlers({
+  dismiss: store.dismiss,
+  isSampled: store.isSampled,
+});

--- a/apps/ui/src/features/onboarding/profile-store.ts
+++ b/apps/ui/src/features/onboarding/profile-store.ts
@@ -56,21 +56,30 @@ export interface OnboardingProfileStore {
   }): Promise<OnboardingProfileWriteState>;
   /**
    * Terminal complete (Submit & Enter Console): finalizes the row with
-   * `status: completed` and the optional Step 4 open goal. Terminal wins —
-   * against a row already `completed` or `dismissed`, nothing is written and
-   * the pre-existing state is returned.
+   * `status: completed`, the Terminal Snapshot's answer columns, and the
+   * optional Step 4 open goal — one atomic write, so a completed row never
+   * depends on the fire-and-forget stepwise writes having landed. Columns
+   * absent from `answers` are left untouched: a snapshot never destroys an
+   * earlier session's persisted partials. Terminal wins — against a row
+   * already `completed` or `dismissed`, nothing is written and the
+   * pre-existing state is returned.
    */
   complete(input: {
     actor: OnboardingProfileActor;
+    answers: OnboardingStepAnswerColumns;
     openGoalText: string | null;
   }): Promise<OnboardingProfileTerminalState>;
   /**
-   * Terminal dismiss (Skip). Terminal wins: when the row is already
-   * `completed` or `dismissed`, nothing is written and the pre-existing state
-   * is returned, so fire-and-forget retries can never corrupt a terminal row.
+   * Terminal dismiss (Skip): finalizes the row with `status: dismissed` and
+   * the Terminal Snapshot of the steps confirmed before the skip, with the
+   * same untouched-columns rule as complete. Terminal wins: when the row is
+   * already `completed` or `dismissed`, nothing is written and the
+   * pre-existing state is returned, so fire-and-forget retries can never
+   * corrupt a terminal row.
    */
   dismiss(input: {
     actor: OnboardingProfileActor;
+    answers: OnboardingStepAnswerColumns;
     dismissedAtStep: number;
   }): Promise<OnboardingProfileTerminalState>;
   /**
@@ -134,14 +143,18 @@ export function createOnboardingProfileStore(
         await tx
           .insert(onboardingProfiles)
           .values({
+            ...input.answers,
             openGoalText: input.openGoalText,
             status: "completed",
             userUid: input.actor.userUid,
           })
           .onConflictDoUpdate({
-            // Answers already given stay persisted: completing touches only
-            // its own columns, never the per-step answer columns.
+            // The Terminal Snapshot lands with the status in one write; the
+            // spread carries only the steps the session confirmed, so answer
+            // columns outside the snapshot stay as the stepwise writes (or an
+            // earlier session) left them.
             set: {
+              ...input.answers,
               openGoalText: input.openGoalText,
               status: "completed",
               updatedAt: new Date(),
@@ -175,14 +188,17 @@ export function createOnboardingProfileStore(
         await tx
           .insert(onboardingProfiles)
           .values({
+            ...input.answers,
             dismissedAtStep: input.dismissedAtStep,
             status: "dismissed",
             userUid: input.actor.userUid,
           })
           .onConflictDoUpdate({
-            // Answers already given stay persisted: only the terminal
-            // columns are touched, never the per-step answer columns.
+            // Same one-write snapshot rule as complete: only the steps the
+            // session confirmed travel here, so answer columns outside the
+            // snapshot keep whatever an earlier write persisted.
             set: {
+              ...input.answers,
               dismissedAtStep: input.dismissedAtStep,
               status: "dismissed",
               updatedAt: new Date(),

--- a/apps/ui/src/features/onboarding/profile-store.ts
+++ b/apps/ui/src/features/onboarding/profile-store.ts
@@ -5,10 +5,12 @@ import { requireCurrentIdentityBinding } from "@/lib/identity-fingerprint-core";
 
 import { onboardingProfiles } from "./schema";
 import type {
+  OnboardingPriorityTag,
   OnboardingProfileStatus,
   OnboardingProfileTerminalState,
   OnboardingProfileWriteState,
   OnboardingRoleType,
+  OnboardingUsageContext,
 } from "./types";
 
 /** The Sampled statuses (ADR-0061): the dialog never shows again. */
@@ -28,13 +30,17 @@ export interface OnboardingProfileActor {
 }
 
 /**
- * The answer columns one stepwise write may touch (Step 1 today; later steps
- * extend this). A step always writes its full column pair, so a re-answer
- * can never leave stale Other text behind.
+ * The answer columns one stepwise write may touch. A step always writes its
+ * full column set, so a re-answer can never leave stale Other text behind.
  */
 export interface OnboardingStepAnswerColumns {
+  priorityDisplayOrder?: OnboardingPriorityTag[];
+  priorityOtherText?: string | null;
+  priorityTags?: OnboardingPriorityTag[];
   roleOtherText?: string | null;
   roleType?: OnboardingRoleType;
+  usageContext?: OnboardingUsageContext;
+  usageOtherText?: string | null;
 }
 
 export interface OnboardingProfileStore {
@@ -48,6 +54,16 @@ export interface OnboardingProfileStore {
     actor: OnboardingProfileActor;
     answers: OnboardingStepAnswerColumns;
   }): Promise<OnboardingProfileWriteState>;
+  /**
+   * Terminal complete (Submit & Enter Console): finalizes the row with
+   * `status: completed` and the optional Step 4 open goal. Terminal wins —
+   * against a row already `completed` or `dismissed`, nothing is written and
+   * the pre-existing state is returned.
+   */
+  complete(input: {
+    actor: OnboardingProfileActor;
+    openGoalText: string | null;
+  }): Promise<OnboardingProfileTerminalState>;
   /**
    * Terminal dismiss (Skip). Terminal wins: when the row is already
    * `completed` or `dismissed`, nothing is written and the pre-existing state
@@ -106,6 +122,46 @@ export function createOnboardingProfileStore(
           throw new Error("Onboarding step answer failed to persist.");
         }
         return { status: row.status };
+      }),
+    complete: (input) =>
+      getDb().transaction(async (tx) => {
+        // Same discipline as dismiss: the terminal write lands on a uid-keyed
+        // row, so re-check the fingerprint in the same transaction (ADR-0059).
+        await requireCurrentIdentityBinding(tx, {
+          crName: input.actor.legacyWorkspaceActor,
+          userUid: input.actor.userUid,
+        });
+        await tx
+          .insert(onboardingProfiles)
+          .values({
+            openGoalText: input.openGoalText,
+            status: "completed",
+            userUid: input.actor.userUid,
+          })
+          .onConflictDoUpdate({
+            // Answers already given stay persisted: completing touches only
+            // its own columns, never the per-step answer columns.
+            set: {
+              openGoalText: input.openGoalText,
+              status: "completed",
+              updatedAt: new Date(),
+            },
+            setWhere: notInArray(onboardingProfiles.status, [
+              ...TERMINAL_ONBOARDING_PROFILE_STATUSES,
+            ]),
+            target: onboardingProfiles.userUid,
+          });
+        const [row] = await tx
+          .select({
+            dismissedAtStep: onboardingProfiles.dismissedAtStep,
+            status: onboardingProfiles.status,
+          })
+          .from(onboardingProfiles)
+          .where(eq(onboardingProfiles.userUid, input.actor.userUid));
+        if (row == null || row.status === "in_progress") {
+          throw new Error("Onboarding complete failed to settle terminally.");
+        }
+        return { dismissedAtStep: row.dismissedAtStep, status: row.status };
       }),
     dismiss: (input) =>
       getDb().transaction(async (tx) => {

--- a/apps/ui/src/features/onboarding/profile-store.ts
+++ b/apps/ui/src/features/onboarding/profile-store.ts
@@ -7,6 +7,8 @@ import { onboardingProfiles } from "./schema";
 import type {
   OnboardingProfileStatus,
   OnboardingProfileTerminalState,
+  OnboardingProfileWriteState,
+  OnboardingRoleType,
 } from "./types";
 
 /** The Sampled statuses (ADR-0061): the dialog never shows again. */
@@ -25,7 +27,27 @@ export interface OnboardingProfileActor {
   userUid: string;
 }
 
+/**
+ * The answer columns one stepwise write may touch (Step 1 today; later steps
+ * extend this). A step always writes its full column pair, so a re-answer
+ * can never leave stale Other text behind.
+ */
+export interface OnboardingStepAnswerColumns {
+  roleOtherText?: string | null;
+  roleType?: OnboardingRoleType;
+}
+
 export interface OnboardingProfileStore {
+  /**
+   * Stepwise answer upsert: creates or updates the row with
+   * `status: in_progress`. Terminal wins — against a `completed` or
+   * `dismissed` row nothing is written and the terminal status is reported,
+   * so fire-and-forget retries can never corrupt a terminal row.
+   */
+  answerStep(input: {
+    actor: OnboardingProfileActor;
+    answers: OnboardingStepAnswerColumns;
+  }): Promise<OnboardingProfileWriteState>;
   /**
    * Terminal dismiss (Skip). Terminal wins: when the row is already
    * `completed` or `dismissed`, nothing is written and the pre-existing state
@@ -52,6 +74,39 @@ export function createOnboardingProfileStore(
   getDb: () => AssistantPgDatabase
 ): OnboardingProfileStore {
   return {
+    answerStep: (input) =>
+      getDb().transaction(async (tx) => {
+        // Same discipline as dismiss: the write lands on a uid-keyed row, so
+        // re-check the fingerprint in the same transaction (ADR-0059).
+        await requireCurrentIdentityBinding(tx, {
+          crName: input.actor.legacyWorkspaceActor,
+          userUid: input.actor.userUid,
+        });
+        await tx
+          .insert(onboardingProfiles)
+          .values({
+            ...input.answers,
+            status: "in_progress",
+            userUid: input.actor.userUid,
+          })
+          .onConflictDoUpdate({
+            // A live row keeps its `in_progress` status; only the step's own
+            // answer columns move, so earlier steps' answers accumulate.
+            set: { ...input.answers, updatedAt: new Date() },
+            setWhere: notInArray(onboardingProfiles.status, [
+              ...TERMINAL_ONBOARDING_PROFILE_STATUSES,
+            ]),
+            target: onboardingProfiles.userUid,
+          });
+        const [row] = await tx
+          .select({ status: onboardingProfiles.status })
+          .from(onboardingProfiles)
+          .where(eq(onboardingProfiles.userUid, input.actor.userUid));
+        if (row == null) {
+          throw new Error("Onboarding step answer failed to persist.");
+        }
+        return { status: row.status };
+      }),
     dismiss: (input) =>
       getDb().transaction(async (tx) => {
         // The dismiss creates or finalizes a uid-keyed row; re-check the

--- a/apps/ui/src/features/onboarding/profile-store.ts
+++ b/apps/ui/src/features/onboarding/profile-store.ts
@@ -1,0 +1,105 @@
+import { eq, notInArray } from "drizzle-orm";
+
+import type { AssistantPgDatabase } from "@/features/chat/persistence/db";
+import { requireCurrentIdentityBinding } from "@/lib/identity-fingerprint-core";
+
+import { onboardingProfiles } from "./schema";
+import type {
+  OnboardingProfileStatus,
+  OnboardingProfileTerminalState,
+} from "./types";
+
+/** The Sampled statuses (ADR-0061): the dialog never shows again. */
+export const TERMINAL_ONBOARDING_PROFILE_STATUSES = [
+  "completed",
+  "dismissed",
+] as const satisfies readonly OnboardingProfileStatus[];
+
+const terminalStatuses: ReadonlySet<OnboardingProfileStatus> = new Set(
+  TERMINAL_ONBOARDING_PROFILE_STATUSES
+);
+
+/** The actor writing their own profile: bare uid key + crName for the re-check. */
+export interface OnboardingProfileActor {
+  legacyWorkspaceActor: string;
+  userUid: string;
+}
+
+export interface OnboardingProfileStore {
+  /**
+   * Terminal dismiss (Skip). Terminal wins: when the row is already
+   * `completed` or `dismissed`, nothing is written and the pre-existing state
+   * is returned, so fire-and-forget retries can never corrupt a terminal row.
+   */
+  dismiss(input: {
+    actor: OnboardingProfileActor;
+    dismissedAtStep: number;
+  }): Promise<OnboardingProfileTerminalState>;
+  /**
+   * The sampling predicate (ADR-0061): `true` when a terminal row exists.
+   * No row and `in_progress` both mean Unsampled.
+   */
+  isSampled(userUid: string): Promise<boolean>;
+}
+
+/**
+ * Persistence for the Onboarding Profile. Takes the assistant Drizzle handle:
+ * the profile table lives in `sealai_onboarding`, but it shares the database,
+ * and the dismiss transaction must span the `identity_fingerprints` re-check
+ * (ADR-0059) anyway.
+ */
+export function createOnboardingProfileStore(
+  getDb: () => AssistantPgDatabase
+): OnboardingProfileStore {
+  return {
+    dismiss: (input) =>
+      getDb().transaction(async (tx) => {
+        // The dismiss creates or finalizes a uid-keyed row; re-check the
+        // fingerprint in the same transaction so a concurrent merge either
+        // sweeps this row or refuses the stale binding (ADR-0059).
+        await requireCurrentIdentityBinding(tx, {
+          crName: input.actor.legacyWorkspaceActor,
+          userUid: input.actor.userUid,
+        });
+        await tx
+          .insert(onboardingProfiles)
+          .values({
+            dismissedAtStep: input.dismissedAtStep,
+            status: "dismissed",
+            userUid: input.actor.userUid,
+          })
+          .onConflictDoUpdate({
+            // Answers already given stay persisted: only the terminal
+            // columns are touched, never the per-step answer columns.
+            set: {
+              dismissedAtStep: input.dismissedAtStep,
+              status: "dismissed",
+              updatedAt: new Date(),
+            },
+            setWhere: notInArray(onboardingProfiles.status, [
+              ...TERMINAL_ONBOARDING_PROFILE_STATUSES,
+            ]),
+            target: onboardingProfiles.userUid,
+          });
+        const [row] = await tx
+          .select({
+            dismissedAtStep: onboardingProfiles.dismissedAtStep,
+            status: onboardingProfiles.status,
+          })
+          .from(onboardingProfiles)
+          .where(eq(onboardingProfiles.userUid, input.actor.userUid));
+        if (row == null || row.status === "in_progress") {
+          throw new Error("Onboarding dismiss failed to settle terminally.");
+        }
+        return { dismissedAtStep: row.dismissedAtStep, status: row.status };
+      }),
+    isSampled: async (userUid) => {
+      const [row] = await getDb()
+        .select({ status: onboardingProfiles.status })
+        .from(onboardingProfiles)
+        .where(eq(onboardingProfiles.userUid, userUid))
+        .limit(1);
+      return row != null && terminalStatuses.has(row.status);
+    },
+  };
+}

--- a/apps/ui/src/features/onboarding/schema.ts
+++ b/apps/ui/src/features/onboarding/schema.ts
@@ -1,0 +1,91 @@
+import { integer, jsonb, pgSchema, text, timestamp } from "drizzle-orm/pg-core";
+
+/**
+ * Postgres schema owning the Onboarding Profile (ADR-0061). Isolated from
+ * `public` so `drizzle-kit push` with `schemaFilter` does not try to drop
+ * operator/managed tables.
+ */
+export const ONBOARDING_DB_SCHEMA = "sealai_onboarding";
+
+export const ns = pgSchema(ONBOARDING_DB_SCHEMA);
+
+/**
+ * `completed` and `dismissed` are terminal — the person is Sampled and the
+ * dialog never shows again. `in_progress` (an abandoned mid-survey row) still
+ * counts as Unsampled.
+ */
+export type OnboardingProfileStatus = "completed" | "dismissed" | "in_progress";
+
+/** Step 1 Cohort Tags: who the person is. */
+export type OnboardingRoleType =
+  | "ai_builder"
+  | "devops_platform_engineer"
+  | "engineering_team_member"
+  | "founder"
+  | "individual_developer"
+  | "other"
+  | "student";
+
+/** Step 2 Cohort Tags: what the person is using Sealos for. */
+export type OnboardingUsageContext =
+  | "ai_built_app"
+  | "demo_or_prototype"
+  | "exploring"
+  | "new_product_launch"
+  | "other"
+  | "real_business"
+  | "side_project"
+  | "team_or_client";
+
+/** Step 3 Cohort Tags: the factors that matter most. */
+export type OnboardingPriorityTag =
+  | "ease_of_use"
+  | "fast_launch"
+  | "low_cost"
+  | "other"
+  | "performance"
+  | "scalability"
+  | "stability";
+
+/**
+ * One Onboarding Profile row per person — Brain's first namespace-less
+ * personal resource, keyed by the bare global `userUid` (ADR-0061). The
+ * database is region-local, so the practical semantic is one profile per
+ * person per region. Unanswered questions are NULL columns; progress is
+ * inferred, never stored. Tag columns hold stable machine values validated by
+ * zod at the application boundary — the database stores plain text.
+ */
+export const onboardingProfiles = ns.table("onboarding_profiles", {
+  /** Bare global user UID: no namespace, no per-region crName, ever. */
+  userUid: text("user_uid").primaryKey(),
+  status: text("status").notNull().$type<OnboardingProfileStatus>(),
+  /** Step (1–4) the survey was on when Skip was clicked. */
+  dismissedAtStep: integer("dismissed_at_step"),
+  /** Step 1 answer; literal `other` pairs with `roleOtherText`. */
+  roleType: text("role_type").$type<OnboardingRoleType>(),
+  /** Step 1 Other free text — optional even when `roleType` is `other`. */
+  roleOtherText: text("role_other_text"),
+  /** Step 2 answer; literal `other` pairs with `usageOtherText`. */
+  usageContext: text("usage_context").$type<OnboardingUsageContext>(),
+  /** Step 2 Other free text — optional even when `usageContext` is `other`. */
+  usageOtherText: text("usage_other_text"),
+  /** Step 3 answer: 1–3 tags; array order = click order. */
+  priorityTags: jsonb("priority_tags").$type<OnboardingPriorityTag[]>(),
+  /** The randomized option order shown that session, Other pinned last. */
+  priorityDisplayOrder: jsonb("priority_display_order").$type<
+    OnboardingPriorityTag[]
+  >(),
+  /** Step 3 Other free text — optional, combinable with other picks. */
+  priorityOtherText: text("priority_other_text"),
+  /** Step 4 open answer. */
+  openGoalText: text("open_goal_text"),
+  /** Doubles as the terminal timestamp; no extra column. */
+  updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+    .defaultNow()
+    .notNull(),
+});
+
+export type OnboardingProfileRow = typeof onboardingProfiles.$inferSelect;

--- a/apps/ui/src/features/onboarding/schema.ts
+++ b/apps/ui/src/features/onboarding/schema.ts
@@ -1,5 +1,11 @@
 import { integer, jsonb, pgSchema, text, timestamp } from "drizzle-orm/pg-core";
 
+import type {
+  OnboardingPriorityTag,
+  OnboardingRoleType,
+  OnboardingUsageContext,
+} from "./types";
+
 /**
  * Postgres schema owning the Onboarding Profile (ADR-0061). Isolated from
  * `public` so `drizzle-kit push` with `schemaFilter` does not try to drop
@@ -16,36 +22,9 @@ export const ns = pgSchema(ONBOARDING_DB_SCHEMA);
  */
 export type OnboardingProfileStatus = "completed" | "dismissed" | "in_progress";
 
-/** Step 1 Cohort Tags: who the person is. */
-export type OnboardingRoleType =
-  | "ai_builder"
-  | "devops_platform_engineer"
-  | "engineering_team_member"
-  | "founder"
-  | "individual_developer"
-  | "other"
-  | "student";
-
-/** Step 2 Cohort Tags: what the person is using Sealos for. */
-export type OnboardingUsageContext =
-  | "ai_built_app"
-  | "demo_or_prototype"
-  | "exploring"
-  | "new_product_launch"
-  | "other"
-  | "real_business"
-  | "side_project"
-  | "team_or_client";
-
-/** Step 3 Cohort Tags: the factors that matter most. */
-export type OnboardingPriorityTag =
-  | "ease_of_use"
-  | "fast_launch"
-  | "low_cost"
-  | "other"
-  | "performance"
-  | "scalability"
-  | "stability";
+// The Cohort Tag vocabularies live with their zod boundary in `./types` (the
+// application boundary owns validation; the database holds plain text) — the
+// type-only imports above keep this module's runtime free of that boundary.
 
 /**
  * One Onboarding Profile row per person — Brain's first namespace-less

--- a/apps/ui/src/features/onboarding/survey-state.test.ts
+++ b/apps/ui/src/features/onboarding/survey-state.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  canAdvanceOnboardingStep,
+  initialOnboardingSurveyState,
+  onboardingSkipPayload,
+  onboardingSurveyReducer,
+} from "./survey-state";
+
+test("role selection is single-select: picking replaces, re-picking clears", () => {
+  const picked = onboardingSurveyReducer(initialOnboardingSurveyState, {
+    role: "founder",
+    type: "toggle-role",
+  });
+  assert.equal(picked.roleType, "founder");
+
+  const replaced = onboardingSurveyReducer(picked, {
+    role: "student",
+    type: "toggle-role",
+  });
+  assert.equal(replaced.roleType, "student");
+
+  const cleared = onboardingSurveyReducer(replaced, {
+    role: "student",
+    type: "toggle-role",
+  });
+  assert.equal(cleared.roleType, null);
+});
+
+test("the Other free text is kept while switching selections", () => {
+  const withOther = onboardingSurveyReducer(
+    onboardingSurveyReducer(initialOnboardingSurveyState, {
+      role: "other",
+      type: "toggle-role",
+    }),
+    { text: "platform team lead", type: "set-role-other-text" }
+  );
+  assert.equal(withOther.roleOtherText, "platform team lead");
+
+  const switched = onboardingSurveyReducer(withOther, {
+    role: "founder",
+    type: "toggle-role",
+  });
+  assert.equal(switched.roleType, "founder");
+  assert.equal(switched.roleOtherText, "platform team lead");
+});
+
+test("Next is gated on a selection and never auto-advances", () => {
+  assert.equal(canAdvanceOnboardingStep(initialOnboardingSurveyState), false);
+
+  const picked = onboardingSurveyReducer(initialOnboardingSurveyState, {
+    role: "ai_builder",
+    type: "toggle-role",
+  });
+  assert.equal(canAdvanceOnboardingStep(picked), true);
+  // Selecting never advances by itself — the step only changes explicitly.
+  assert.equal(picked.currentStep, 1);
+});
+
+test("Skip reports the real current step, selection or not", () => {
+  assert.deepEqual(onboardingSkipPayload(initialOnboardingSurveyState), {
+    dismissedAtStep: 1,
+  });
+  assert.deepEqual(
+    onboardingSkipPayload({
+      ...initialOnboardingSurveyState,
+      currentStep: 3,
+    }),
+    { dismissedAtStep: 3 }
+  );
+});

--- a/apps/ui/src/features/onboarding/survey-state.test.ts
+++ b/apps/ui/src/features/onboarding/survey-state.test.ts
@@ -7,6 +7,7 @@ import {
   type OnboardingSurveyAction,
   type OnboardingSurveyState,
   onboardingCompletePayload,
+  onboardingOtherTextMissing,
   onboardingPriorityAnswerPayload,
   onboardingRoleAnswerPayload,
   onboardingSkipEvent,
@@ -193,6 +194,50 @@ test("Next is gated per step and Step 4 is always open", () => {
 test("a closed gate makes advance a no-op", () => {
   const stuck = reduce(initialState(), { type: "advance-step" });
   assert.equal(stuck.currentStep, 1);
+});
+
+test("a selected Other requires text before its step advances", () => {
+  // Step 1: Other alone keeps Next clickable but the advance is refused…
+  const blank = reduce(initialState(), { role: "other", type: "toggle-role" });
+  assert.equal(canAdvanceOnboardingStep(blank), true);
+  assert.equal(onboardingOtherTextMissing(blank), true);
+  assert.equal(reduce(blank, { type: "advance-step" }).currentStep, 1);
+  // …whitespace is not text…
+  const padded = reduce(blank, { text: "   ", type: "set-role-other-text" });
+  assert.equal(onboardingOtherTextMissing(padded), true);
+  // …and real text opens the step.
+  const filled = reduce(blank, { text: "SRE", type: "set-role-other-text" });
+  assert.equal(onboardingOtherTextMissing(filled), false);
+  const two = reduce(filled, { type: "advance-step" });
+  assert.equal(two.currentStep, 2);
+
+  // The same rule holds on Steps 2 and 3.
+  const usageBlank = reduce(two, { type: "toggle-usage", usage: "other" });
+  assert.equal(onboardingOtherTextMissing(usageBlank), true);
+  assert.equal(reduce(usageBlank, { type: "advance-step" }).currentStep, 2);
+  const three = reduce(
+    usageBlank,
+    { text: "homelab", type: "set-usage-other-text" },
+    { type: "advance-step" }
+  );
+  assert.equal(three.currentStep, 3);
+  const priorityBlank = reduce(three, {
+    tag: "other",
+    type: "toggle-priority",
+  });
+  assert.equal(onboardingOtherTextMissing(priorityBlank), true);
+  assert.equal(reduce(priorityBlank, { type: "advance-step" }).currentStep, 3);
+  // A non-Other pick with Other unselected never demands text.
+  const withoutOther = reduce(priorityBlank, {
+    tag: "other",
+    type: "toggle-priority",
+  });
+  const stability = reduce(withoutOther, {
+    tag: "stability",
+    type: "toggle-priority",
+  });
+  assert.equal(onboardingOtherTextMissing(stability), false);
+  assert.equal(reduce(stability, { type: "advance-step" }).currentStep, 4);
 });
 
 test("the role write payload is the Other pair or a bare tag, never loose text", () => {

--- a/apps/ui/src/features/onboarding/survey-state.test.ts
+++ b/apps/ui/src/features/onboarding/survey-state.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import {
   canAdvanceOnboardingStep,
   initialOnboardingSurveyState,
+  onboardingRoleAnswerPayload,
   onboardingSkipPayload,
   onboardingSurveyReducer,
 } from "./survey-state";
@@ -56,6 +57,77 @@ test("Next is gated on a selection and never auto-advances", () => {
   assert.equal(canAdvanceOnboardingStep(picked), true);
   // Selecting never advances by itself — the step only changes explicitly.
   assert.equal(picked.currentStep, 1);
+});
+
+test("Next advances exactly one gated step and never past the placeholder", () => {
+  // No selection: the gate is closed and advance is a no-op.
+  const stuck = onboardingSurveyReducer(initialOnboardingSurveyState, {
+    type: "advance-step",
+  });
+  assert.equal(stuck.currentStep, 1);
+
+  const picked = onboardingSurveyReducer(initialOnboardingSurveyState, {
+    role: "founder",
+    type: "toggle-role",
+  });
+  const advanced = onboardingSurveyReducer(picked, { type: "advance-step" });
+  assert.equal(advanced.currentStep, 2);
+  // The answer survives the advance — Skip on a later step must not lose it.
+  assert.equal(advanced.roleType, "founder");
+
+  // Step 2 is a placeholder on this slice: nothing selectable, so the gate
+  // stays closed and advance is again a no-op.
+  assert.equal(canAdvanceOnboardingStep(advanced), false);
+  const parked = onboardingSurveyReducer(advanced, { type: "advance-step" });
+  assert.equal(parked.currentStep, 2);
+});
+
+test("the role write payload is the Other pair or a bare tag, never loose text", () => {
+  // Nothing selected: there is nothing to persist.
+  assert.equal(onboardingRoleAnswerPayload(initialOnboardingSurveyState), null);
+
+  // A non-Other pick never carries text — even stale text kept from a
+  // previous Other selection stays out of the payload.
+  const founderWithStaleText = onboardingSurveyReducer(
+    onboardingSurveyReducer(
+      onboardingSurveyReducer(initialOnboardingSurveyState, {
+        role: "other",
+        type: "toggle-role",
+      }),
+      { text: "platform team lead", type: "set-role-other-text" }
+    ),
+    { role: "founder", type: "toggle-role" }
+  );
+  assert.deepEqual(onboardingRoleAnswerPayload(founderWithStaleText), {
+    roleOtherText: null,
+    roleType: "founder",
+    step: 1,
+  });
+
+  // Other stores the pair; the free text is trimmed.
+  const other = onboardingSurveyReducer(
+    onboardingSurveyReducer(initialOnboardingSurveyState, {
+      role: "other",
+      type: "toggle-role",
+    }),
+    { text: "  platform team lead ", type: "set-role-other-text" }
+  );
+  assert.deepEqual(onboardingRoleAnswerPayload(other), {
+    roleOtherText: "platform team lead",
+    roleType: "other",
+    step: 1,
+  });
+
+  // The text is optional: Other with blank text is the pair (other, NULL).
+  const otherBlank = onboardingSurveyReducer(other, {
+    text: "   ",
+    type: "set-role-other-text",
+  });
+  assert.deepEqual(onboardingRoleAnswerPayload(otherBlank), {
+    roleOtherText: null,
+    roleType: "other",
+    step: 1,
+  });
 });
 
 test("Skip reports the real current step, selection or not", () => {

--- a/apps/ui/src/features/onboarding/survey-state.test.ts
+++ b/apps/ui/src/features/onboarding/survey-state.test.ts
@@ -3,99 +3,206 @@ import { test } from "node:test";
 
 import {
   canAdvanceOnboardingStep,
-  initialOnboardingSurveyState,
+  createInitialOnboardingSurveyState,
+  type OnboardingSurveyAction,
+  type OnboardingSurveyState,
+  onboardingCompletePayload,
+  onboardingPriorityAnswerPayload,
   onboardingRoleAnswerPayload,
   onboardingSkipPayload,
   onboardingSurveyReducer,
+  onboardingUsageAnswerPayload,
 } from "./survey-state";
 
+/** Deterministic RNG so display-order assertions are reproducible. */
+function seededRandom(seed: number): () => number {
+  let s = seed;
+  return () => {
+    s = (s * 1_664_525 + 1_013_904_223) % 4_294_967_296;
+    return s / 4_294_967_296;
+  };
+}
+
+function initialState(): OnboardingSurveyState {
+  return createInitialOnboardingSurveyState(seededRandom(7));
+}
+
+function reduce(
+  state: OnboardingSurveyState,
+  ...actions: OnboardingSurveyAction[]
+): OnboardingSurveyState {
+  return actions.reduce(onboardingSurveyReducer, state);
+}
+
+const ALL_PRIORITY_TAGS = [
+  "ease_of_use",
+  "fast_launch",
+  "low_cost",
+  "other",
+  "performance",
+  "scalability",
+  "stability",
+] as const;
+
+test("the display order is a per-session shuffle of every tag with Other pinned last", () => {
+  const orders = [1, 7, 42].map(
+    (seed) =>
+      createInitialOnboardingSurveyState(seededRandom(seed))
+        .priorityDisplayOrder
+  );
+
+  for (const order of orders) {
+    // Every tag exactly once…
+    assert.deepEqual([...order].sort(), [...ALL_PRIORITY_TAGS]);
+    // …with Other always closing the list.
+    assert.equal(order.at(-1), "other");
+  }
+  // A fresh session gets a fresh order (deterministic under these seeds).
+  assert.notDeepEqual(orders[0], orders[1]);
+  assert.notDeepEqual(orders[1], orders[2]);
+});
+
 test("role selection is single-select: picking replaces, re-picking clears", () => {
-  const picked = onboardingSurveyReducer(initialOnboardingSurveyState, {
+  const picked = reduce(initialState(), {
     role: "founder",
     type: "toggle-role",
   });
   assert.equal(picked.roleType, "founder");
 
-  const replaced = onboardingSurveyReducer(picked, {
-    role: "student",
-    type: "toggle-role",
-  });
+  const replaced = reduce(picked, { role: "student", type: "toggle-role" });
   assert.equal(replaced.roleType, "student");
 
-  const cleared = onboardingSurveyReducer(replaced, {
-    role: "student",
-    type: "toggle-role",
-  });
+  const cleared = reduce(replaced, { role: "student", type: "toggle-role" });
   assert.equal(cleared.roleType, null);
 });
 
+test("usage selection is single-select: picking replaces, re-picking clears", () => {
+  const picked = reduce(initialState(), {
+    type: "toggle-usage",
+    usage: "exploring",
+  });
+  assert.equal(picked.usageContext, "exploring");
+
+  const replaced = reduce(picked, {
+    type: "toggle-usage",
+    usage: "real_business",
+  });
+  assert.equal(replaced.usageContext, "real_business");
+
+  const cleared = reduce(replaced, {
+    type: "toggle-usage",
+    usage: "real_business",
+  });
+  assert.equal(cleared.usageContext, null);
+});
+
+test("priority picks keep click order and a fourth selection is refused", () => {
+  const three = reduce(
+    initialState(),
+    { tag: "low_cost", type: "toggle-priority" },
+    { tag: "stability", type: "toggle-priority" },
+    { tag: "ease_of_use", type: "toggle-priority" }
+  );
+  // Array order = click order, not display order.
+  assert.deepEqual(three.priorityTags, [
+    "low_cost",
+    "stability",
+    "ease_of_use",
+  ]);
+
+  // The cap is 3: a fourth pick changes nothing — no swap, no reorder.
+  const refused = reduce(three, {
+    tag: "performance",
+    type: "toggle-priority",
+  });
+  assert.deepEqual(refused.priorityTags, [
+    "low_cost",
+    "stability",
+    "ease_of_use",
+  ]);
+
+  // Unpicking reopens a slot; the survivors keep their click order.
+  const reopened = reduce(refused, {
+    tag: "stability",
+    type: "toggle-priority",
+  });
+  assert.deepEqual(reopened.priorityTags, ["low_cost", "ease_of_use"]);
+  const swapped = reduce(reopened, {
+    tag: "performance",
+    type: "toggle-priority",
+  });
+  assert.deepEqual(swapped.priorityTags, [
+    "low_cost",
+    "ease_of_use",
+    "performance",
+  ]);
+});
+
 test("the Other free text is kept while switching selections", () => {
-  const withOther = onboardingSurveyReducer(
-    onboardingSurveyReducer(initialOnboardingSurveyState, {
-      role: "other",
-      type: "toggle-role",
-    }),
+  const withOther = reduce(
+    initialState(),
+    { role: "other", type: "toggle-role" },
     { text: "platform team lead", type: "set-role-other-text" }
   );
   assert.equal(withOther.roleOtherText, "platform team lead");
 
-  const switched = onboardingSurveyReducer(withOther, {
-    role: "founder",
-    type: "toggle-role",
-  });
+  const switched = reduce(withOther, { role: "founder", type: "toggle-role" });
   assert.equal(switched.roleType, "founder");
   assert.equal(switched.roleOtherText, "platform team lead");
 });
 
-test("Next is gated on a selection and never auto-advances", () => {
-  assert.equal(canAdvanceOnboardingStep(initialOnboardingSurveyState), false);
+test("Next is gated per step and Step 4 is always open", () => {
+  const start = initialState();
+  assert.equal(canAdvanceOnboardingStep(start), false);
 
-  const picked = onboardingSurveyReducer(initialOnboardingSurveyState, {
-    role: "ai_builder",
-    type: "toggle-role",
-  });
-  assert.equal(canAdvanceOnboardingStep(picked), true);
+  const one = reduce(start, { role: "ai_builder", type: "toggle-role" });
+  assert.equal(canAdvanceOnboardingStep(one), true);
   // Selecting never advances by itself — the step only changes explicitly.
-  assert.equal(picked.currentStep, 1);
+  assert.equal(one.currentStep, 1);
+
+  const two = reduce(one, { type: "advance-step" });
+  assert.equal(two.currentStep, 2);
+  assert.equal(canAdvanceOnboardingStep(two), false);
+  const three = reduce(
+    two,
+    { type: "toggle-usage", usage: "side_project" },
+    { type: "advance-step" }
+  );
+  assert.equal(three.currentStep, 3);
+  assert.equal(canAdvanceOnboardingStep(three), false);
+
+  const four = reduce(
+    three,
+    { tag: "fast_launch", type: "toggle-priority" },
+    { type: "advance-step" }
+  );
+  assert.equal(four.currentStep, 4);
+  // Step 4 is optional: the submit gate is open with nothing typed…
+  assert.equal(canAdvanceOnboardingStep(four), true);
+  // …but there is no step 5 — submit is terminal, not an advance.
+  assert.equal(reduce(four, { type: "advance-step" }).currentStep, 4);
+
+  // Answers survive the whole walk — Skip on a later step must not lose them.
+  assert.equal(four.roleType, "ai_builder");
+  assert.equal(four.usageContext, "side_project");
+  assert.deepEqual(four.priorityTags, ["fast_launch"]);
 });
 
-test("Next advances exactly one gated step and never past the placeholder", () => {
-  // No selection: the gate is closed and advance is a no-op.
-  const stuck = onboardingSurveyReducer(initialOnboardingSurveyState, {
-    type: "advance-step",
-  });
+test("a closed gate makes advance a no-op", () => {
+  const stuck = reduce(initialState(), { type: "advance-step" });
   assert.equal(stuck.currentStep, 1);
-
-  const picked = onboardingSurveyReducer(initialOnboardingSurveyState, {
-    role: "founder",
-    type: "toggle-role",
-  });
-  const advanced = onboardingSurveyReducer(picked, { type: "advance-step" });
-  assert.equal(advanced.currentStep, 2);
-  // The answer survives the advance — Skip on a later step must not lose it.
-  assert.equal(advanced.roleType, "founder");
-
-  // Step 2 is a placeholder on this slice: nothing selectable, so the gate
-  // stays closed and advance is again a no-op.
-  assert.equal(canAdvanceOnboardingStep(advanced), false);
-  const parked = onboardingSurveyReducer(advanced, { type: "advance-step" });
-  assert.equal(parked.currentStep, 2);
 });
 
 test("the role write payload is the Other pair or a bare tag, never loose text", () => {
   // Nothing selected: there is nothing to persist.
-  assert.equal(onboardingRoleAnswerPayload(initialOnboardingSurveyState), null);
+  assert.equal(onboardingRoleAnswerPayload(initialState()), null);
 
   // A non-Other pick never carries text — even stale text kept from a
   // previous Other selection stays out of the payload.
-  const founderWithStaleText = onboardingSurveyReducer(
-    onboardingSurveyReducer(
-      onboardingSurveyReducer(initialOnboardingSurveyState, {
-        role: "other",
-        type: "toggle-role",
-      }),
-      { text: "platform team lead", type: "set-role-other-text" }
-    ),
+  const founderWithStaleText = reduce(
+    initialState(),
+    { role: "other", type: "toggle-role" },
+    { text: "platform team lead", type: "set-role-other-text" },
     { role: "founder", type: "toggle-role" }
   );
   assert.deepEqual(onboardingRoleAnswerPayload(founderWithStaleText), {
@@ -105,11 +212,9 @@ test("the role write payload is the Other pair or a bare tag, never loose text",
   });
 
   // Other stores the pair; the free text is trimmed.
-  const other = onboardingSurveyReducer(
-    onboardingSurveyReducer(initialOnboardingSurveyState, {
-      role: "other",
-      type: "toggle-role",
-    }),
+  const other = reduce(
+    initialState(),
+    { role: "other", type: "toggle-role" },
     { text: "  platform team lead ", type: "set-role-other-text" }
   );
   assert.deepEqual(onboardingRoleAnswerPayload(other), {
@@ -119,7 +224,7 @@ test("the role write payload is the Other pair or a bare tag, never loose text",
   });
 
   // The text is optional: Other with blank text is the pair (other, NULL).
-  const otherBlank = onboardingSurveyReducer(other, {
+  const otherBlank = reduce(other, {
     text: "   ",
     type: "set-role-other-text",
   });
@@ -130,15 +235,86 @@ test("the role write payload is the Other pair or a bare tag, never loose text",
   });
 });
 
+test("the usage write payload is the Other pair or a bare tag, never loose text", () => {
+  assert.equal(onboardingUsageAnswerPayload(initialState()), null);
+
+  const staleText = reduce(
+    initialState(),
+    { type: "toggle-usage", usage: "other" },
+    { text: "migrating a homelab", type: "set-usage-other-text" },
+    { type: "toggle-usage", usage: "exploring" }
+  );
+  assert.deepEqual(onboardingUsageAnswerPayload(staleText), {
+    step: 2,
+    usageContext: "exploring",
+    usageOtherText: null,
+  });
+
+  const other = reduce(
+    initialState(),
+    { type: "toggle-usage", usage: "other" },
+    { text: " migrating a homelab  ", type: "set-usage-other-text" }
+  );
+  assert.deepEqual(onboardingUsageAnswerPayload(other), {
+    step: 2,
+    usageContext: "other",
+    usageOtherText: "migrating a homelab",
+  });
+});
+
+test("the priority write payload carries click order, display order, and the Other pair", () => {
+  assert.equal(onboardingPriorityAnswerPayload(initialState()), null);
+
+  const state = reduce(
+    initialState(),
+    { tag: "stability", type: "toggle-priority" },
+    { tag: "other", type: "toggle-priority" },
+    { text: "  fair pricing ", type: "set-priority-other-text" }
+  );
+  assert.deepEqual(onboardingPriorityAnswerPayload(state), {
+    priorityDisplayOrder: state.priorityDisplayOrder,
+    priorityOtherText: "fair pricing",
+    priorityTags: ["stability", "other"],
+    step: 3,
+  });
+
+  // Without Other among the picks the stale text stays out of the payload.
+  const withoutOther = reduce(state, { tag: "other", type: "toggle-priority" });
+  assert.deepEqual(onboardingPriorityAnswerPayload(withoutOther), {
+    priorityDisplayOrder: state.priorityDisplayOrder,
+    priorityOtherText: null,
+    priorityTags: ["stability"],
+    step: 3,
+  });
+});
+
+test("the complete payload trims the optional open goal to text or null", () => {
+  assert.deepEqual(onboardingCompletePayload(initialState()), {
+    openGoalText: null,
+  });
+  assert.deepEqual(
+    onboardingCompletePayload(
+      reduce(initialState(), { text: "   ", type: "set-open-goal-text" })
+    ),
+    { openGoalText: null }
+  );
+  assert.deepEqual(
+    onboardingCompletePayload(
+      reduce(initialState(), {
+        text: " deploy an AI agent ",
+        type: "set-open-goal-text",
+      })
+    ),
+    { openGoalText: "deploy an AI agent" }
+  );
+});
+
 test("Skip reports the real current step, selection or not", () => {
-  assert.deepEqual(onboardingSkipPayload(initialOnboardingSurveyState), {
+  assert.deepEqual(onboardingSkipPayload(initialState()), {
     dismissedAtStep: 1,
   });
   assert.deepEqual(
-    onboardingSkipPayload({
-      ...initialOnboardingSurveyState,
-      currentStep: 3,
-    }),
+    onboardingSkipPayload({ ...initialState(), currentStep: 3 }),
     { dismissedAtStep: 3 }
   );
 });

--- a/apps/ui/src/features/onboarding/survey-state.test.ts
+++ b/apps/ui/src/features/onboarding/survey-state.test.ts
@@ -9,7 +9,9 @@ import {
   onboardingCompletePayload,
   onboardingPriorityAnswerPayload,
   onboardingRoleAnswerPayload,
+  onboardingSkipEvent,
   onboardingSkipPayload,
+  onboardingStepViewEvent,
   onboardingSurveyReducer,
   onboardingUsageAnswerPayload,
 } from "./survey-state";
@@ -317,4 +319,27 @@ test("Skip reports the real current step, selection or not", () => {
     onboardingSkipPayload({ ...initialState(), currentStep: 3 }),
     { dismissedAtStep: 3 }
   );
+});
+
+test("the funnel events carry the step number and nothing else", () => {
+  // The GTM payloads are structure-only (spec #88): a step number is the
+  // whole event — deepEqual pins that no answer field can ride along.
+  assert.deepEqual(onboardingStepViewEvent(1), {
+    event: "onboarding_step_view",
+    step: 1,
+  });
+  assert.deepEqual(onboardingStepViewEvent(4), {
+    event: "onboarding_step_view",
+    step: 4,
+  });
+  assert.deepEqual(onboardingSkipEvent(2), {
+    event: "onboarding_skip",
+    step: 2,
+  });
+
+  // Outside the 4-step survey there is no event to send.
+  for (const step of [0, 5, 2.5, Number.NaN]) {
+    assert.equal(onboardingStepViewEvent(step), null);
+    assert.equal(onboardingSkipEvent(step), null);
+  }
 });

--- a/apps/ui/src/features/onboarding/survey-state.test.ts
+++ b/apps/ui/src/features/onboarding/survey-state.test.ts
@@ -6,6 +6,7 @@ import {
   createInitialOnboardingSurveyState,
   type OnboardingSurveyAction,
   type OnboardingSurveyState,
+  onboardingAnswersSnapshot,
   onboardingCompletePayload,
   onboardingOtherTextMissing,
   onboardingPriorityAnswerPayload,
@@ -337,13 +338,14 @@ test("the priority write payload carries click order, display order, and the Oth
 
 test("the complete payload trims the optional open goal to text or null", () => {
   assert.deepEqual(onboardingCompletePayload(initialState()), {
+    answers: [],
     openGoalText: null,
   });
   assert.deepEqual(
     onboardingCompletePayload(
       reduce(initialState(), { text: "   ", type: "set-open-goal-text" })
     ),
-    { openGoalText: null }
+    { answers: [], openGoalText: null }
   );
   assert.deepEqual(
     onboardingCompletePayload(
@@ -352,18 +354,63 @@ test("the complete payload trims the optional open goal to text or null", () => 
         type: "set-open-goal-text",
       })
     ),
-    { openGoalText: "deploy an AI agent" }
+    { answers: [], openGoalText: "deploy an AI agent" }
   );
 });
 
 test("Skip reports the real current step, selection or not", () => {
   assert.deepEqual(onboardingSkipPayload(initialState()), {
+    answers: [],
     dismissedAtStep: 1,
   });
   assert.deepEqual(
     onboardingSkipPayload({ ...initialState(), currentStep: 3 }),
-    { dismissedAtStep: 3 }
+    { answers: [], dismissedAtStep: 3 }
   );
+});
+
+test("the Terminal Snapshot carries every step confirmed with Next", () => {
+  // Steps 1-3 answered and confirmed; the state sits on Step 4.
+  const state = reduce(
+    initialState(),
+    { role: "founder", type: "toggle-role" },
+    { type: "advance-step" },
+    { type: "toggle-usage", usage: "real_business" },
+    { type: "advance-step" },
+    { tag: "stability", type: "toggle-priority" },
+    { type: "advance-step" }
+  );
+
+  const snapshot = onboardingAnswersSnapshot(state);
+
+  assert.deepEqual(snapshot, [
+    { roleOtherText: null, roleType: "founder", step: 1 },
+    { step: 2, usageContext: "real_business", usageOtherText: null },
+    {
+      priorityDisplayOrder: state.priorityDisplayOrder,
+      priorityOtherText: null,
+      priorityTags: ["stability"],
+      step: 3,
+    },
+  ]);
+  // The complete payload rides exactly this snapshot.
+  assert.deepEqual(onboardingCompletePayload(state).answers, snapshot);
+});
+
+test("the Terminal Snapshot excludes the current step's unconfirmed selection", () => {
+  // Step 1 confirmed; a Step 2 selection made but never advanced past.
+  const state = reduce(
+    initialState(),
+    { role: "founder", type: "toggle-role" },
+    { type: "advance-step" },
+    { type: "toggle-usage", usage: "exploring" }
+  );
+
+  // Skip here submits only what Next confirmed — the Step 2 pick stays out.
+  assert.deepEqual(onboardingSkipPayload(state), {
+    answers: [{ roleOtherText: null, roleType: "founder", step: 1 }],
+    dismissedAtStep: 2,
+  });
 });
 
 test("the funnel events carry the step number and nothing else", () => {

--- a/apps/ui/src/features/onboarding/survey-state.ts
+++ b/apps/ui/src/features/onboarding/survey-state.ts
@@ -1,3 +1,9 @@
+import type {
+  BrainGtmOnboardingSkipEvent,
+  BrainGtmOnboardingStep,
+  BrainGtmOnboardingStepViewEvent,
+} from "@/features/analytics/brain-gtm";
+
 import {
   type AnswerOnboardingStepRequest,
   type CompleteOnboardingProfileRequest,
@@ -239,4 +245,31 @@ export function onboardingSkipPayload(state: OnboardingSurveyState): {
   dismissedAtStep: number;
 } {
   return { dismissedAtStep: state.currentStep };
+}
+
+/** Narrows the reducer's numeric step to the closed GTM step union. */
+function onboardingGtmStep(step: number): BrainGtmOnboardingStep | null {
+  return step === 1 || step === 2 || step === 3 || step === 4 ? step : null;
+}
+
+/**
+ * The funnel view event for a step being shown; the dialog's appearance is
+ * step 1. Structure-only (spec #88): the event type has no fields for answer
+ * values, free text, or user IDs, so nothing else can travel to GTM.
+ */
+export function onboardingStepViewEvent(
+  step: number
+): BrainGtmOnboardingStepViewEvent | null {
+  const gtmStep = onboardingGtmStep(step);
+  return gtmStep === null
+    ? null
+    : { event: "onboarding_step_view", step: gtmStep };
+}
+
+/** The funnel skip event: just the step the person left from. */
+export function onboardingSkipEvent(
+  step: number
+): BrainGtmOnboardingSkipEvent | null {
+  const gtmStep = onboardingGtmStep(step);
+  return gtmStep === null ? null : { event: "onboarding_skip", step: gtmStep };
 }

--- a/apps/ui/src/features/onboarding/survey-state.ts
+++ b/apps/ui/src/features/onboarding/survey-state.ts
@@ -7,8 +7,10 @@ import type {
 import {
   type AnswerOnboardingStepRequest,
   type CompleteOnboardingProfileRequest,
+  type DismissOnboardingProfileRequest,
   ONBOARDING_PRIORITY_TAGS_MAX,
   ONBOARDING_SURVEY_TOTAL_STEPS,
+  type OnboardingAnswersSnapshot,
   type OnboardingPriorityTag,
   type OnboardingRoleType,
   type OnboardingUsageContext,
@@ -253,21 +255,54 @@ export function onboardingPriorityAnswerPayload(
 }
 
 /**
- * The terminal payload "Submit & Enter Console" fires: the optional Step 4
- * open goal, trimmed to text or null (an empty submit completes cleanly).
+ * The Terminal Snapshot this session earned: the answers of every step
+ * already confirmed with Next (strictly below the current step — a selection
+ * still sitting on the current step was never confirmed). It rides on the
+ * terminal write so a Sampled row is complete even when a stepwise write
+ * silently failed.
+ */
+export function onboardingAnswersSnapshot(
+  state: OnboardingSurveyState
+): OnboardingAnswersSnapshot {
+  return [
+    onboardingRoleAnswerPayload(state),
+    onboardingUsageAnswerPayload(state),
+    onboardingPriorityAnswerPayload(state),
+  ].filter(
+    (payload): payload is AnswerOnboardingStepRequest =>
+      payload !== null && payload.step < state.currentStep
+  );
+}
+
+/**
+ * The terminal payload "Submit & Enter Console" fires: the Terminal Snapshot
+ * (submit sits on Step 4, so all three answer steps are confirmed) plus the
+ * optional open goal, trimmed to text or null (an empty submit completes
+ * cleanly).
  */
 export function onboardingCompletePayload(
   state: OnboardingSurveyState
 ): CompleteOnboardingProfileRequest {
   const trimmed = state.openGoalText.trim();
-  return { openGoalText: trimmed === "" ? null : trimmed };
+  return {
+    answers: onboardingAnswersSnapshot(state),
+    openGoalText: trimmed === "" ? null : trimmed,
+  };
 }
 
-/** The terminal dismiss payload Skip fires: the step the survey was on. */
-export function onboardingSkipPayload(state: OnboardingSurveyState): {
-  dismissedAtStep: number;
-} {
-  return { dismissedAtStep: state.currentStep };
+/**
+ * The terminal dismiss payload Skip fires: the step the survey was on, plus
+ * the Terminal Snapshot of the steps confirmed before it. The current step's
+ * unconfirmed selection and any Step 4 draft stay out — Skip declines to
+ * submit them.
+ */
+export function onboardingSkipPayload(
+  state: OnboardingSurveyState
+): DismissOnboardingProfileRequest {
+  return {
+    answers: onboardingAnswersSnapshot(state),
+    dismissedAtStep: state.currentStep,
+  };
 }
 
 /** Narrows the reducer's numeric step to the closed GTM step union. */

--- a/apps/ui/src/features/onboarding/survey-state.ts
+++ b/apps/ui/src/features/onboarding/survey-state.ts
@@ -1,28 +1,90 @@
-import type { AnswerOnboardingStepRequest, OnboardingRoleType } from "./types";
+import {
+  type AnswerOnboardingStepRequest,
+  type CompleteOnboardingProfileRequest,
+  ONBOARDING_PRIORITY_TAGS_MAX,
+  ONBOARDING_SURVEY_TOTAL_STEPS,
+  type OnboardingPriorityTag,
+  type OnboardingRoleType,
+  type OnboardingUsageContext,
+} from "./types";
 
 /**
  * Survey flow state as plain data + pure functions (the spec's pure-reducer
  * seam): thin components render it, so all flow logic is unit-testable
- * without DOM. Step 1 is the real role question; later steps extend the
- * state and actions without changing the shape of the seam.
+ * without DOM. Selections, Other texts, and the Step 3 display order all
+ * live here.
  */
 export interface OnboardingSurveyState {
   /** The real current step, shown by the indicator and sent with Skip. */
   currentStep: number;
+  openGoalText: string;
+  /** The randomized Step 3 option order this session, Other pinned last. */
+  priorityDisplayOrder: OnboardingPriorityTag[];
+  priorityOtherText: string;
+  /** Step 3 picks; array order = click order. */
+  priorityTags: OnboardingPriorityTag[];
   roleOtherText: string;
   roleType: OnboardingRoleType | null;
+  usageContext: OnboardingUsageContext | null;
+  usageOtherText: string;
 }
 
 export type OnboardingSurveyAction =
+  | { text: string; type: "set-open-goal-text" }
+  | { text: string; type: "set-priority-other-text" }
   | { text: string; type: "set-role-other-text" }
+  | { text: string; type: "set-usage-other-text" }
   | { type: "advance-step" }
-  | { role: OnboardingRoleType; type: "toggle-role" };
+  | { role: OnboardingRoleType; type: "toggle-role" }
+  | { tag: OnboardingPriorityTag; type: "toggle-priority" }
+  | { type: "toggle-usage"; usage: OnboardingUsageContext };
 
-export const initialOnboardingSurveyState: OnboardingSurveyState = {
-  currentStep: 1,
-  roleOtherText: "",
-  roleType: null,
-};
+/** The six non-Other Step 3 options — the pool the per-session shuffle draws from. */
+const PRIORITY_TAG_POOL: readonly OnboardingPriorityTag[] = [
+  "ease_of_use",
+  "stability",
+  "low_cost",
+  "performance",
+  "scalability",
+  "fast_launch",
+];
+
+/**
+ * The Step 3 display order: the six non-Other options in a fresh random
+ * order each session (an unbiased draw-without-replacement over the injected
+ * RNG), Other always pinned last. The order is captured with the answer so
+ * position bias in click-order data stays measurable (spec #88).
+ */
+export function onboardingPriorityDisplayOrder(
+  random: () => number = Math.random
+): OnboardingPriorityTag[] {
+  const pool = [...PRIORITY_TAG_POOL];
+  const shuffled: OnboardingPriorityTag[] = [];
+  while (pool.length > 0) {
+    const [tag] = pool.splice(Math.floor(random() * pool.length), 1);
+    if (tag !== undefined) {
+      shuffled.push(tag);
+    }
+  }
+  return [...shuffled, "other"];
+}
+
+/** A fresh session's state; the RNG seam keeps the shuffle testable. */
+export function createInitialOnboardingSurveyState(
+  random: () => number = Math.random
+): OnboardingSurveyState {
+  return {
+    currentStep: 1,
+    openGoalText: "",
+    priorityDisplayOrder: onboardingPriorityDisplayOrder(random),
+    priorityOtherText: "",
+    priorityTags: [],
+    roleOtherText: "",
+    roleType: null,
+    usageContext: null,
+    usageOtherText: "",
+  };
+}
 
 export function onboardingSurveyReducer(
   state: OnboardingSurveyState,
@@ -32,18 +94,44 @@ export function onboardingSurveyReducer(
     case "advance-step":
       // Advancing is always explicit (Next), gated on the current step's
       // answer, and one step at a time; answers already given are kept.
-      return canAdvanceOnboardingStep(state)
+      // Step 4 has no step to advance to — its exit is the terminal submit.
+      return canAdvanceOnboardingStep(state) &&
+        state.currentStep < ONBOARDING_SURVEY_TOTAL_STEPS
         ? { ...state, currentStep: state.currentStep + 1 }
         : state;
+    case "set-open-goal-text":
+      return { ...state, openGoalText: action.text };
+    case "set-priority-other-text":
+      return { ...state, priorityOtherText: action.text };
     case "set-role-other-text":
       return { ...state, roleOtherText: action.text };
+    case "set-usage-other-text":
+      return { ...state, usageOtherText: action.text };
+    case "toggle-priority": {
+      // Step 3 is multi-select capped at 3: unpicking always works, a pick
+      // appends in click order, and a fourth pick is refused outright.
+      if (state.priorityTags.includes(action.tag)) {
+        return {
+          ...state,
+          priorityTags: state.priorityTags.filter((tag) => tag !== action.tag),
+        };
+      }
+      return state.priorityTags.length >= ONBOARDING_PRIORITY_TAGS_MAX
+        ? state
+        : { ...state, priorityTags: [...state.priorityTags, action.tag] };
+    }
     case "toggle-role":
-      // Step 1 is semantically single-select regardless of the checkbox-like
-      // visual: picking an option replaces the previous pick, re-picking it
-      // clears the selection.
+      // Steps 1 and 2 are semantically single-select regardless of the
+      // checkbox-like visual: picking an option replaces the previous pick,
+      // re-picking it clears the selection.
       return {
         ...state,
         roleType: state.roleType === action.role ? null : action.role,
+      };
+    case "toggle-usage":
+      return {
+        ...state,
+        usageContext: state.usageContext === action.usage ? null : action.usage,
       };
     default:
       return state;
@@ -54,16 +142,31 @@ export function onboardingSurveyReducer(
 export function canAdvanceOnboardingStep(
   state: OnboardingSurveyState
 ): boolean {
-  // Per-step gate: Step 1 needs a role; the Step 2 placeholder has nothing
-  // to answer yet, so its gate stays closed until a later ticket opens it.
-  return state.currentStep === 1 && state.roleType !== null;
+  switch (state.currentStep) {
+    case 1:
+      return state.roleType !== null;
+    case 2:
+      return state.usageContext !== null;
+    case 3:
+      return state.priorityTags.length > 0;
+    case 4:
+      // The open goal is optional: submit is never gated.
+      return true;
+    default:
+      return false;
+  }
+}
+
+/** Other is a pair: text only travels with the `other` tag, trimmed. */
+function otherPairText(selected: boolean, text: string): string | null {
+  const trimmed = text.trim();
+  return selected && trimmed !== "" ? trimmed : null;
 }
 
 /**
  * The stepwise write payload Next fires on Step 1, or `null` with nothing
- * selected (Next is disabled then). Other is always a pair: the literal
- * `other` tag plus the trimmed optional text; any other tag carries no text,
- * even when stale Other text is still sitting in the state.
+ * selected (Next is disabled then). Any non-Other tag carries no text, even
+ * when stale Other text is still sitting in the state.
  */
 export function onboardingRoleAnswerPayload(
   state: OnboardingSurveyState
@@ -71,12 +174,64 @@ export function onboardingRoleAnswerPayload(
   if (state.roleType === null) {
     return null;
   }
-  const text = state.roleOtherText.trim();
   return {
-    roleOtherText: state.roleType === "other" && text !== "" ? text : null,
+    roleOtherText: otherPairText(
+      state.roleType === "other",
+      state.roleOtherText
+    ),
     roleType: state.roleType,
     step: 1,
   };
+}
+
+/** The stepwise write payload Next fires on Step 2; same pair rules. */
+export function onboardingUsageAnswerPayload(
+  state: OnboardingSurveyState
+): Extract<AnswerOnboardingStepRequest, { step: 2 }> | null {
+  if (state.usageContext === null) {
+    return null;
+  }
+  return {
+    step: 2,
+    usageContext: state.usageContext,
+    usageOtherText: otherPairText(
+      state.usageContext === "other",
+      state.usageOtherText
+    ),
+  };
+}
+
+/**
+ * The stepwise write payload Next fires on Step 3: picks in click order plus
+ * the display order actually shown; the Other text travels only while Other
+ * is among the picks.
+ */
+export function onboardingPriorityAnswerPayload(
+  state: OnboardingSurveyState
+): Extract<AnswerOnboardingStepRequest, { step: 3 }> | null {
+  if (state.priorityTags.length === 0) {
+    return null;
+  }
+  return {
+    priorityDisplayOrder: [...state.priorityDisplayOrder],
+    priorityOtherText: otherPairText(
+      state.priorityTags.includes("other"),
+      state.priorityOtherText
+    ),
+    priorityTags: [...state.priorityTags],
+    step: 3,
+  };
+}
+
+/**
+ * The terminal payload "Submit & Enter Console" fires: the optional Step 4
+ * open goal, trimmed to text or null (an empty submit completes cleanly).
+ */
+export function onboardingCompletePayload(
+  state: OnboardingSurveyState
+): CompleteOnboardingProfileRequest {
+  const trimmed = state.openGoalText.trim();
+  return { openGoalText: trimmed === "" ? null : trimmed };
 }
 
 /** The terminal dismiss payload Skip fires: the step the survey was on. */

--- a/apps/ui/src/features/onboarding/survey-state.ts
+++ b/apps/ui/src/features/onboarding/survey-state.ts
@@ -1,0 +1,58 @@
+import type { OnboardingRoleType } from "./types";
+
+/**
+ * Survey flow state as plain data + pure functions (the spec's pure-reducer
+ * seam): thin components render it, so all flow logic is unit-testable
+ * without DOM. This tracer bullet carries Step 1 only; later steps extend the
+ * state and actions without changing the shape of the seam.
+ */
+export interface OnboardingSurveyState {
+  /** The real current step, shown by the indicator and sent with Skip. */
+  currentStep: number;
+  roleOtherText: string;
+  roleType: OnboardingRoleType | null;
+}
+
+export type OnboardingSurveyAction =
+  | { text: string; type: "set-role-other-text" }
+  | { role: OnboardingRoleType; type: "toggle-role" };
+
+export const initialOnboardingSurveyState: OnboardingSurveyState = {
+  currentStep: 1,
+  roleOtherText: "",
+  roleType: null,
+};
+
+export function onboardingSurveyReducer(
+  state: OnboardingSurveyState,
+  action: OnboardingSurveyAction
+): OnboardingSurveyState {
+  switch (action.type) {
+    case "set-role-other-text":
+      return { ...state, roleOtherText: action.text };
+    case "toggle-role":
+      // Step 1 is semantically single-select regardless of the checkbox-like
+      // visual: picking an option replaces the previous pick, re-picking it
+      // clears the selection.
+      return {
+        ...state,
+        roleType: state.roleType === action.role ? null : action.role,
+      };
+    default:
+      return state;
+  }
+}
+
+/** Next stays disabled at zero selections; there is no auto-advance anywhere. */
+export function canAdvanceOnboardingStep(
+  state: OnboardingSurveyState
+): boolean {
+  return state.roleType !== null;
+}
+
+/** The terminal dismiss payload Skip fires: the step the survey was on. */
+export function onboardingSkipPayload(state: OnboardingSurveyState): {
+  dismissedAtStep: number;
+} {
+  return { dismissedAtStep: state.currentStep };
+}

--- a/apps/ui/src/features/onboarding/survey-state.ts
+++ b/apps/ui/src/features/onboarding/survey-state.ts
@@ -12,6 +12,7 @@ import {
   type OnboardingPriorityTag,
   type OnboardingRoleType,
   type OnboardingUsageContext,
+  onboardingPriorityTagSchema,
 } from "./types";
 
 /**
@@ -45,15 +46,9 @@ export type OnboardingSurveyAction =
   | { tag: OnboardingPriorityTag; type: "toggle-priority" }
   | { type: "toggle-usage"; usage: OnboardingUsageContext };
 
-/** The six non-Other Step 3 options — the pool the per-session shuffle draws from. */
-const PRIORITY_TAG_POOL: readonly OnboardingPriorityTag[] = [
-  "ease_of_use",
-  "stability",
-  "low_cost",
-  "performance",
-  "scalability",
-  "fast_launch",
-];
+/** The non-Other Step 3 options — the pool the per-session shuffle draws from. */
+const PRIORITY_TAG_POOL: readonly OnboardingPriorityTag[] =
+  onboardingPriorityTagSchema.options.filter((tag) => tag !== "other");
 
 /**
  * The Step 3 display order: the six non-Other options in a fresh random

--- a/apps/ui/src/features/onboarding/survey-state.ts
+++ b/apps/ui/src/features/onboarding/survey-state.ts
@@ -1,9 +1,9 @@
-import type { OnboardingRoleType } from "./types";
+import type { AnswerOnboardingStepRequest, OnboardingRoleType } from "./types";
 
 /**
  * Survey flow state as plain data + pure functions (the spec's pure-reducer
  * seam): thin components render it, so all flow logic is unit-testable
- * without DOM. This tracer bullet carries Step 1 only; later steps extend the
+ * without DOM. Step 1 is the real role question; later steps extend the
  * state and actions without changing the shape of the seam.
  */
 export interface OnboardingSurveyState {
@@ -15,6 +15,7 @@ export interface OnboardingSurveyState {
 
 export type OnboardingSurveyAction =
   | { text: string; type: "set-role-other-text" }
+  | { type: "advance-step" }
   | { role: OnboardingRoleType; type: "toggle-role" };
 
 export const initialOnboardingSurveyState: OnboardingSurveyState = {
@@ -28,6 +29,12 @@ export function onboardingSurveyReducer(
   action: OnboardingSurveyAction
 ): OnboardingSurveyState {
   switch (action.type) {
+    case "advance-step":
+      // Advancing is always explicit (Next), gated on the current step's
+      // answer, and one step at a time; answers already given are kept.
+      return canAdvanceOnboardingStep(state)
+        ? { ...state, currentStep: state.currentStep + 1 }
+        : state;
     case "set-role-other-text":
       return { ...state, roleOtherText: action.text };
     case "toggle-role":
@@ -47,7 +54,29 @@ export function onboardingSurveyReducer(
 export function canAdvanceOnboardingStep(
   state: OnboardingSurveyState
 ): boolean {
-  return state.roleType !== null;
+  // Per-step gate: Step 1 needs a role; the Step 2 placeholder has nothing
+  // to answer yet, so its gate stays closed until a later ticket opens it.
+  return state.currentStep === 1 && state.roleType !== null;
+}
+
+/**
+ * The stepwise write payload Next fires on Step 1, or `null` with nothing
+ * selected (Next is disabled then). Other is always a pair: the literal
+ * `other` tag plus the trimmed optional text; any other tag carries no text,
+ * even when stale Other text is still sitting in the state.
+ */
+export function onboardingRoleAnswerPayload(
+  state: OnboardingSurveyState
+): Extract<AnswerOnboardingStepRequest, { step: 1 }> | null {
+  if (state.roleType === null) {
+    return null;
+  }
+  const text = state.roleOtherText.trim();
+  return {
+    roleOtherText: state.roleType === "other" && text !== "" ? text : null,
+    roleType: state.roleType,
+    step: 1,
+  };
 }
 
 /** The terminal dismiss payload Skip fires: the step the survey was on. */

--- a/apps/ui/src/features/onboarding/survey-state.ts
+++ b/apps/ui/src/features/onboarding/survey-state.ts
@@ -97,6 +97,7 @@ export function onboardingSurveyReducer(
       // answer, and one step at a time; answers already given are kept.
       // Step 4 has no step to advance to — its exit is the terminal submit.
       return canAdvanceOnboardingStep(state) &&
+        !onboardingOtherTextMissing(state) &&
         state.currentStep < ONBOARDING_SURVEY_TOTAL_STEPS
         ? { ...state, currentStep: state.currentStep + 1 }
         : state;
@@ -136,6 +137,33 @@ export function onboardingSurveyReducer(
       };
     default:
       return state;
+  }
+}
+
+/**
+ * A selected Other must carry text before its step can advance. Next stays
+ * clickable while the text is missing — the click surfaces the inline
+ * "This field is required." error instead of advancing (design spec), so
+ * this is a separate predicate from `canAdvanceOnboardingStep`, which drives
+ * the disabled state.
+ */
+export function onboardingOtherTextMissing(
+  state: OnboardingSurveyState
+): boolean {
+  switch (state.currentStep) {
+    case 1:
+      return state.roleType === "other" && state.roleOtherText.trim() === "";
+    case 2:
+      return (
+        state.usageContext === "other" && state.usageOtherText.trim() === ""
+      );
+    case 3:
+      return (
+        state.priorityTags.includes("other") &&
+        state.priorityOtherText.trim() === ""
+      );
+    default:
+      return false;
   }
 }
 

--- a/apps/ui/src/features/onboarding/types.ts
+++ b/apps/ui/src/features/onboarding/types.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 
-import type { OnboardingProfileStatus, OnboardingRoleType } from "./schema";
+import type {
+  OnboardingPriorityTag,
+  OnboardingProfileStatus,
+  OnboardingRoleType,
+  OnboardingUsageContext,
+} from "./schema";
 
 export type {
   OnboardingPriorityTag,
@@ -43,8 +48,37 @@ export const onboardingRoleTypeSchema = z.enum([
   "student",
 ] as const satisfies readonly OnboardingRoleType[]);
 
+/** Step 2 Cohort Tags as the zod boundary (stable machine values, ADR-0061). */
+export const onboardingUsageContextSchema = z.enum([
+  "ai_built_app",
+  "demo_or_prototype",
+  "exploring",
+  "new_product_launch",
+  "other",
+  "real_business",
+  "side_project",
+  "team_or_client",
+] as const satisfies readonly OnboardingUsageContext[]);
+
+/** Step 3 Cohort Tags as the zod boundary (stable machine values, ADR-0061). */
+export const onboardingPriorityTagSchema = z.enum([
+  "ease_of_use",
+  "fast_launch",
+  "low_cost",
+  "other",
+  "performance",
+  "scalability",
+  "stability",
+] as const satisfies readonly OnboardingPriorityTag[]);
+
+/** Step 3 caps the picks at three (spec #88: "Choose up to 3."). */
+export const ONBOARDING_PRIORITY_TAGS_MAX = 3;
+
 /** Sane length bound for every optional Other free text (spec #88). */
 export const ONBOARDING_OTHER_TEXT_MAX_LENGTH = 500;
+
+/** Sane length bound for the Step 4 open goal — an answer, not an essay. */
+export const ONBOARDING_OPEN_GOAL_TEXT_MAX_LENGTH = 2000;
 
 const onboardingOtherTextSchema = z
   .string()
@@ -53,10 +87,20 @@ const onboardingOtherTextSchema = z
   .max(ONBOARDING_OTHER_TEXT_MAX_LENGTH)
   .nullable();
 
+/** Text may only travel with the `other` tag — Other is always a pair. */
+function loosePairIssue(ctx: z.RefinementCtx, path: string) {
+  ctx.addIssue({
+    code: "custom",
+    message: "Other text requires the `other` tag.",
+    path: [path],
+  });
+}
+
 /**
  * The stepwise answer write: one step's answer fields, upserted with
  * `status: in_progress` at the moment the person advances. A discriminated
- * union on `step` — later steps add members without changing the surface.
+ * union on `step` — Step 4's open goal travels on the terminal complete write
+ * instead, because its only advance is the submit itself.
  * Other is always a pair: free text may only travel with the `other` tag.
  */
 export const answerOnboardingStepRequestSchema = z
@@ -66,6 +110,27 @@ export const answerOnboardingStepRequestSchema = z
       roleType: onboardingRoleTypeSchema,
       step: z.literal(1),
     }),
+    z.object({
+      step: z.literal(2),
+      usageContext: onboardingUsageContextSchema,
+      usageOtherText: onboardingOtherTextSchema,
+    }),
+    z.object({
+      /**
+       * The randomized order the options were shown in that session — all
+       * seven tags exactly once, Other always pinned last (spec #88).
+       */
+      priorityDisplayOrder: z
+        .array(onboardingPriorityTagSchema)
+        .length(onboardingPriorityTagSchema.options.length),
+      priorityOtherText: onboardingOtherTextSchema,
+      /** 1-3 distinct tags; array order = click order. */
+      priorityTags: z
+        .array(onboardingPriorityTagSchema)
+        .min(1)
+        .max(ONBOARDING_PRIORITY_TAGS_MAX),
+      step: z.literal(3),
+    }),
   ])
   .superRefine((value, ctx) => {
     if (
@@ -73,11 +138,43 @@ export const answerOnboardingStepRequestSchema = z
       value.roleType !== "other" &&
       value.roleOtherText !== null
     ) {
-      ctx.addIssue({
-        code: "custom",
-        message: "Other text requires the `other` tag.",
-        path: ["roleOtherText"],
-      });
+      loosePairIssue(ctx, "roleOtherText");
+    }
+    if (
+      value.step === 2 &&
+      value.usageContext !== "other" &&
+      value.usageOtherText !== null
+    ) {
+      loosePairIssue(ctx, "usageOtherText");
+    }
+    if (value.step === 3) {
+      if (
+        !value.priorityTags.includes("other") &&
+        value.priorityOtherText !== null
+      ) {
+        loosePairIssue(ctx, "priorityOtherText");
+      }
+      if (new Set(value.priorityTags).size !== value.priorityTags.length) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Priority tags must be distinct.",
+          path: ["priorityTags"],
+        });
+      }
+      // With length pinned to the vocabulary size, distinctness makes the
+      // display order a full permutation; Other must close it.
+      if (
+        new Set(value.priorityDisplayOrder).size !==
+          value.priorityDisplayOrder.length ||
+        value.priorityDisplayOrder.at(-1) !== "other"
+      ) {
+        ctx.addIssue({
+          code: "custom",
+          message:
+            "Display order must show every tag exactly once with `other` last.",
+          path: ["priorityDisplayOrder"],
+        });
+      }
     }
   });
 
@@ -96,6 +193,25 @@ export interface OnboardingProfileWriteState {
 export const dismissOnboardingProfileRequestSchema = z.object({
   dismissedAtStep: onboardingSurveyStepSchema,
 });
+
+/**
+ * The terminal complete write ("Submit & Enter Console"). It carries the
+ * Step 4 open goal because submit is that step's only advance — a separate
+ * fire-and-forget step write could land after the terminal one and lose the
+ * text to terminal-wins. The text is optional: `null` submits cleanly.
+ */
+export const completeOnboardingProfileRequestSchema = z.object({
+  openGoalText: z
+    .string()
+    .trim()
+    .min(1)
+    .max(ONBOARDING_OPEN_GOAL_TEXT_MAX_LENGTH)
+    .nullable(),
+});
+
+export type CompleteOnboardingProfileRequest = z.infer<
+  typeof completeOnboardingProfileRequestSchema
+>;
 
 export type DismissOnboardingProfileRequest = z.infer<
   typeof dismissOnboardingProfileRequestSchema

--- a/apps/ui/src/features/onboarding/types.ts
+++ b/apps/ui/src/features/onboarding/types.ts
@@ -1,19 +1,8 @@
 import { z } from "zod";
 
-import type {
-  OnboardingPriorityTag,
-  OnboardingProfileStatus,
-  OnboardingRoleType,
-  OnboardingUsageContext,
-} from "./schema";
+import type { OnboardingProfileStatus } from "./schema";
 
-export type {
-  OnboardingPriorityTag,
-  OnboardingProfileRow,
-  OnboardingProfileStatus,
-  OnboardingRoleType,
-  OnboardingUsageContext,
-} from "./schema";
+export type { OnboardingProfileRow, OnboardingProfileStatus } from "./schema";
 
 /** The sampling dialog is a 4-step survey; Skip records the step it was on. */
 export const ONBOARDING_SURVEY_TOTAL_STEPS = 4;
@@ -37,7 +26,11 @@ export type OnboardingSamplingVerdict = z.infer<
   typeof onboardingSamplingVerdictSchema
 >;
 
-/** Step 1 Cohort Tags as the zod boundary (stable machine values, ADR-0061). */
+/**
+ * Step 1 Cohort Tags (stable machine values, ADR-0061). The zod enum is the
+ * single source of each vocabulary: the row types and the request boundary
+ * both derive from it, so a new value cannot land in one and not the other.
+ */
 export const onboardingRoleTypeSchema = z.enum([
   "ai_builder",
   "devops_platform_engineer",
@@ -46,9 +39,11 @@ export const onboardingRoleTypeSchema = z.enum([
   "individual_developer",
   "other",
   "student",
-] as const satisfies readonly OnboardingRoleType[]);
+]);
 
-/** Step 2 Cohort Tags as the zod boundary (stable machine values, ADR-0061). */
+export type OnboardingRoleType = z.infer<typeof onboardingRoleTypeSchema>;
+
+/** Step 2 Cohort Tags (stable machine values, ADR-0061). */
 export const onboardingUsageContextSchema = z.enum([
   "ai_built_app",
   "demo_or_prototype",
@@ -58,9 +53,13 @@ export const onboardingUsageContextSchema = z.enum([
   "real_business",
   "side_project",
   "team_or_client",
-] as const satisfies readonly OnboardingUsageContext[]);
+]);
 
-/** Step 3 Cohort Tags as the zod boundary (stable machine values, ADR-0061). */
+export type OnboardingUsageContext = z.infer<
+  typeof onboardingUsageContextSchema
+>;
+
+/** Step 3 Cohort Tags (stable machine values, ADR-0061). */
 export const onboardingPriorityTagSchema = z.enum([
   "ease_of_use",
   "fast_launch",
@@ -69,7 +68,9 @@ export const onboardingPriorityTagSchema = z.enum([
   "performance",
   "scalability",
   "stability",
-] as const satisfies readonly OnboardingPriorityTag[]);
+]);
+
+export type OnboardingPriorityTag = z.infer<typeof onboardingPriorityTagSchema>;
 
 /** Step 3 caps the picks at three (spec #88: "Choose up to 3."). */
 export const ONBOARDING_PRIORITY_TAGS_MAX = 3;

--- a/apps/ui/src/features/onboarding/types.ts
+++ b/apps/ui/src/features/onboarding/types.ts
@@ -191,17 +191,48 @@ export interface OnboardingProfileWriteState {
   status: OnboardingProfileStatus;
 }
 
+/**
+ * The Terminal Snapshot: the answers of every step the session confirmed
+ * (advanced past with Next), carried on the terminal write itself. The
+ * stepwise writes are fire-and-forget and may silently fail, so the terminal
+ * write cannot rely on them having landed — a Sampled row must be complete
+ * on the strength of this one request. Steps absent from the snapshot are
+ * left untouched by the store, so an earlier session's persisted partials
+ * survive a snapshot that never re-answered them.
+ */
+export const onboardingAnswersSnapshotSchema = z
+  .array(answerOnboardingStepRequestSchema)
+  .max(ONBOARDING_SURVEY_TOTAL_STEPS - 1)
+  .superRefine((answers, ctx) => {
+    if (new Set(answers.map((answer) => answer.step)).size !== answers.length) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Snapshot steps must be distinct.",
+      });
+    }
+  });
+
+export type OnboardingAnswersSnapshot = z.infer<
+  typeof onboardingAnswersSnapshotSchema
+>;
+
 export const dismissOnboardingProfileRequestSchema = z.object({
+  // Defaulted for one deploy's grace: a terminal write from a client built
+  // before the snapshot existed lands as an empty snapshot — exactly the
+  // pre-snapshot behavior — instead of being refused. The inferred request
+  // type still requires it, so no current client can forget it.
+  answers: onboardingAnswersSnapshotSchema.default([]),
   dismissedAtStep: onboardingSurveyStepSchema,
 });
 
 /**
- * The terminal complete write ("Submit & Enter Console"). It carries the
- * Step 4 open goal because submit is that step's only advance — a separate
- * fire-and-forget step write could land after the terminal one and lose the
- * text to terminal-wins. The text is optional: `null` submits cleanly.
+ * The terminal complete write ("Submit & Enter Console"): the Terminal
+ * Snapshot plus the Step 4 open goal, which travels here because submit is
+ * that step's only advance. The text is optional: `null` submits cleanly.
  */
 export const completeOnboardingProfileRequestSchema = z.object({
+  // Same one-deploy grace as dismiss: absent means an empty snapshot.
+  answers: onboardingAnswersSnapshotSchema.default([]),
   openGoalText: z
     .string()
     .trim()

--- a/apps/ui/src/features/onboarding/types.ts
+++ b/apps/ui/src/features/onboarding/types.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+export type {
+  OnboardingPriorityTag,
+  OnboardingProfileRow,
+  OnboardingProfileStatus,
+  OnboardingRoleType,
+  OnboardingUsageContext,
+} from "./schema";
+
+/** The sampling dialog is a 4-step survey; Skip records the step it was on. */
+export const ONBOARDING_SURVEY_TOTAL_STEPS = 4;
+
+export const onboardingSurveyStepSchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(ONBOARDING_SURVEY_TOTAL_STEPS);
+
+/**
+ * The sampling predicate's whole response (ADR-0061): `sampled: true` when a
+ * terminal profile row exists. Nothing else is exposed — the client never
+ * needs the stored answers.
+ */
+export const onboardingSamplingVerdictSchema = z.object({
+  sampled: z.boolean(),
+});
+
+export type OnboardingSamplingVerdict = z.infer<
+  typeof onboardingSamplingVerdictSchema
+>;
+
+export const dismissOnboardingProfileRequestSchema = z.object({
+  dismissedAtStep: onboardingSurveyStepSchema,
+});
+
+export type DismissOnboardingProfileRequest = z.infer<
+  typeof dismissOnboardingProfileRequestSchema
+>;
+
+/**
+ * The state a terminal write settles on. Terminal wins: when the row was
+ * already `completed` or `dismissed`, the write is a no-op and this reports
+ * the pre-existing state.
+ */
+export interface OnboardingProfileTerminalState {
+  dismissedAtStep: number | null;
+  status: "completed" | "dismissed";
+}

--- a/apps/ui/src/features/onboarding/types.ts
+++ b/apps/ui/src/features/onboarding/types.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import type { OnboardingProfileStatus, OnboardingRoleType } from "./schema";
+
 export type {
   OnboardingPriorityTag,
   OnboardingProfileRow,
@@ -29,6 +31,67 @@ export const onboardingSamplingVerdictSchema = z.object({
 export type OnboardingSamplingVerdict = z.infer<
   typeof onboardingSamplingVerdictSchema
 >;
+
+/** Step 1 Cohort Tags as the zod boundary (stable machine values, ADR-0061). */
+export const onboardingRoleTypeSchema = z.enum([
+  "ai_builder",
+  "devops_platform_engineer",
+  "engineering_team_member",
+  "founder",
+  "individual_developer",
+  "other",
+  "student",
+] as const satisfies readonly OnboardingRoleType[]);
+
+/** Sane length bound for every optional Other free text (spec #88). */
+export const ONBOARDING_OTHER_TEXT_MAX_LENGTH = 500;
+
+const onboardingOtherTextSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(ONBOARDING_OTHER_TEXT_MAX_LENGTH)
+  .nullable();
+
+/**
+ * The stepwise answer write: one step's answer fields, upserted with
+ * `status: in_progress` at the moment the person advances. A discriminated
+ * union on `step` — later steps add members without changing the surface.
+ * Other is always a pair: free text may only travel with the `other` tag.
+ */
+export const answerOnboardingStepRequestSchema = z
+  .discriminatedUnion("step", [
+    z.object({
+      roleOtherText: onboardingOtherTextSchema,
+      roleType: onboardingRoleTypeSchema,
+      step: z.literal(1),
+    }),
+  ])
+  .superRefine((value, ctx) => {
+    if (
+      value.step === 1 &&
+      value.roleType !== "other" &&
+      value.roleOtherText !== null
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Other text requires the `other` tag.",
+        path: ["roleOtherText"],
+      });
+    }
+  });
+
+export type AnswerOnboardingStepRequest = z.infer<
+  typeof answerOnboardingStepRequestSchema
+>;
+
+/**
+ * The state a stepwise write settles on: `in_progress` after a live upsert,
+ * or the pre-existing terminal status when terminal-wins made it a no-op.
+ */
+export interface OnboardingProfileWriteState {
+  status: OnboardingProfileStatus;
+}
 
 export const dismissOnboardingProfileRequestSchema = z.object({
   dismissedAtStep: onboardingSurveyStepSchema,

--- a/apps/ui/src/lib/identity-fingerprint-core.test.ts
+++ b/apps/ui/src/lib/identity-fingerprint-core.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { PGlite } from "@electric-sql/pglite";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { migrate } from "drizzle-orm/pglite/migrator";
 
@@ -17,6 +17,7 @@ import {
   githubOauthConnections,
   identityFingerprints,
 } from "@/features/chat/persistence/schema";
+import { onboardingProfiles } from "@/features/onboarding/schema";
 
 import {
   createIdentityFingerprintStore,
@@ -375,6 +376,116 @@ test("a merge re-keys pending current-generation authorization sessions and leav
       workspaceActor: "session-cr",
     },
   ]);
+});
+
+function selectProfiles(userUids: string[]) {
+  return db
+    .select({
+      dismissedAtStep: onboardingProfiles.dismissedAtStep,
+      roleType: onboardingProfiles.roleType,
+      status: onboardingProfiles.status,
+      updatedAt: onboardingProfiles.updatedAt,
+      userUid: onboardingProfiles.userUid,
+    })
+    .from(onboardingProfiles)
+    .where(inArray(onboardingProfiles.userUid, userUids))
+    .orderBy(onboardingProfiles.userUid);
+}
+
+async function observeCapturingTelemetry(
+  binding: Parameters<typeof observe>[0]
+): Promise<Record<string, unknown> | undefined> {
+  const infoCalls: unknown[][] = [];
+  const originalInfo = console.info;
+  console.info = (...args: unknown[]) => {
+    infoCalls.push(args);
+  };
+  try {
+    assert.deepEqual(await observe(binding), { outcome: "merge" });
+  } finally {
+    console.info = originalInfo;
+  }
+  return infoCalls.find(
+    (args) =>
+      args[0] === "[telemetry] account merge re-keyed personal resources"
+  )?.[1] as Record<string, unknown> | undefined;
+}
+
+test("a merge re-keys the tombstone's onboarding profile when the survivor holds none", async () => {
+  // ADR-0061: the profile is keyed by the bare uid, and updatedAt doubles as
+  // the terminal timestamp — a re-key must not touch it.
+  const terminalUpdatedAt = new Date("2026-06-20T08:00:00Z");
+  await observe({
+    crName: "profile-cr",
+    mintedAt: 7000,
+    userUid: "profile-tombstone-uid",
+  });
+  await db.insert(onboardingProfiles).values({
+    dismissedAtStep: 2,
+    roleType: "founder",
+    status: "dismissed",
+    updatedAt: terminalUpdatedAt,
+    userUid: "profile-tombstone-uid",
+  });
+
+  const telemetry = await observeCapturingTelemetry({
+    crName: "profile-cr",
+    mintedAt: 8000,
+    userUid: "profile-survivor-uid",
+  });
+
+  assert.deepEqual(
+    await selectProfiles(["profile-tombstone-uid", "profile-survivor-uid"]),
+    [
+      {
+        dismissedAtStep: 2,
+        roleType: "founder",
+        status: "dismissed",
+        updatedAt: terminalUpdatedAt,
+        userUid: "profile-survivor-uid",
+      },
+    ]
+  );
+  assert.equal(telemetry?.profilesRekeyed, 1);
+  assert.equal(telemetry?.profilesReleased, 0);
+});
+
+test("where both merged accounts hold a profile, the survivor's row wins and the tombstone's is deleted", async () => {
+  await observe({
+    crName: "profile-both-cr",
+    mintedAt: 9000,
+    userUid: "both-tombstone-uid",
+  });
+  await db.insert(onboardingProfiles).values([
+    { status: "completed", userUid: "both-tombstone-uid" },
+    {
+      dismissedAtStep: 1,
+      status: "dismissed",
+      updatedAt: new Date("2026-06-21T09:00:00Z"),
+      userUid: "both-survivor-uid",
+    },
+  ]);
+
+  const telemetry = await observeCapturingTelemetry({
+    crName: "profile-both-cr",
+    mintedAt: 9500,
+    userUid: "both-survivor-uid",
+  });
+
+  assert.deepEqual(
+    await selectProfiles(["both-tombstone-uid", "both-survivor-uid"]),
+    [
+      {
+        dismissedAtStep: 1,
+        roleType: null,
+        status: "dismissed",
+        updatedAt: new Date("2026-06-21T09:00:00Z"),
+        userUid: "both-survivor-uid",
+      },
+    ]
+  );
+  assert.equal(telemetry?.profilesRekeyed, 0);
+  assert.equal(telemetry?.profilesReleased, 1);
 });
 
 test("a write-transaction re-check passes only while the binding is current", async () => {

--- a/apps/ui/src/lib/identity-fingerprint-core.test.ts
+++ b/apps/ui/src/lib/identity-fingerprint-core.test.ts
@@ -378,15 +378,10 @@ test("a merge re-keys pending current-generation authorization sessions and leav
   ]);
 });
 
+// Full rows, so any field-level answer merging shows up in the deepEqual.
 function selectProfiles(userUids: string[]) {
   return db
-    .select({
-      dismissedAtStep: onboardingProfiles.dismissedAtStep,
-      roleType: onboardingProfiles.roleType,
-      status: onboardingProfiles.status,
-      updatedAt: onboardingProfiles.updatedAt,
-      userUid: onboardingProfiles.userUid,
-    })
+    .select()
     .from(onboardingProfiles)
     .where(inArray(onboardingProfiles.userUid, userUids))
     .orderBy(onboardingProfiles.userUid);
@@ -420,7 +415,9 @@ test("a merge re-keys the tombstone's onboarding profile when the survivor holds
     mintedAt: 7000,
     userUid: "profile-tombstone-uid",
   });
+  const tombstoneCreatedAt = new Date("2026-06-20T07:00:00Z");
   await db.insert(onboardingProfiles).values({
+    createdAt: tombstoneCreatedAt,
     dismissedAtStep: 2,
     roleType: "founder",
     status: "dismissed",
@@ -434,14 +431,23 @@ test("a merge re-keys the tombstone's onboarding profile when the survivor holds
     userUid: "profile-survivor-uid",
   });
 
+  // Only the key moved: every other column, answered or not, is verbatim.
   assert.deepEqual(
     await selectProfiles(["profile-tombstone-uid", "profile-survivor-uid"]),
     [
       {
+        createdAt: tombstoneCreatedAt,
         dismissedAtStep: 2,
+        openGoalText: null,
+        priorityDisplayOrder: null,
+        priorityOtherText: null,
+        priorityTags: null,
+        roleOtherText: null,
         roleType: "founder",
         status: "dismissed",
         updatedAt: terminalUpdatedAt,
+        usageContext: null,
+        usageOtherText: null,
         userUid: "profile-survivor-uid",
       },
     ]
@@ -456,12 +462,27 @@ test("where both merged accounts hold a profile, the survivor's row wins and the
     mintedAt: 9000,
     userUid: "both-tombstone-uid",
   });
+  // The tombstone answered everything; the survivor answered nothing. Any
+  // field-level merging would surface as a non-null answer column below.
+  const survivorTouchedAt = new Date("2026-06-21T09:00:00Z");
   await db.insert(onboardingProfiles).values([
-    { status: "completed", userUid: "both-tombstone-uid" },
     {
+      openGoalText: "migrate the studio's client apps",
+      priorityDisplayOrder: ["low_cost", "stability", "other"],
+      priorityOtherText: "compliance",
+      priorityTags: ["stability", "other"],
+      roleOtherText: "agency owner",
+      roleType: "other",
+      status: "completed",
+      usageContext: "team_or_client",
+      usageOtherText: "client work",
+      userUid: "both-tombstone-uid",
+    },
+    {
+      createdAt: survivorTouchedAt,
       dismissedAtStep: 1,
       status: "dismissed",
-      updatedAt: new Date("2026-06-21T09:00:00Z"),
+      updatedAt: survivorTouchedAt,
       userUid: "both-survivor-uid",
     },
   ]);
@@ -476,10 +497,18 @@ test("where both merged accounts hold a profile, the survivor's row wins and the
     await selectProfiles(["both-tombstone-uid", "both-survivor-uid"]),
     [
       {
+        createdAt: survivorTouchedAt,
         dismissedAtStep: 1,
+        openGoalText: null,
+        priorityDisplayOrder: null,
+        priorityOtherText: null,
+        priorityTags: null,
+        roleOtherText: null,
         roleType: null,
         status: "dismissed",
-        updatedAt: new Date("2026-06-21T09:00:00Z"),
+        updatedAt: survivorTouchedAt,
+        usageContext: null,
+        usageOtherText: null,
         userUid: "both-survivor-uid",
       },
     ]

--- a/apps/ui/src/lib/identity-fingerprint-core.ts
+++ b/apps/ui/src/lib/identity-fingerprint-core.ts
@@ -12,6 +12,7 @@ import {
   identityFingerprints,
 } from "@/features/chat/persistence/schema";
 import { CURRENT_GITHUB_OWNER_IDENTITY_VERSION } from "@/features/deploy/github/owner-identity";
+import { onboardingProfiles } from "@/features/onboarding/schema";
 
 /**
  * Identity Fingerprints (ADR-0059): the authorization layer's region-local
@@ -216,6 +217,8 @@ async function rekeyPersonalResources(
   connectionsRekeyed: number;
   conversations: number;
   installSessionsRekeyed: number;
+  profilesReleased: number;
+  profilesRekeyed: number;
 }> {
   // Pending authorization sessions are swept BEFORE connections: the OAuth
   // callback consumes its session row under a row lock and writes the
@@ -289,10 +292,38 @@ async function rekeyPersonalResources(
     .where(tombstoneConnectionWhere)
     .returning({ id: githubOauthConnections.id });
 
+  // The Onboarding Profile is keyed by the bare uid alone (ADR-0061): the
+  // tombstone's row follows the survivor only where the survivor holds none;
+  // otherwise the survivor's row is authoritative and the tombstone's is
+  // deleted — one row per person, no answer-level merging. `updatedAt`
+  // doubles as the terminal timestamp, so a re-key never touches it.
+  const survivorProfiles = alias(onboardingProfiles, "survivor_profiles");
+  const rekeyedProfiles = await tx
+    .update(onboardingProfiles)
+    .set({ userUid: input.survivorUserUid })
+    .where(
+      and(
+        eq(onboardingProfiles.userUid, input.tombstoneUserUid),
+        notExists(
+          tx
+            .select({ userUid: survivorProfiles.userUid })
+            .from(survivorProfiles)
+            .where(eq(survivorProfiles.userUid, input.survivorUserUid))
+        )
+      )
+    )
+    .returning({ userUid: onboardingProfiles.userUid });
+  const releasedProfiles = await tx
+    .delete(onboardingProfiles)
+    .where(eq(onboardingProfiles.userUid, input.tombstoneUserUid))
+    .returning({ userUid: onboardingProfiles.userUid });
+
   return {
     connectionsReleased: releasedConnections.length,
     connectionsRekeyed: rekeyedConnections.length,
     conversations: conversations.length,
     installSessionsRekeyed: rekeyedInstallSessions.length,
+    profilesReleased: releasedProfiles.length,
+    profilesRekeyed: rekeyedProfiles.length,
   };
 }

--- a/apps/ui/src/lib/personal-resource-http.ts
+++ b/apps/ui/src/lib/personal-resource-http.ts
@@ -1,0 +1,90 @@
+import {
+  type AppTokenVerificationConfig,
+  appTokenFromRequest,
+} from "./app-token";
+import {
+  IdentityBindingSupersededError,
+  type ObserveIdentityFingerprint,
+} from "./identity-fingerprint-core";
+import {
+  authorizeWorkspaceActor,
+  encodedKubeconfigFromRequest,
+  type VerifyKubeconfigNamespace,
+} from "./request-kubeconfig-auth";
+import type { VerifiedWorkspaceActorAuthorization } from "./verified-personal-actor";
+
+/**
+ * Shared HTTP surface for personal-resource route handlers — the server-side
+ * counterpart of `personal-resource-headers.ts`. Every personal-resource
+ * feature (onboarding profile, assistant conversations, GitHub connections)
+ * answers failures with the same `{ code, error }` envelope and enters
+ * through the same workspace-actor authorization step.
+ */
+
+export function jsonError(input: {
+  code: string;
+  message: string;
+  status: number;
+}): Response {
+  return Response.json(
+    { code: input.code, error: input.message },
+    { status: input.status }
+  );
+}
+
+/** The write found the binding superseded by a concurrent merge (ADR-0059). */
+export function supersededBindingResponse(error: unknown): Response | null {
+  return error instanceof IdentityBindingSupersededError
+    ? jsonError({
+        code: "app_token_superseded",
+        message: "Authentication is required.",
+        status: 401,
+      })
+    : null;
+}
+
+export interface PersonalResourceAuthorizationOptions {
+  /** Test seam; defaults to `JWT_INTERNAL` from the env. */
+  appTokenConfig?: AppTokenVerificationConfig | null;
+  normalizeNamespace?: (namespace: string) => string;
+  /** Test seam; defaults to the region-local Identity Fingerprint store. */
+  observeFingerprint?: ObserveIdentityFingerprint;
+  verify?: VerifyKubeconfigNamespace;
+}
+
+/**
+ * Authorizes one personal-resource request through the workspace-actor choke
+ * point, reading credentials and the expected `namespace` query parameter
+ * from the request. A failure arrives already mapped onto the shared error
+ * envelope; callers only map the verified authorization onto their own actor
+ * shape.
+ */
+export async function authorizePersonalResourceRequest(
+  request: Request,
+  options: PersonalResourceAuthorizationOptions
+): Promise<
+  | { authorization: VerifiedWorkspaceActorAuthorization; ok: true }
+  | { ok: false; response: Response }
+> {
+  const clientNamespace = new URL(request.url).searchParams.get("namespace");
+  const authorization = await authorizeWorkspaceActor({
+    appToken: appTokenFromRequest(request),
+    appTokenConfig: options.appTokenConfig,
+    encodedKubeconfig: encodedKubeconfigFromRequest(request),
+    expectedNamespace: clientNamespace?.trim() || undefined,
+    normalizeNamespace: options.normalizeNamespace,
+    observeFingerprint: options.observeFingerprint,
+    verify: options.verify,
+  });
+  if (!authorization.ok) {
+    return {
+      ok: false,
+      response: jsonError({
+        code: authorization.code,
+        message: authorization.message,
+        status: authorization.status,
+      }),
+    };
+  }
+  return { authorization, ok: true };
+}

--- a/docs/adr/0061-key-the-onboarding-profile-by-bare-user-uid.md
+++ b/docs/adr/0061-key-the-onboarding-profile-by-bare-user-uid.md
@@ -1,0 +1,90 @@
+# Key the Onboarding Profile by the Bare User UID
+
+The first-entry sampling dialog (the user understanding loop) captures an
+Onboarding Profile: who the person is, what they came to do, which factors
+matter to them. The profile is semantically "this person", not "this person
+in this workspace", yet every existing personal resource is keyed by
+`(namespace, userUid)` (ADR-0059). The profile becomes Brain's first
+namespace-less personal resource, so its key, its sampling predicate, its
+authorization path, and its account-merge behavior are fixed here.
+
+## Decision
+
+### Key the profile by the bare userUid
+
+An Onboarding Profile is owned by `userUid` alone — one row per person; the
+workspace namespace never enters the key. Brain's database is region-local,
+so the practical semantic is one profile per person per region: the same
+person entering Brain in a second region is sampled again. Cross-region
+deduplication is consciously not built; cohort data is per-region and its
+consumers must read it that way.
+
+The key answers the workspace questions by construction: a member invited
+into someone else's workspace is sampled on their own first entry — once per
+person — and creating or switching workspaces never re-triggers the dialog.
+
+### Judge sampling by state, not by a login event
+
+Brain has no login page, so "first login" is not an event it can observe.
+The dialog trigger is a state predicate instead: a verified Workspace Actor
+whose `userUid` has no terminal profile record in this region — no
+`completed` and no `dismissed` row — is Unsampled, and the dialog shows.
+The predicate is re-evaluated on every entry until a terminal record lands.
+Completing the survey or skipping it (Skip writes `dismissed`, per the
+Skip-semantics decision) is terminal and permanently ends the dialog;
+abandoning the tab mid-survey leaves stepwise-persisted answers but no
+terminal record, so the person is re-judged — and re-shown — on next entry.
+Never-again is enforced by the database row, not by browser state.
+
+### Reuse the personal-resource authorization path unchanged
+
+The sampling predicate query and every profile write travel the existing
+verified-personal-actor choke point — app-token signature verification,
+kubeconfig crName cross-check, namespace SSAR — even though the namespace
+does not enter the profile key. No lighter uid-only path is added: a second
+authorization surface would need its own fail-closed argument, and the
+choke point's in-transaction Identity Fingerprint re-check is required for
+profile writes anyway. Authorization failure fails closed: no dialog, no
+blocked console entry, re-judged on the next entry.
+
+### Join the merge sweep; the survivor wins
+
+The account-merge re-key sweep (ADR-0059) covers the profile table from day
+one. A tombstone-keyed profile row is re-keyed to the surviving uid when the
+survivor holds none; when both merged accounts hold a profile, the
+survivor's row is authoritative and the tombstone's row is deleted, keeping
+cohort statistics one-row-per-person. No answer-level merging is attempted.
+Unlike the GitHub Connection precedent, this delete destroys no credential —
+at worst a re-sampleable survey response.
+
+### crName never enters the profile
+
+The profile table is greenfield: rows are uid-keyed from the first insert
+and there is no legacy adoption path. The per-region `crName` is never
+stored — the direct extension of ADR-0059's rule that per-region
+identifiers must not enter globally keyed rows.
+
+## Considered Options
+
+- Key by `(namespace, userUid)` like every other personal resource:
+  rejected. The profile would re-trigger per workspace, contradicting the
+  product semantic of sampling a person once; invited members and workspace
+  switchers are exactly the cases a namespace key gets wrong.
+- A lighter uid-only authorization path (skip the namespace SSAR): rejected.
+  The dialog appears only inside a workspace surface, so the SSAR always
+  passes and skipping it saves nothing real, while a second path would
+  duplicate the fail-closed and merge-guard machinery.
+- Merge answer content when both merged accounts hold a profile: rejected.
+  Beta merge volume is near zero and the loss is one re-sampleable
+  three-question response; content merging buys complexity, not data.
+
+## Consequences
+
+The Onboarding Profile is Brain's first namespace-less personal resource and
+the precedent for any future one. Cohort data is per-region; operators
+reading it must not assume platform-global uniqueness of a person. The
+sampling dialog's never-again promise is exactly as durable as the profile
+row.
+
+This decision supplements ADR-0059 — its key model, trust source, and
+Identity Fingerprint machinery are reused unchanged — and revises nothing.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ One line per decision; the linked record is authoritative. When adding an ADR, t
 - [0057 — Forget GitHub Connections Locally on Disconnect](0057-forget-github-connections-locally-on-disconnect.md)
 - [0058 — Derive Project Display Names from Deployment Sources at Creation](0058-derive-project-display-names-from-deployment-sources.md)
 - [0059 — Key Personal Resources by the Global User UID](0059-key-personal-resources-by-global-user-uid.md) *(revises ADR-0036, ADR-0047, and ADR-0056)*
+- [0061 — Key the Onboarding Profile by the Bare User UID](0061-key-the-onboarding-profile-by-bare-user-uid.md) *(supplements ADR-0059)*
 
 ## Conventions
 

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -48,6 +48,7 @@
   --color-brand-primary-foreground: var(--sealai-brand-primary-foreground);
   --color-brand-primary: var(--sealai-brand-primary);
   --color-project-chrome-surface: var(--project-chrome-surface);
+  --color-onboarding-heading-accent: var(--onboarding-heading-accent);
   --color-db-access-sticky-header-surface: var(
     --db-access-sticky-header-surface
   );
@@ -125,6 +126,14 @@
     color-mix(in oklab, var(--input) 30%, transparent),
     color-mix(in oklab, var(--input) 30%, transparent)
   );
+  /** Onboarding survey dialog tokens (Figma Brain V2.0 onboarding). */
+  --onboarding-survey-surface-overlay: linear-gradient(
+    -30deg,
+    rgb(10 163 249 / 12%) 8.73%,
+    rgb(181 180 255 / 12%) 78.53%
+  );
+  --onboarding-heading-accent: #146dff;
+
   --project-surface-motion-duration: var(
     --project-surface-motion-enter-duration
   );


### PR DESCRIPTION
## Summary

Adds the onboarding survey feature to the UI app: a multi-step survey dialog gated on first entry, with a persisted per-user onboarding profile.

- **Onboarding dialog & gate** — new `features/onboarding` module: survey state machine (`survey-state.ts`), gate logic that decides when to show the dialog, and the dialog itself styled to the Brain V2.0 design (ring-radio selection, sRGB gradient ramps, grouped step rhythm, morphing "Other" input with focus handling).
- **Profile persistence** — `onboarding_profiles` table (drizzle migration 0011) keyed by bare user uid (see new ADR), with HTTP handlers/routes for `step`, `complete`, `dismiss`, and `sampling`. Step 1 persists the role answer stepwise; Steps 2–4 complete the survey into a terminal `completed` profile; Skip writes a terminal `dismissed` profile. Merge sweep never merges answers across profile rows (pinned by test).
- **Analytics** — three structure-only GTM funnel events in `brain-gtm.ts`.
- **Shared plumbing** — extracted a shared personal-resource HTTP surface (`personal-resource-http.ts`) reused by the GitHub connection handlers; identity fingerprint core extended for profile keying.
- **Dev tweaks** — pane now portals above dialog layers so it stays usable while the onboarding dialog is open.
- **Docs** — ADR "key the onboarding profile by bare user uid" + CONTEXT.md updates.

## Test plan

- [x] Unit/integration tests added: `onboarding-dialog.test.tsx`, `profile-http-handlers.test.ts`, `survey-state.test.ts`, `onboarding-gate-core.test.ts`, plus updated identity-fingerprint and dev-tweaks tests
- [x] `bun typecheck` / `bun check` clean on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)