### PR TITLE
feat(onboarding): stacked option cards and stable frame height

### DIFF
--- a/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.test.tsx
@@ -27,8 +27,34 @@ const STEP_THREE_SUBTITLE_RE = /Choose up to 3\./;
 const STEP_FOUR_TITLE_RE = /Anything specific you're trying to achieve\?/;
 const OTHER_REQUIRED_RE = /This field is required\./;
 
+/**
+ * All four step panels stay mounted (stacked for frame-height stability),
+ * with inactive ones marked inert. The helpers scope every query and text
+ * assertion to reachable content — what a user could actually see or focus.
+ */
+function isReachable(element: Element): boolean {
+  return element.closest("[inert]") === null;
+}
+
 function bodyButtons(): HTMLButtonElement[] {
-  return [...document.querySelectorAll("button")] as HTMLButtonElement[];
+  return (
+    [...document.querySelectorAll("button")] as HTMLButtonElement[]
+  ).filter(isReachable);
+}
+
+function reachableInput(): HTMLInputElement | null {
+  const input = (
+    [...document.querySelectorAll("input")] as HTMLInputElement[]
+  ).find(isReachable);
+  return input ?? null;
+}
+
+function reachableText(): string {
+  const clone = document.body.cloneNode(true) as HTMLElement;
+  for (const hidden of clone.querySelectorAll("[inert]")) {
+    hidden.remove();
+  }
+  return clone.textContent ?? "";
 }
 
 function buttonByText(text: string): HTMLButtonElement {
@@ -39,7 +65,7 @@ function buttonByText(text: string): HTMLButtonElement {
   return button;
 }
 
-/** Option cards prefix their text with the label ("Stability: I need…"). */
+/** Option cards start their text with the label ("Stability" + description). */
 function optionButton(label: string): HTMLButtonElement {
   const button = bodyButtons().find((candidate) =>
     candidate.textContent?.trim().startsWith(label)
@@ -126,8 +152,8 @@ test("Step 1 skips with the step number and gates Next on a selection", async ()
       );
     });
 
-    assert.match(document.body.textContent ?? "", STEP_INDICATOR_RE);
-    assert.match(document.body.textContent ?? "", STEP_ONE_TITLE_RE);
+    assert.match(reachableText(), STEP_INDICATOR_RE);
+    assert.match(reachableText(), STEP_ONE_TITLE_RE);
 
     const next = bodyButtons().find((candidate) =>
       candidate.textContent?.includes("Next")
@@ -146,11 +172,11 @@ test("Step 1 skips with the step number and gates Next on a selection", async ()
     });
     assert.equal(next.disabled, true);
 
-    assert.equal(document.querySelector("input"), null);
+    assert.equal(reachableInput(), null);
     await actAndDrain(() => {
       fireEvent.click(buttonByText("Other"));
     });
-    const otherInput = document.querySelector("input");
+    const otherInput = reachableInput();
     assert.ok(otherInput, "selecting Other morphs the card into an input");
     // Empty Other keeps Next clickable — the click surfaces the inline
     // required error instead of disabling the button (pinned below).
@@ -195,23 +221,23 @@ test("an empty Other refuses Next with the inline error until text arrives", asy
     await actAndDrain(() => {
       fireEvent.click(buttonByText("Other"));
     });
-    assert.doesNotMatch(document.body.textContent ?? "", OTHER_REQUIRED_RE);
+    assert.doesNotMatch(reachableText(), OTHER_REQUIRED_RE);
 
     // Next with no text: the error appears, nothing advances or persists.
     await clickNext();
-    assert.match(document.body.textContent ?? "", OTHER_REQUIRED_RE);
-    assert.match(document.body.textContent ?? "", STEP_INDICATOR_RE);
+    assert.match(reachableText(), OTHER_REQUIRED_RE);
+    assert.match(reachableText(), STEP_INDICATOR_RE);
     assert.equal(answers.length, 0);
 
     // Typing clears the error display without another Next.
-    const otherInput = document.querySelector("input");
+    const otherInput = reachableInput();
     assert.ok(otherInput, "the morphed Other input is rendered");
     await actAndDrain(() => {
       otherInput.focus();
       fireEvent.input(otherInput, { target: { value: "SRE" } });
       fireEvent.keyUp(otherInput, { key: "d" });
     });
-    assert.doesNotMatch(document.body.textContent ?? "", OTHER_REQUIRED_RE);
+    assert.doesNotMatch(reachableText(), OTHER_REQUIRED_RE);
 
     // The glyph inside the morphed field unselects Other, restoring the card.
     const unselect = bodyButtons().find(
@@ -221,21 +247,21 @@ test("an empty Other refuses Next with the inline error until text arrives", asy
     await actAndDrain(() => {
       fireEvent.click(unselect);
     });
-    assert.equal(document.querySelector("input"), null);
+    assert.equal(reachableInput(), null);
     assert.ok(buttonByText("Other"), "the Other card is restored");
 
     // With text in place, Next advances and the trimmed pair persists.
     await actAndDrain(() => {
       fireEvent.click(buttonByText("Other"));
     });
-    const revived = document.querySelector("input");
+    const revived = reachableInput();
     assert.ok(revived, "re-selecting Other morphs the card again");
     // The Other text survives the unselect round-trip by design.
     await clickNext();
     assert.deepEqual(answers, [
       { roleOtherText: "SRE", roleType: "other", step: 1 },
     ]);
-    assert.match(document.body.textContent ?? "", STEP_TWO_INDICATOR_RE);
+    assert.match(reachableText(), STEP_TWO_INDICATOR_RE);
   } finally {
     await actAndDrain(() => {
       rendered?.unmount();
@@ -268,7 +294,7 @@ test("the morphed Other input claims focus on select, wrapper press, and refused
     await actAndDrain(() => {
       fireEvent.click(buttonByText("Other"));
     });
-    const otherInput = document.querySelector("input");
+    const otherInput = reachableInput();
     assert.ok(otherInput, "the morphed Other input is rendered");
     assert.equal(document.activeElement, otherInput);
 
@@ -290,7 +316,7 @@ test("the morphed Other input claims focus on select, wrapper press, and refused
       otherInput.blur();
     });
     await clickNext();
-    assert.match(document.body.textContent ?? "", OTHER_REQUIRED_RE);
+    assert.match(reachableText(), OTHER_REQUIRED_RE);
     assert.equal(document.activeElement, otherInput);
   } finally {
     await actAndDrain(() => {
@@ -343,18 +369,18 @@ test("the survey walks Steps 1-4, persists each advance, and submits terminally"
     await actAndDrain(() => {
       fireEvent.click(buttonByText("Other"));
     });
-    const roleInput = document.querySelector("input");
+    const roleInput = reachableInput();
     assert.ok(roleInput, "the Other input is revealed");
     await typeInto(roleInput, "  platform team lead ");
     await clickNext();
     assert.deepEqual(answers, [
       { roleOtherText: "platform team lead", roleType: "other", step: 1 },
     ]);
-    assert.match(document.body.textContent ?? "", STEP_TWO_INDICATOR_RE);
-    assert.doesNotMatch(document.body.textContent ?? "", STEP_ONE_TITLE_RE);
+    assert.match(reachableText(), STEP_TWO_INDICATOR_RE);
+    assert.doesNotMatch(reachableText(), STEP_ONE_TITLE_RE);
 
     // Step 2: single-select usage context.
-    assert.match(document.body.textContent ?? "", STEP_TWO_TITLE_RE);
+    assert.match(reachableText(), STEP_TWO_TITLE_RE);
     await actAndDrain(() => {
       fireEvent.click(buttonByText("Running a real business project"));
     });
@@ -364,10 +390,10 @@ test("the survey walks Steps 1-4, persists each advance, and submits terminally"
       usageContext: "real_business",
       usageOtherText: null,
     });
-    assert.match(document.body.textContent ?? "", STEP_THREE_INDICATOR_RE);
+    assert.match(reachableText(), STEP_THREE_INDICATOR_RE);
 
     // Step 3: multi-select capped at 3, Other pinned last with optional text.
-    assert.match(document.body.textContent ?? "", STEP_THREE_SUBTITLE_RE);
+    assert.match(reachableText(), STEP_THREE_SUBTITLE_RE);
     await actAndDrain(() => {
       fireEvent.click(optionButton("Stability"));
     });
@@ -379,7 +405,7 @@ test("the survey walks Steps 1-4, persists each advance, and submits terminally"
     });
     // The cap is 3: every unselected option is locked out.
     assert.equal(optionButton("Performance").disabled, true);
-    const priorityInput = document.querySelector("input");
+    const priorityInput = reachableInput();
     assert.ok(priorityInput, "the Step 3 Other input is revealed");
     await typeInto(priorityInput, " fair pricing ");
     await clickNext();
@@ -402,10 +428,10 @@ test("the survey walks Steps 1-4, persists each advance, and submits terminally"
     assert.equal(priorityAnswer.step, 3);
     assert.equal(priorityAnswer.priorityDisplayOrder.length, 7);
     assert.equal(priorityAnswer.priorityDisplayOrder.at(-1), "other");
-    assert.match(document.body.textContent ?? "", STEP_FOUR_INDICATOR_RE);
+    assert.match(reachableText(), STEP_FOUR_INDICATOR_RE);
 
     // Step 4: the open goal is optional; submit fires the terminal payload.
-    assert.match(document.body.textContent ?? "", STEP_FOUR_TITLE_RE);
+    assert.match(reachableText(), STEP_FOUR_TITLE_RE);
     // The open goal is an auto-growing textarea (2000 characters allowed).
     const goalInput = document.querySelector("textarea");
     assert.ok(goalInput, "the open goal field is rendered");
@@ -574,6 +600,61 @@ test("Skip fires the funnel event with the step it left from", async () => {
   }
 });
 
+test("previewStep starts the survey on that step, fully interactive", async () => {
+  const dom = installTestDom();
+  const previousActEnvironment = setActEnvironment(true);
+  const { render } = await import("@testing-library/react/pure");
+  const { fireEvent } = await import("@testing-library/dom");
+  const dataLayer: unknown[] = [];
+  Object.assign(window, { dataLayer });
+  const answers: unknown[] = [];
+  let rendered: ReturnType<typeof render> | undefined;
+
+  try {
+    await actAndDrain(() => {
+      rendered = render(
+        <OnboardingSurveyCard
+          onAnswerStep={(payload) => {
+            answers.push(payload);
+          }}
+          onComplete={() => undefined}
+          onSkip={() => undefined}
+          previewStep={3}
+        />
+      );
+    });
+
+    // The survey genuinely sits on the previewed step: indicator, panel,
+    // and the funnel's mount view all say step 3.
+    assert.match(reachableText(), STEP_THREE_INDICATOR_RE);
+    assert.match(reachableText(), STEP_THREE_SUBTITLE_RE);
+    assert.doesNotMatch(reachableText(), STEP_ONE_TITLE_RE);
+    assert.deepEqual(dataLayer, [funnelEntry("onboarding_step_view", 3)]);
+
+    // Step 3's own gating applies: Next unlocks with a pick and advances
+    // to step 4, persisting the step 3 payload like any real session.
+    const next = bodyButtons().find((candidate) =>
+      candidate.textContent?.includes("Next")
+    );
+    assert.ok(next, "the footer renders Next for the previewed step");
+    assert.equal(next.disabled, true);
+    await actAndDrain(() => {
+      fireEvent.click(optionButton("Stability"));
+    });
+    assert.equal(next.disabled, false);
+    await clickNext();
+    assert.match(reachableText(), STEP_FOUR_INDICATOR_RE);
+    assert.equal(answers.length, 1);
+    assert.equal((answers[0] as { step: number }).step, 3);
+  } finally {
+    await actAndDrain(() => {
+      rendered?.unmount();
+    });
+    restoreActEnvironment(previousActEnvironment);
+    await dom.restore();
+  }
+});
+
 test("a broken dataLayer never touches the survey flow", async () => {
   const dom = installTestDom();
   const previousActEnvironment = setActEnvironment(true);
@@ -612,7 +693,7 @@ test("a broken dataLayer never touches the survey flow", async () => {
     await clickNext();
 
     // The survey advanced and persisted as if analytics did not exist.
-    assert.match(document.body.textContent ?? "", STEP_TWO_INDICATOR_RE);
+    assert.match(reachableText(), STEP_TWO_INDICATOR_RE);
     assert.equal(answers.length, 1);
 
     await actAndDrain(() => {

--- a/apps/ui/src/features/onboarding/onboarding-dialog.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-dialog.tsx
@@ -159,7 +159,7 @@ function OptionCard({
       className={cn(
         // min-h, not h: the Step 3 descriptions must stay readable, so a
         // card grows and wraps rather than truncating its one-liner.
-        "flex min-h-12 cursor-pointer items-center justify-between gap-3 rounded-lg border border-transparent px-4 py-2.5 text-left text-foreground text-sm transition-colors",
+        "flex min-h-12 cursor-pointer items-center justify-between gap-3 rounded-lg border border-transparent px-4 py-2 text-left text-foreground text-sm transition-colors",
         // The deepened wash carries the selected state so it never rides on
         // the 16px glyph alone.
         selected ? "bg-input" : "bg-input/30 hover:border-border",
@@ -185,8 +185,9 @@ function LengthHint({ max, value }: { max: number; value: string }) {
 }
 
 /**
- * At most one Other field mounts at a time, so its error message can hold a
- * fixed id for the input's `aria-describedby`.
+ * Passed steps keep their Other fields mounted in their inert panels, but
+ * only the active step's field ever receives `error`, so the error message
+ * can hold a fixed id for the input's `aria-describedby`.
  */
 const OTHER_ERROR_ID = "onboarding-other-error";
 
@@ -226,7 +227,7 @@ function OtherOptionField({
         className={cn(
           // A focus-within field wrapper: matches appFieldFocusClass's blue
           // by eye, per the field-state outlier note.
-          "flex min-h-12 items-center gap-3 rounded-lg border border-input bg-input/30 px-4 py-2.5 transition-colors",
+          "flex min-h-12 items-center gap-3 rounded-lg border border-input bg-input/30 px-4 py-2 transition-colors",
           error
             ? "border-destructive ring-[1px] ring-destructive/50"
             : "focus-within:border-blue-400 focus-within:ring-[1px] focus-within:ring-blue-400/50"
@@ -300,8 +301,33 @@ function progressSegmentClass(index: number, currentStep: number): string {
  * One step's heading and inputs travel as a group: the tight gap binds the
  * heading to what it introduces while keeping the step frame compact enough
  * that the options do not end in a large unused gap.
+ *
+ * All four panels stay mounted, stacked in one grid cell, so the frame is
+ * always exactly as tall as the tallest step at any width or copy length:
+ * advancing never moves the frame edge or the Next button, and a future
+ * cross-step transition has both steps in the DOM to animate between. An
+ * inactive panel is invisible and inert — unfocusable and hidden from
+ * readers — so the stack never leaks tab stops or announcement text.
  */
-const stepGroupClass = "flex min-h-[20rem] flex-col gap-6";
+function StepPanel({
+  active,
+  children,
+}: {
+  active: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "col-start-1 row-start-1 flex min-h-[20rem] flex-col gap-6",
+        !active && "invisible"
+      )}
+      inert={!active}
+    >
+      {children}
+    </div>
+  );
+}
 
 function StepHeading({
   subtitle,
@@ -338,6 +364,15 @@ export interface OnboardingSurveyCardProps {
   onComplete: (payload: CompleteOnboardingProfileRequest) => void;
   /** Skip: the single exit short of the final submit; the owner persists. */
   onSkip: (payload: DismissOnboardingProfileRequest) => void;
+  /**
+   * Dev-only (the dev tweaks preview knob, set while the dialog is
+   * force-opened): the survey genuinely starts on this step, so selections,
+   * gating, and Next behave exactly as a session that reached it — earlier
+   * steps just hold no answers (the forced dialog's writes are inert).
+   * Read once at mount; the owner remounts the card (keyed by this value)
+   * to apply a change.
+   */
+  previewStep?: number;
 }
 
 function stepAnswerPayload(
@@ -363,20 +398,30 @@ export function OnboardingSurveyCard({
   onAnswerStep,
   onComplete,
   onSkip,
+  previewStep,
 }: OnboardingSurveyCardProps) {
   const [state, dispatch] = useReducer(
     onboardingSurveyReducer,
     undefined,
     // The card mounts when the dialog opens, so the lazy initializer is the
-    // once-per-session seat of the Step 3 display-order shuffle.
-    () => createInitialOnboardingSurveyState()
+    // once-per-session seat of the Step 3 display-order shuffle — and of the
+    // dev preview's starting step.
+    () => {
+      const initial = createInitialOnboardingSurveyState();
+      return previewStep === undefined
+        ? initial
+        : { ...initial, currentStep: previewStep };
+    }
   );
   // Armed by a refused Next; the visible error also needs the text to still
   // be missing, so typing or unselecting Other clears it without a reset.
   const [otherErrorArmed, setOtherErrorArmed] = useState(false);
   const otherError = otherErrorArmed && onboardingOtherTextMissing(state);
-  // At most one Other field renders at a time, so the steps share one ref;
-  // the card holds it to send focus into the field on a refused Next.
+  // The steps share one ref; passed steps keep their Other fields mounted in
+  // inert panels, but a field only ever mounts when Other is selected on the
+  // active step (there is no back navigation), so the latest mount — the one
+  // holding the ref — is the active step's field whenever a refused Next
+  // needs to send focus into it.
   const otherInputRef = useRef<HTMLInputElement>(null);
 
   // The funnel view events: one per step shown, the mount itself being the
@@ -432,8 +477,11 @@ export function OnboardingSurveyCard({
   };
 
   return (
-    <div className="flex flex-col gap-10 p-9">
-      <div className="flex flex-col gap-4">
+    // Explicit seams instead of one container gap: the header keeps its
+    // wide berth from the step body, while the footer sits closer so the
+    // frame ends compactly under the options.
+    <div className="flex flex-col p-9">
+      <div className="mb-10 flex flex-col gap-4">
         <div className="flex items-center justify-between">
           <span className="text-muted-foreground text-sm">
             Step {state.currentStep} of {ONBOARDING_SURVEY_TOTAL_STEPS}
@@ -461,18 +509,18 @@ export function OnboardingSurveyCard({
       </div>
       {/* Plain headings: the dialog context is optional for the card so the
           frame stays testable in a plain DOM; the shell labels the dialog. */}
-      {state.currentStep === 1 ? (
-        <div className={stepGroupClass}>
+      <div className="grid">
+        <StepPanel active={state.currentStep === 1}>
           <StepHeading
             subtitle="This helps us tailor your workspace experience."
             title="Tell us a bit about you."
           />
-          <fieldset className="grid gap-x-3 gap-y-3 border-0 sm:grid-cols-2">
+          <fieldset className="grid gap-x-3 gap-y-2 border-0 sm:grid-cols-2">
             <legend className="sr-only">Your role</legend>
             {ROLE_OPTIONS.map((option) =>
               option.value === "other" && state.roleType === "other" ? (
                 <OtherOptionField
-                  error={otherError}
+                  error={otherError && state.currentStep === 1}
                   inputRef={otherInputRef}
                   key={option.value}
                   label="Describe your role"
@@ -499,20 +547,18 @@ export function OnboardingSurveyCard({
               )
             )}
           </fieldset>
-        </div>
-      ) : null}
-      {state.currentStep === 2 ? (
-        <div className={stepGroupClass}>
+        </StepPanel>
+        <StepPanel active={state.currentStep === 2}>
           <StepHeading
             subtitle="Let us know what stage your project is in."
             title="What are you using Sealos for?"
           />
-          <fieldset className="grid gap-x-3 gap-y-3 border-0 sm:grid-cols-2">
+          <fieldset className="grid gap-x-3 gap-y-2 border-0 sm:grid-cols-2">
             <legend className="sr-only">Your usage context</legend>
             {USAGE_OPTIONS.map((option) =>
               option.value === "other" && state.usageContext === "other" ? (
                 <OtherOptionField
-                  error={otherError}
+                  error={otherError && state.currentStep === 2}
                   inputRef={otherInputRef}
                   key={option.value}
                   label="Describe your usage"
@@ -539,21 +585,19 @@ export function OnboardingSurveyCard({
               )
             )}
           </fieldset>
-        </div>
-      ) : null}
-      {state.currentStep === 3 ? (
-        <div className={stepGroupClass}>
+        </StepPanel>
+        <StepPanel active={state.currentStep === 3}>
           <StepHeading
             subtitle="Choose up to 3."
             title="Which factors are most important to you?"
           />
-          <fieldset className="grid gap-x-3 gap-y-3 border-0 sm:grid-cols-2">
+          <fieldset className="grid gap-x-3 gap-y-2 border-0 sm:grid-cols-2">
             <legend className="sr-only">Your top priorities</legend>
             {state.priorityDisplayOrder.map((tag) => {
               if (tag === "other" && state.priorityTags.includes("other")) {
                 return (
                   <OtherOptionField
-                    error={otherError}
+                    error={otherError && state.currentStep === 3}
                     inputRef={otherInputRef}
                     key={tag}
                     label="Describe your priority"
@@ -583,21 +627,23 @@ export function OnboardingSurveyCard({
                   selected={selected}
                   shape="checkbox"
                 >
-                  <span className="font-medium">{option.label}</span>
-                  {option.description == null ? null : (
-                    <span className="text-muted-foreground">
-                      {": "}
-                      {option.description}
-                    </span>
-                  )}
+                  {/* Stacked label/description: the description wraps inside
+                      its own muted block, so long or localized copy reads as
+                      typesetting rather than a run-in line overflowing. */}
+                  <span className="flex flex-col">
+                    <span className="font-medium">{option.label}</span>
+                    {option.description == null ? null : (
+                      <span className="text-muted-foreground leading-snug">
+                        {option.description}
+                      </span>
+                    )}
+                  </span>
                 </OptionCard>
               );
             })}
           </fieldset>
-        </div>
-      ) : null}
-      {state.currentStep === 4 ? (
-        <div className={stepGroupClass}>
+        </StepPanel>
+        <StepPanel active={state.currentStep === 4}>
           <StepHeading title="Anything specific you're trying to achieve?" />
           <div className="flex flex-col gap-1.5">
             {/* Auto-growing (field-sizing-content via AppTextarea): the open
@@ -627,9 +673,9 @@ export function OnboardingSurveyCard({
               />
             </div>
           </div>
-        </div>
-      ) : null}
-      <div className="flex justify-end">
+        </StepPanel>
+      </div>
+      <div className="mt-8 flex justify-end">
         {state.currentStep === ONBOARDING_SURVEY_TOTAL_STEPS ? (
           // The terminal submit: never gated (the open goal is optional) and
           // never awaited — the owner closes the dialog into the console.
@@ -678,6 +724,7 @@ export function OnboardingDialog({
   onComplete,
   onSkip,
   open,
+  previewStep,
 }: OnboardingDialogProps) {
   return (
     <AppDialog.Root onOpenChange={refuseOnboardingDialogClose} open={open}>
@@ -692,9 +739,13 @@ export function OnboardingDialog({
             body pans while Next/Submit stays reachable at the frame's end. */}
         <div className="min-h-0 flex-1 overflow-y-auto">
           <OnboardingSurveyCard
+            // The card reads previewStep once at mount (it seeds the
+            // reducer), so the key remounts it when the knob moves.
+            key={previewStep ?? "follow"}
             onAnswerStep={onAnswerStep}
             onComplete={onComplete}
             onSkip={onSkip}
+            previewStep={previewStep}
           />
         </div>
       </AppDialog.Content>

--- a/apps/ui/src/features/onboarding/onboarding-gate.tsx
+++ b/apps/ui/src/features/onboarding/onboarding-gate.tsx
@@ -41,6 +41,15 @@ const ONBOARDING_TWEAKS = {
       step: 1,
       value: 0,
     },
+    // Only honored while the modal is forced: preview never redirects a
+    // real survey in progress, where the forced-looking step could submit.
+    previewStep: {
+      label: "Preview step (0 follows the survey · 1-4 force)",
+      max: 4,
+      min: 0,
+      step: 1,
+      value: 0,
+    },
   },
 } as const;
 
@@ -58,6 +67,10 @@ export function OnboardingGate() {
   const { values } = useDevTweaks("onboarding", ONBOARDING_TWEAKS);
   const forceOpen =
     process.env.NODE_ENV === "development" && values.forceModal >= 0.5;
+  const previewStep =
+    forceOpen && values.previewStep >= 1 && values.previewStep <= 4
+      ? Math.round(values.previewStep)
+      : undefined;
 
   useEffect(() => {
     // The app token arrives asynchronously from the Desktop SDK; with no
@@ -172,6 +185,7 @@ export function OnboardingGate() {
       onComplete={handleComplete}
       onSkip={handleSkip}
       open={open || forceOpen}
+      previewStep={previewStep}
     />
   );
 }


### PR DESCRIPTION
Step 3's run-in "Label: description" cards wrapped raggedly and made the dialog taller than the other steps. Three changes, validated against a side-by-side prototype:

- Step 3 cards stack a medium label over a muted description, so long or future-localized copy wraps as typesetting instead of overflow.
- All four step panels stay mounted in one grid cell (inactive ones invisible + inert): the frame is always exactly as tall as the tallest step, so advancing never moves the Next button, and cross-step transitions have both steps in the DOM to animate between later.
- Tightened option-row gaps, card paddings, and the body-to-footer seam so the uniform height sits just above the old 20rem floor.

Dev tweaks gains a "Preview step" knob (honored only while the modal is forced): the survey genuinely starts on the chosen step, so gating and interactions behave like a real session while writes stay inert.