### PR TITLE
fix(ui): show pod workspace quota

### DIFF
--- a/apps/ui/src/features/shell/app-sidebar-upgrade.test.ts
+++ b/apps/ui/src/features/shell/app-sidebar-upgrade.test.ts
@@ -11,6 +11,7 @@ test("formatWorkspaceQuotaRows maps Sealos quota items to sidebar rows", () => {
     { limit: 16_000, type: "cpu", used: 500 },
     { limit: 65_536, type: "memory", used: 1024 },
     { limit: 204_800, type: "storage", used: 3072 },
+    { limit: 20, type: "pod", used: 3 },
     { limit: 10, type: "nodeport", used: 0 },
   ];
 
@@ -18,6 +19,7 @@ test("formatWorkspaceQuotaRows maps Sealos quota items to sidebar rows", () => {
     ["CPU", "0.5C/16C"],
     ["Memory", "1Gi/64Gi"],
     ["Storage", "3Gi/200Gi"],
+    ["Pods", "3/20"],
     ["Ports", "0/10"],
   ]);
 });
@@ -29,6 +31,7 @@ test("formatWorkspaceQuotaRows keeps stable rows for missing quota items", () =>
       ["CPU", "1C/2C"],
       ["Memory", "--/--"],
       ["Storage", "--/--"],
+      ["Pods", "--/--"],
       ["Ports", "--/--"],
     ]
   );

--- a/apps/ui/src/features/shell/app-sidebar-upgrade.ts
+++ b/apps/ui/src/features/shell/app-sidebar-upgrade.ts
@@ -2,7 +2,7 @@ import { BinaryScale, Quantity, Scale } from "@workspace/shared";
 
 export interface WorkspaceQuotaItem {
   limit: number;
-  type: "cpu" | "memory" | "nodeport" | "storage";
+  type: "cpu" | "memory" | "nodeport" | "pod" | "storage";
   used: number;
 }
 
@@ -12,6 +12,7 @@ const WORKSPACE_QUOTA_ROW_DEFINITIONS = [
   { label: "CPU", type: "cpu" },
   { label: "Memory", type: "memory" },
   { label: "Storage", type: "storage" },
+  { label: "Pods", type: "pod" },
   { label: "Ports", type: "nodeport" },
 ] as const;
 
@@ -67,6 +68,7 @@ function formatQuotaValue(item: WorkspaceQuotaItem) {
         item.used
       )}/${formatBinaryQuotaNumberFromMi(item.limit)}`;
     case "nodeport":
+    case "pod":
       return `${formatPortQuotaNumber(item.used)}/${formatPortQuotaNumber(
         item.limit
       )}`;

--- a/apps/ui/src/features/shell/app-sidebar.tsx
+++ b/apps/ui/src/features/shell/app-sidebar.tsx
@@ -131,6 +131,7 @@ function isWorkspaceQuotaItem(value: unknown): value is WorkspaceQuotaItem {
     (item.type === "cpu" ||
       item.type === "memory" ||
       item.type === "storage" ||
+      item.type === "pod" ||
       item.type === "nodeport") &&
     typeof item.used === "number" &&
     typeof item.limit === "number"
@@ -139,11 +140,10 @@ function isWorkspaceQuotaItem(value: unknown): value is WorkspaceQuotaItem {
 
 async function loadWorkspaceQuotaRows(): Promise<AppSidebarUpgradeUsageRow[]> {
   const snapshot = await sealosApp.getWorkspaceQuota();
-  return formatWorkspaceQuotaRows(
-    Array.isArray(snapshot.quota)
-      ? snapshot.quota.filter(isWorkspaceQuotaItem)
-      : []
-  );
+  const rawQuota: readonly unknown[] = Array.isArray(snapshot.quota)
+    ? snapshot.quota
+    : [];
+  return formatWorkspaceQuotaRows(rawQuota.filter(isWorkspaceQuotaItem));
 }
 
 async function openCostCenterApp() {


### PR DESCRIPTION
## Summary

- accept the Desktop SDK `pod` workspace quota item at runtime
- display pod usage and limits in the sidebar upgrade panel
- preserve compatibility with SDK versions whose TypeScript union does not yet include `pod`

## Why

User quota CRDs already contain pod limits, but the Desktop quota API and the brain quota formatter did not expose and render them end to end.

## Validation

- focused quota formatter tests: 7/7
- `bun typecheck`
- `bun check`

## Related change

The corresponding Sealos Desktop PR exposes the `pod` quota item from Kubernetes ResourceQuota. Its link will be added here after both PRs are created.