### PR TITLE
feat(dev-tweaks): contain frame mode in <body>, reskin the panel on glass

### DIFF
--- a/apps/ui/src/features/dev-tweaks/dev-tweaks-enabled.tsx
+++ b/apps/ui/src/features/dev-tweaks/dev-tweaks-enabled.tsx
@@ -11,11 +11,11 @@ import type { CSSProperties, ReactNode } from "react";
 
 /**
  * Host bridge: the panel skin is self-owned (`--dtp-*`, always dark), but the
- * fonts and the frame card's surface come from the host so the docked page
- * keeps its real look.
+ * fonts and the frame card's ring come from the host. The card surface needs
+ * no bridge — frame mode docks the page by insetting `<body>` itself, so the
+ * card already wears the app's own background.
  */
 const HOST_BRIDGE_STYLE: CSSProperties = {
-  "--dtp-card-bg": "var(--background)",
   "--dtp-card-ring": "var(--border)",
   "--dtp-font-mono": "var(--font-mono)",
   "--dtp-font-sans": "var(--font-sans)",

--- a/packages/dev-tweaks/src/panel.test.tsx
+++ b/packages/dev-tweaks/src/panel.test.tsx
@@ -380,6 +380,46 @@ test("indicator shows MOCK ×N for several active mock groups", async () => {
   });
 });
 
+test("frame mode insets the document and leaves nothing behind", async () => {
+  await withScene(async ({ fireEvent, openPanel, renderScene, screen }) => {
+    const { unmount } = await renderScene((surface) => (
+      <surface.DevTweaksProvider>
+        <surface.DevTweaksPanel
+          style={{ "--dtp-card-ring": "#abcabc" } as React.CSSProperties}
+        >
+          <span>page</span>
+        </surface.DevTweaksPanel>
+      </surface.DevTweaksProvider>
+    ));
+
+    const root = document.documentElement;
+    // The page is never wrapped: frame mode insets `<body>` itself, so the
+    // old card element must not come back.
+    assert.equal(document.querySelector(".dtp-card"), null);
+    // Bridge variables land on the root, the one ancestor both the card
+    // (`<body>`) and the top-layer panel share.
+    assert.equal(root.style.getPropertyValue("--dtp-card-ring"), "#abcabc");
+    assert.ok(root.classList.contains("dtp-frame-host"));
+    assert.equal(root.classList.contains("dtp-framed"), false);
+
+    await openPanel();
+    assert.ok(root.classList.contains("dtp-framed"));
+    assert.equal(root.style.getPropertyValue("--dtp-frame-panel-w"), "384px");
+    assert.equal(root.style.getPropertyValue("--dtp-frame-gap"), "32px");
+
+    await actAndDrain(() => {
+      fireEvent.click(screen.getByLabelText("Switch to floating window"));
+    });
+    assert.equal(root.classList.contains("dtp-framed"), false);
+
+    await actAndDrain(() => {
+      unmount();
+    });
+    assert.equal(root.classList.contains("dtp-frame-host"), false);
+    assert.equal(root.style.getPropertyValue("--dtp-card-ring"), "");
+  });
+});
+
 test("demo entry: alwaysVisible keeps the capsule present when clean", async () => {
   await withScene(async ({ renderScene, screen }) => {
     const scene = (surface: PackageSurface) => (

--- a/packages/dev-tweaks/src/panel/controls.tsx
+++ b/packages/dev-tweaks/src/panel/controls.tsx
@@ -21,6 +21,29 @@ interface ControlInputProps<D extends DevTweaksControlDef> {
   value: DevTweaksValue;
 }
 
+/** A range this coarse gets one tick per step; anything finer gets a 10% grid. */
+const COARSE_STEP_LIMIT = 10;
+const FINE_TICK_COUNT = 9;
+
+/** Tick offsets as percentages of the track, excluding both end caps. */
+function sliderTicks(def: DevTweaksSliderDef): number[] {
+  const span = def.max - def.min;
+  if (span <= 0) {
+    return [];
+  }
+  const steps = Math.round(span / (def.step ?? 1));
+  if (steps > COARSE_STEP_LIMIT) {
+    return Array.from(
+      { length: FINE_TICK_COUNT },
+      (_, index) => (index + 1) * 10
+    );
+  }
+  return Array.from(
+    { length: Math.max(steps - 1, 0) },
+    (_, index) => ((index + 1) / steps) * 100
+  );
+}
+
 function SliderControl({
   def,
   onChange,
@@ -43,6 +66,15 @@ function SliderControl({
       >
         <Slider.Control className="dtp-slider-control">
           <Slider.Track className="dtp-slider-track">
+            <span aria-hidden className="dtp-slider-ticks">
+              {sliderTicks(def).map((offset) => (
+                <span
+                  className="dtp-slider-tick"
+                  key={offset}
+                  style={{ left: `${offset}%` }}
+                />
+              ))}
+            </span>
             <Slider.Indicator className="dtp-slider-indicator" />
             <Slider.Thumb aria-label={def.label} className="dtp-slider-thumb" />
           </Slider.Track>

--- a/packages/dev-tweaks/src/panel/frame.ts
+++ b/packages/dev-tweaks/src/panel/frame.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { useEffect } from "react";
+
+/** Applied while the panel chrome is mounted — carries the transitions. */
+const HOST_CLASS = "dtp-frame-host";
+/** Applied only while frame mode is docking the page. */
+const FRAMED_CLASS = "dtp-framed";
+
+const GAP_VAR = "--dtp-frame-gap";
+const PANEL_W_VAR = "--dtp-frame-panel-w";
+const DURATION_VAR = "--dtp-frame-ms";
+
+export interface FrameModeInput {
+  /** Transition length in ms; 0 under reduced motion. */
+  durationMs: number;
+  /** True only while the panel is open in frame mode. */
+  framed: boolean;
+  /** Card inset on every side, px. */
+  gap: number;
+  /** Width of the panel strip the card makes room for, px. */
+  panelWidth: number;
+  /** Host bridge custom properties (`--dtp-*`), forwarded to the root. */
+  vars?: CSSProperties;
+}
+
+function customProperties(vars: CSSProperties | undefined): [string, string][] {
+  return Object.entries(vars ?? {})
+    .filter(([name]) => name.startsWith("--"))
+    .map(([name, value]) => [name, String(value)]);
+}
+
+/**
+ * Frame mode as a document-level effect: `<body>` becomes the inset card and
+ * `<html>` carries the scrim. `styles.css` explains why the containment sits
+ * on the body instead of on a wrapper element.
+ *
+ * The bridge variables ride up to `<html>` because both the body and the
+ * top-layer panel need to read them, and neither one is a descendant of
+ * anything this package renders.
+ */
+export function useFrameMode({
+  durationMs,
+  framed,
+  gap,
+  panelWidth,
+  vars,
+}: FrameModeInput): void {
+  // Serialized so an inline `style` object literal cannot re-run the effect
+  // on every render.
+  const varsKey = JSON.stringify(customProperties(vars));
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const entries = JSON.parse(varsKey) as [string, string][];
+    root.classList.add(HOST_CLASS);
+    for (const [name, value] of entries) {
+      root.style.setProperty(name, value);
+    }
+    return () => {
+      root.classList.remove(HOST_CLASS);
+      for (const [name] of entries) {
+        root.style.removeProperty(name);
+      }
+    };
+  }, [varsKey]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.style.setProperty(GAP_VAR, `${gap}px`);
+    root.style.setProperty(PANEL_W_VAR, `${panelWidth}px`);
+    root.style.setProperty(DURATION_VAR, `${durationMs}ms`);
+    root.classList.toggle(FRAMED_CLASS, framed);
+    return () => {
+      root.classList.remove(FRAMED_CLASS);
+      root.style.removeProperty(GAP_VAR);
+      root.style.removeProperty(PANEL_W_VAR);
+      root.style.removeProperty(DURATION_VAR);
+    };
+  }, [durationMs, framed, gap, panelWidth]);
+}

--- a/packages/dev-tweaks/src/panel/panel.tsx
+++ b/packages/dev-tweaks/src/panel/panel.tsx
@@ -495,13 +495,13 @@ function CollapsibleSection({
             onClick={() => setCollapsed((previous) => !previous)}
             type="button"
           >
-            <span className="dtp-chevron">
-              <IconChevron size={10} />
-            </span>
             {title}
             {count === undefined ? null : (
               <span className="dtp-count">{count}</span>
             )}
+            <span className="dtp-chevron">
+              <IconChevron size={12} />
+            </span>
           </button>
         </h3>
         <div className="dtp-groupbody">
@@ -573,14 +573,14 @@ function GroupSection({
           title={group.def.note}
           type="button"
         >
-          <span className="dtp-chevron">
-            <IconChevron />
-          </span>
           <span className="dtp-grouptitle">{group.def.title}</span>
           <span className="dtp-tag">{group.def.feature}</span>
           {group.def.kind === "mock" ? (
             <span className="dtp-mocktag">MOCK</span>
           ) : null}
+          <span className="dtp-chevron">
+            <IconChevron />
+          </span>
         </button>
         {dirty ? (
           <button

--- a/packages/dev-tweaks/src/panel/panel.tsx
+++ b/packages/dev-tweaks/src/panel/panel.tsx
@@ -5,6 +5,7 @@ import {
   type ReactNode,
   type RefObject,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -19,6 +20,7 @@ import type {
   DevTweaksValue,
 } from "../types";
 import { ControlRow } from "./controls";
+import { useFrameMode } from "./frame";
 import {
   IconChevron,
   IconClose,
@@ -49,11 +51,12 @@ const SNAP_MS = 200;
 const HIGHLIGHT_MS = 1400;
 
 export interface DevTweaksPanelProps {
-  /** The host app — in frame mode it docks into an inset card. */
+  /** The host app — in frame mode its own `<body>` becomes the inset card. */
   children?: ReactNode;
   /**
    * Host bridge variables (`--dtp-font-sans`, `--dtp-font-mono`,
-   * `--dtp-card-bg`, `--dtp-card-ring`) — applied to all panel chrome.
+   * `--dtp-card-ring`). Frame mode is a document-level effect, so these are
+   * forwarded to `<html>` rather than to a wrapper element.
    */
   style?: CSSProperties;
 }
@@ -120,43 +123,19 @@ function PanelChrome({
   const mode: PanelMode = narrow ? "float" : prefs.mode;
   const framed = open && mode === "frame";
   const slideMs = open ? OPEN_MS : CLOSE_MS;
-  const frameTransition = (properties: string[]) =>
-    properties
-      .map((property) => `${property} ${reducedMotion ? 0 : slideMs}ms ease`)
-      .join(", ");
 
-  const cardStyle: CSSProperties = {
-    // Ring via shadow (no 1px layout shift) + soft elevation; both states
-    // keep the same two-layer list shape so the browser interpolates.
-    borderRadius: framed ? 14 : 0,
-    boxShadow: framed
-      ? "0 0 0 1px var(--dtp-card-ring, var(--dtp-border)), 0 24px 64px -24px rgb(0 0 0 / 0.6)"
-      : "0 0 0 0 var(--dtp-card-ring, var(--dtp-border)), 0 24px 64px -24px rgb(0 0 0 / 0)",
-    height: framed ? `calc(100dvh - ${2 * FRAME_GAP}px)` : "100dvh",
-    margin: framed
-      ? `${FRAME_GAP}px ${FRAME_GAP + PANEL_W + FRAME_GAP}px ${FRAME_GAP}px ${FRAME_GAP}px`
-      : "0px",
-    transition: frameTransition([
-      "margin",
-      "height",
-      "border-radius",
-      "box-shadow",
-    ]),
-  };
+  // The card is the host's own `<body>` — nothing here wraps the children.
+  useFrameMode({
+    durationMs: reducedMotion ? 0 : slideMs,
+    framed,
+    gap: FRAME_GAP,
+    panelWidth: PANEL_W,
+    vars: style,
+  });
 
   return (
-    <div style={{ display: "contents", ...style }}>
-      <div
-        aria-hidden
-        className="dtp-skin dtp-backdrop"
-        style={{
-          opacity: framed ? 1 : 0,
-          transition: frameTransition(["opacity"]),
-        }}
-      />
-      <div className="dtp-skin dtp-card" style={cardStyle}>
-        {children}
-      </div>
+    <>
+      {children}
       <PanelAside
         key={mode}
         mode={mode}
@@ -170,7 +149,7 @@ function PanelChrome({
         store={store}
         updatePrefs={updatePrefs}
       />
-    </div>
+    </>
   );
 }
 
@@ -255,6 +234,30 @@ function floatAsideStyle({
   };
 }
 
+/**
+ * Keeps the element in the top layer for its whole life. Frame mode contains
+ * the body, and a contained body is the containing block for its `position:
+ * fixed` children — the top layer is the only place left that still measures
+ * against the viewport. The popover stays open throughout: showing and hiding
+ * the panel is still opacity and transform, so the transitions are untouched.
+ *
+ * No-op where the platform has no popover support (the test DOM).
+ */
+function useTopLayer(ref: RefObject<HTMLElement | null>): void {
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!(element && "showPopover" in element)) {
+      return;
+    }
+    element.showPopover();
+    return () => {
+      if (element.isConnected) {
+        element.hidePopover();
+      }
+    };
+  }, [ref]);
+}
+
 function PanelAside({
   mode,
   narrow,
@@ -266,6 +269,7 @@ function PanelAside({
   updatePrefs,
 }: PanelAsideProps) {
   const panelRef = useRef<HTMLElement | null>(null);
+  useTopLayer(panelRef);
   // Mount flag — lets the first open play an entrance transition even when
   // the aside just remounted (hard mode handoff).
   const [entered, setEntered] = useState(false);
@@ -311,6 +315,7 @@ function PanelAside({
       className="dtp-skin dtp-panel"
       data-mode={mode}
       inert={!open}
+      popover="manual"
       ref={panelRef}
       style={geometry}
     >

--- a/packages/dev-tweaks/src/styles.css
+++ b/packages/dev-tweaks/src/styles.css
@@ -2,7 +2,7 @@
  * Dev tweaks panel — always-dark, self-owned skin on `--dtp-*` variables.
  * The package ships its own tokens and never reads host theme tokens; the
  * only host bridges are optional overrides passed down as CSS variables:
- * `--dtp-font-sans`, `--dtp-font-mono`, `--dtp-card-bg`, `--dtp-card-ring`.
+ * `--dtp-font-sans`, `--dtp-font-mono`, `--dtp-card-ring`.
  *
  * Palette + restraint: vercel.com/design.md (Geist dark grays, monochrome,
  * color only for meaning — amber = mock, blue = focus).
@@ -33,21 +33,63 @@
   --dtp-mono: var(--dtp-font-mono, "Geist Mono", ui-monospace, monospace);
 }
 
-/* ---------- frame chrome (page docked as an inset card) ---------- */
+/* ---------- frame mode (the page's own <body> is the inset card) ---------- */
 
-.dtp-backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
-  background: rgb(0 0 0 / 0.4);
+/*
+ * Frame mode does not wrap the page in a card — it turns `<body>` into one.
+ *
+ * `contain: layout` is the whole trick. It makes the body the containing
+ * block for every `position: fixed` descendant *and* for everything React
+ * portals into `document.body`, so dialogs, sheets, menus, tooltips and
+ * toasts land inside the card without one line of change in the host's
+ * components. It also makes the body a formatting context root, which stops
+ * the usual body-to-viewport overflow propagation — so `overflow: hidden`
+ * clips at the card's rounded corners instead of at the window edge.
+ *
+ * `<html>` carries the scrim. Without a background of its own the body's
+ * background propagates to the canvas and paints the whole window.
+ *
+ * The card wears whatever background the host already gave its body, so
+ * there is nothing to bridge: the docked page keeps its real surface.
+ *
+ * Nothing the panel renders can live inside a contained body, so the panel
+ * rides the top layer instead — see `.dtp-panel[popover]`.
+ */
+
+.dtp-frame-host {
+  --dtp-frame-gap: 32px;
+  --dtp-frame-panel-w: 384px;
+  --dtp-frame-ms: 300ms;
+  --dtp-frame-radius: 14px;
+  --dtp-frame-scrim: rgb(0 0 0 / 0.4);
+  transition: background-color var(--dtp-frame-ms) ease;
 }
 
-.dtp-card {
-  position: relative;
-  z-index: 1;
+.dtp-frame-host > body {
+  transition:
+    margin var(--dtp-frame-ms) ease,
+    height var(--dtp-frame-ms) ease,
+    border-radius var(--dtp-frame-ms) ease,
+    box-shadow var(--dtp-frame-ms) ease;
+}
+
+.dtp-framed {
+  /* The card measures against the root, so the root needs a definite height. */
+  height: 100%;
+  background-color: var(--dtp-frame-scrim);
+}
+
+.dtp-framed > body {
+  height: calc(100% - var(--dtp-frame-gap) * 2);
+  margin: var(--dtp-frame-gap);
+  margin-right: calc(var(--dtp-frame-gap) * 2 + var(--dtp-frame-panel-w));
+  contain: layout;
   overflow: hidden;
-  background: var(--dtp-card-bg, canvas);
+  border-radius: var(--dtp-frame-radius);
+  /* Ring as a shadow layer — no 1px of layout shift when it appears. */
+  box-shadow:
+    0 0 0 1px var(--dtp-card-ring, #232323),
+    0 24px 64px -24px rgb(0 0 0 / 0.6);
 }
 
 /* ---------- panel ---------- */
@@ -65,6 +107,19 @@
   border: 1px solid var(--dtp-border);
   border-radius: var(--dtp-radius);
   box-shadow: 0 12px 48px -12px rgb(0 0 0 / 0.7);
+}
+
+/*
+ * Top-layer panel. The UA popover rules have to be undone: they force
+ * `inset: 0`, `margin: auto` and fit-content sizing, which would fight the
+ * geometry the panel sets inline.
+ */
+.dtp-panel[popover] {
+  inset: auto;
+  width: auto;
+  height: auto;
+  padding: 0;
+  margin: 0;
 }
 
 .dtp-panel *:focus-visible {
@@ -867,8 +922,8 @@
 /* ---------- reduced motion ---------- */
 
 @media (prefers-reduced-motion: reduce) {
-  .dtp-backdrop,
-  .dtp-card,
+  .dtp-frame-host,
+  .dtp-frame-host > body,
   .dtp-panel,
   .dtp-panel *,
   .dtp-capsule {

--- a/packages/dev-tweaks/src/styles.css
+++ b/packages/dev-tweaks/src/styles.css
@@ -4,30 +4,37 @@
  * only host bridges are optional overrides passed down as CSS variables:
  * `--dtp-font-sans`, `--dtp-font-mono`, `--dtp-card-ring`.
  *
- * Palette + restraint: vercel.com/design.md (Geist dark grays, monochrome,
- * color only for meaning — amber = mock, blue = focus).
+ * Material: one lifted gray ground with every surface above it painted as
+ * white at a low alpha, so the panel reads as a single material lit at four
+ * levels rather than five separately mixed grays (dialkit's glass skin).
+ * Color only for meaning — amber = mock, blue = focus.
  * Shape: a tweak-panel row stack — every control is a filled chip of the same
  * height, label left / value right, and a slider paints its fill into the
  * chip itself rather than sitting on a separate track.
  */
 
 .dtp-skin {
-  /* Geist dark scale */
-  --dtp-bg: #0a0a0a;
-  --dtp-bg-raised: #1a1a1a;
-  --dtp-bg-hover: #202020;
-  --dtp-bg-fill: #2e2e2e;
-  --dtp-bg-fill-hover: #3a3a3a;
-  --dtp-border: #232323;
-  --dtp-border-strong: #343434;
-  --dtp-text: #ededed;
-  --dtp-text-dim: #a1a1a1;
-  --dtp-text-faint: #6f6f6f;
+  --dtp-bg: #212121;
+
+  /* Surfaces — white over the ground, not standalone grays. */
+  --dtp-surface: rgb(255 255 255 / 0.05);
+  --dtp-surface-hover: rgb(255 255 255 / 0.1);
+  --dtp-surface-strong: rgb(255 255 255 / 0.11);
+  --dtp-divider: rgb(255 255 255 / 0.06);
+  --dtp-border: rgb(255 255 255 / 0.1);
+  --dtp-border-strong: rgb(255 255 255 / 0.15);
+
+  /* Three levels of text, and one more for anything disabled. */
+  --dtp-text: #fff;
+  --dtp-text-dim: rgb(255 255 255 / 0.7);
+  --dtp-text-faint: rgb(255 255 255 / 0.4);
+  --dtp-text-off: rgb(255 255 255 / 0.18);
+
   --dtp-focus: #0070f3;
   --dtp-mock: #f5a623;
   --dtp-radius: 14px;
   --dtp-radius-s: 8px;
-  --dtp-radius-xs: 5px;
+  --dtp-radius-xs: 6px;
   --dtp-row-h: 36px;
   --dtp-font: var(--dtp-font-sans, Geist, ui-sans-serif, system-ui, sans-serif);
   --dtp-mono: var(--dtp-font-mono, "Geist Mono", ui-monospace, monospace);
@@ -88,7 +95,7 @@
   border-radius: var(--dtp-frame-radius);
   /* Ring as a shadow layer — no 1px of layout shift when it appears. */
   box-shadow:
-    0 0 0 1px var(--dtp-card-ring, #232323),
+    0 0 0 1px var(--dtp-card-ring, rgb(255 255 255 / 0.1)),
     0 24px 64px -24px rgb(0 0 0 / 0.6);
 }
 
@@ -99,14 +106,16 @@
   flex-direction: column;
   overflow: hidden;
   font-family: var(--dtp-font);
-  font-size: 12px;
+  font-size: 13px;
   line-height: 1.4;
   color: var(--dtp-text);
   color-scheme: dark;
-  background: var(--dtp-bg);
+  /* Held just off opaque so the blur has something to do. */
+  background: color-mix(in srgb, var(--dtp-bg) 92%, transparent);
   border: 1px solid var(--dtp-border);
   border-radius: var(--dtp-radius);
-  box-shadow: 0 12px 48px -12px rgb(0 0 0 / 0.7);
+  box-shadow: 0 8px 32px rgb(0 0 0 / 0.5);
+  backdrop-filter: blur(20px);
 }
 
 /*
@@ -134,9 +143,9 @@
   flex: none;
   gap: 2px;
   align-items: center;
-  height: 48px;
-  padding: 0 10px 0 16px;
-  border-bottom: 1px solid var(--dtp-border);
+  height: 44px;
+  padding: 0 10px 0 14px;
+  border-bottom: 1px solid var(--dtp-divider);
 }
 
 .dtp-panel[data-mode="float"] .dtp-header {
@@ -152,9 +161,9 @@
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 13px;
-  font-weight: 500;
-  letter-spacing: -0.005em;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
   white-space: nowrap;
 }
 
@@ -171,17 +180,17 @@
   border: none;
   border-radius: var(--dtp-radius-xs);
   transition:
-    color 120ms ease,
-    background-color 120ms ease;
+    color 150ms ease,
+    background-color 150ms ease;
 }
 
 .dtp-iconbtn:hover:not(:disabled) {
   color: var(--dtp-text);
-  background: var(--dtp-bg-raised);
+  background: var(--dtp-surface);
 }
 
 .dtp-iconbtn:disabled {
-  color: #3a3a3a;
+  color: var(--dtp-text-off);
   cursor: default;
 }
 
@@ -191,19 +200,18 @@
   gap: 7px;
   align-items: center;
   height: 40px;
-  padding: 0 10px 0 16px;
-  font-size: 11px;
+  padding: 0 10px 0 14px;
+  font-size: 12px;
   color: var(--dtp-text-faint);
-  border-top: 1px solid var(--dtp-border);
+  border-top: 1px solid var(--dtp-divider);
 }
 
 .dtp-kbd {
   padding: 2px 5px;
   font-family: var(--dtp-mono);
-  font-size: 10px;
+  font-size: 11px;
   color: var(--dtp-text-dim);
-  background: var(--dtp-bg-raised);
-  border: 1px solid var(--dtp-border);
+  background: var(--dtp-surface);
   border-radius: 4px;
 }
 
@@ -212,26 +220,25 @@
   padding: 0 10px;
   margin-left: auto;
   font: inherit;
-  font-size: 11px;
+  font-size: 12px;
+  font-weight: 500;
   color: var(--dtp-text-dim);
   cursor: pointer;
   background: transparent;
-  border: 1px solid transparent;
+  border: none;
   border-radius: var(--dtp-radius-xs);
   transition:
-    color 120ms ease,
-    background-color 120ms ease,
-    border-color 120ms ease;
+    color 150ms ease,
+    background-color 150ms ease;
 }
 
 .dtp-clearall:hover:not(:disabled) {
   color: var(--dtp-text);
-  background: var(--dtp-bg-raised);
-  border-color: var(--dtp-border);
+  background: var(--dtp-surface);
 }
 
 .dtp-clearall:disabled {
-  color: #3a3a3a;
+  color: var(--dtp-text-off);
   cursor: default;
 }
 
@@ -241,8 +248,8 @@
   display: flex;
   flex: 1;
   flex-direction: column;
-  gap: 22px;
-  padding: 14px 12px 16px;
+  gap: 18px;
+  padding: 12px;
   overflow-y: auto;
   overscroll-behavior: contain;
   scrollbar-color: var(--dtp-border-strong) transparent;
@@ -255,66 +262,64 @@
 
 .dtp-body::-webkit-scrollbar-thumb {
   background: var(--dtp-border-strong);
-  border: 2px solid var(--dtp-bg);
+  background-clip: content-box;
+  border: 2px solid transparent;
   border-radius: 4px;
 }
 
+/* Top-level section title — the panel's own voice, above the group titles. */
 .dtp-sectionhead {
   display: flex;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--dtp-text-faint);
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--dtp-text);
+  letter-spacing: -0.01em;
 }
 
-/* Whole-row toggle: the trailing hairline lives inside the button. */
+/* Whole-row toggle; the caret closes the row at its right edge. */
 .dtp-sectiontoggle {
   display: flex;
   flex: 1;
-  gap: 8px;
+  gap: 7px;
   align-items: center;
   min-width: 0;
-  height: 22px;
+  height: 28px;
   padding: 0;
   font: inherit;
   color: inherit;
   text-align: left;
-  text-transform: inherit;
-  letter-spacing: inherit;
   cursor: pointer;
   background: transparent;
   border: none;
   border-radius: var(--dtp-radius-xs);
-  transition: color 120ms ease;
-}
-
-.dtp-sectiontoggle:hover {
-  color: var(--dtp-text-dim);
-}
-
-.dtp-sectiontoggle::after {
-  flex: 1;
-  content: "";
-  border-top: 1px solid var(--dtp-border);
 }
 
 .dtp-sectionhead .dtp-count {
   font-family: var(--dtp-mono);
-  font-size: 10px;
+  font-size: 12px;
+  font-weight: 500;
   color: var(--dtp-text-faint);
   letter-spacing: 0;
 }
 
+/* Disclosure caret — shared by section and group headers, pinned right. */
+.dtp-chevron {
+  display: inline-flex;
+  flex: none;
+  margin-left: auto;
+  color: var(--dtp-text-faint);
+  transition: transform 200ms ease;
+}
+
 /* Inner body of a collapsible section — breathing room below the header. */
 .dtp-sectionbody {
-  padding-top: 10px;
+  padding-top: 6px;
 }
 
 .dtp-section {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 6px;
   border-radius: var(--dtp-radius-s);
 }
 
@@ -334,9 +339,9 @@
 
 .dtp-empty {
   padding: 12px 14px;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--dtp-text-faint);
-  background: var(--dtp-bg-raised);
+  background: var(--dtp-surface);
   border-radius: var(--dtp-radius-s);
 }
 
@@ -354,7 +359,7 @@
   align-items: center;
   min-width: 0;
   padding: 0 4px;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--dtp-text-faint);
 }
 
@@ -378,13 +383,13 @@
   border: none;
   border-radius: var(--dtp-radius-xs);
   transition:
-    color 120ms ease,
-    background-color 120ms ease;
+    color 150ms ease,
+    background-color 150ms ease;
 }
 
 .dtp-active-x:hover {
   color: var(--dtp-text);
-  background: var(--dtp-bg-hover);
+  background: var(--dtp-surface-hover);
 }
 
 /* ---------- groups ---------- */
@@ -394,21 +399,17 @@
   flex-direction: column;
 }
 
-.dtp-group + .dtp-group {
-  margin-top: 12px;
+/* Groups are separated by a hairline they share, not by a gap. */
+.dtp-sectionbody > .dtp-group + .dtp-group {
+  margin-top: 4px;
+  border-top: 1px solid var(--dtp-divider);
 }
 
 .dtp-grouprow {
   display: flex;
   align-items: center;
-  height: 32px;
-  padding-right: 6px;
-  border-radius: var(--dtp-radius-s);
-  transition: background-color 120ms ease;
-}
-
-.dtp-grouprow:hover {
-  background: var(--dtp-bg-raised);
+  height: var(--dtp-row-h);
+  padding-right: 4px;
 }
 
 .dtp-grouphead {
@@ -418,21 +419,22 @@
   align-items: center;
   min-width: 0;
   height: 100%;
-  padding: 0 8px 0 6px;
+  padding: 0;
   font: inherit;
-  color: var(--dtp-text);
+  color: var(--dtp-text-dim);
   text-align: left;
   cursor: pointer;
   background: transparent;
   border: none;
-  border-radius: var(--dtp-radius-s);
+  transition: color 150ms ease;
 }
 
-.dtp-chevron {
-  display: inline-flex;
-  flex: none;
-  color: var(--dtp-text-faint);
-  transition: transform 200ms ease;
+.dtp-grouphead:hover {
+  color: var(--dtp-text);
+}
+
+.dtp-grouphead .dtp-chevron {
+  padding-left: 6px;
 }
 
 .dtp-group[data-collapsed="true"] .dtp-chevron {
@@ -442,16 +444,17 @@
 .dtp-grouptitle {
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 12px;
-  font-weight: 500;
-  letter-spacing: -0.005em;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
   white-space: nowrap;
 }
 
 .dtp-tag {
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 11px;
+  font-size: 12px;
+  font-weight: 500;
   color: var(--dtp-text-faint);
   white-space: nowrap;
 }
@@ -463,7 +466,7 @@
   font-size: 9px;
   color: var(--dtp-mock);
   letter-spacing: 0.08em;
-  background: rgb(245 166 35 / 0.1);
+  background: rgb(245 166 35 / 0.12);
   border-radius: 4px;
 }
 
@@ -485,8 +488,8 @@
 .dtp-groupbody-pad {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 5px 0 2px;
+  gap: 6px;
+  padding: 2px 0 12px;
 }
 
 /* ---------- control rows ---------- */
@@ -501,19 +504,14 @@
   gap: 10px;
   align-items: center;
   min-height: var(--dtp-row-h);
-  padding: 0 12px;
-  background: var(--dtp-bg-raised);
+  padding: 0 10px 0 12px;
+  background: var(--dtp-surface);
   border-radius: var(--dtp-radius-s);
-  /* Hairline edge — on a near-black ground the chips need a defined rim. */
-  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.04);
-  transition:
-    background-color 120ms ease,
-    box-shadow 120ms ease;
+  transition: background-color 150ms ease;
 }
 
 .dtp-row:hover {
-  background: var(--dtp-bg-hover);
-  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.07);
+  background: var(--dtp-surface-hover);
 }
 
 .dtp-label {
@@ -526,7 +524,8 @@
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 12px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--dtp-text-dim);
   white-space: nowrap;
 }
@@ -552,20 +551,20 @@
   justify-content: center;
   width: 22px;
   height: 22px;
-  margin-right: -5px;
+  margin-right: -4px;
   color: var(--dtp-text-faint);
   cursor: pointer;
   background: transparent;
   border: none;
   border-radius: var(--dtp-radius-xs);
   transition:
-    color 120ms ease,
-    background-color 120ms ease;
+    color 150ms ease,
+    background-color 150ms ease;
 }
 
 .dtp-reset:hover {
   color: var(--dtp-text);
-  background: var(--dtp-bg-fill);
+  background: var(--dtp-surface-strong);
 }
 
 .dtp-val {
@@ -573,10 +572,16 @@
   z-index: 1;
   flex: none;
   font-family: var(--dtp-mono);
-  font-size: 12px;
+  font-size: 13px;
+  font-weight: 500;
   font-variant-numeric: tabular-nums;
-  color: var(--dtp-text);
+  color: var(--dtp-text-dim);
   text-align: right;
+}
+
+.dtp-row[data-ov="true"] .dtp-val,
+.dtp-row:hover .dtp-val {
+  color: var(--dtp-text);
 }
 
 .dtp-val i {
@@ -610,6 +615,7 @@
 
 .dtp-slider-track {
   position: relative;
+  display: flex;
   width: 100%;
   height: 100%;
   overflow: hidden;
@@ -617,34 +623,69 @@
   border-radius: var(--dtp-radius-s);
 }
 
-.dtp-slider-indicator {
+/*
+ * Step ticks, drawn under the fill so the fill swallows them as it passes —
+ * the row keeps its calm until a pointer is on it.
+ */
+.dtp-slider-ticks {
   position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  background: var(--dtp-bg-fill);
-  transition: background-color 120ms ease;
+  inset: 0;
+  pointer-events: none;
 }
 
-.dtp-row:hover .dtp-slider-indicator {
-  background: var(--dtp-bg-fill-hover);
-}
-
-/* Thumb: a hairline marker at the fill edge, not a knob. base-ui positions it
-   inline (start edge + centered translate), so only the shape is ours. */
-.dtp-slider-thumb {
-  width: 2px;
-  height: 100%;
-  background: var(--dtp-text-faint);
-  border-radius: 1px;
+.dtp-slider-tick {
+  position: absolute;
+  top: 50%;
+  width: 1px;
+  height: 8px;
+  background: var(--dtp-border-strong);
+  border-radius: 999px;
   opacity: 0;
-  transition: opacity 120ms ease;
+  transform: translate(-50%, -50%);
+  transition: opacity 200ms ease;
+}
+
+.dtp-row:hover .dtp-slider-tick,
+.dtp-slider[data-dragging] .dtp-slider-tick {
+  opacity: 1;
+}
+
+.dtp-slider-indicator {
+  background: var(--dtp-surface-strong);
+  transition: background-color 150ms ease;
+}
+
+.dtp-row:hover .dtp-slider-indicator,
+.dtp-slider[data-dragging] .dtp-slider-indicator {
+  background: var(--dtp-border-strong);
+}
+
+/*
+ * Thumb: a short rounded bar at the fill edge, not a knob. base-ui positions
+ * it with the `translate` property, which leaves `transform` free for the
+ * idle-to-active grow.
+ */
+.dtp-slider-thumb {
+  width: 3px;
+  height: 20px;
+  background: var(--dtp-text);
+  border-radius: 999px;
+  opacity: 0;
+  transform: scaleX(0.25);
+  transition:
+    opacity 150ms ease,
+    transform 250ms cubic-bezier(0.3, 0.8, 0.4, 1);
 }
 
 .dtp-row:hover .dtp-slider-thumb,
-.dtp-slider-thumb[data-dragging],
 .dtp-slider-thumb:focus-visible {
-  opacity: 1;
+  opacity: 0.5;
+  transform: scaleX(1);
+}
+
+.dtp-slider-thumb[data-dragging] {
+  opacity: 0.9;
+  transform: scaleX(1);
 }
 
 /* number (base-ui number field) */
@@ -663,22 +704,27 @@
   height: 24px;
   padding: 0;
   font-family: var(--dtp-mono);
-  font-size: 12px;
+  font-size: 13px;
+  font-weight: 500;
   font-variant-numeric: tabular-nums;
-  color: var(--dtp-text);
+  color: var(--dtp-text-dim);
   text-align: right;
   appearance: textfield;
   background: transparent;
   border: none;
   border-bottom: 1px solid transparent;
-  transition: border-color 120ms ease;
+  transition:
+    color 150ms ease,
+    border-color 150ms ease;
 }
 
 .dtp-row:hover .dtp-num {
+  color: var(--dtp-text);
   border-bottom-color: var(--dtp-border-strong);
 }
 
 .dtp-num:focus {
+  color: var(--dtp-text);
   outline: none;
   border-bottom-color: var(--dtp-text-faint);
 }
@@ -689,7 +735,7 @@
 }
 
 .dtp-unit {
-  font-size: 11px;
+  font-size: 12px;
   color: var(--dtp-text-faint);
 }
 
@@ -702,33 +748,31 @@
   flex: none;
   grid-template-columns: 1fr 1fr;
   align-items: center;
-  width: 72px;
-  height: 26px;
-  padding: 0;
-  margin-right: -4px;
+  width: 76px;
+  height: 28px;
+  padding: 2px;
+  margin-right: -6px;
   margin-left: auto;
   font: inherit;
   cursor: pointer;
-  background: rgb(0 0 0 / 0.55);
-  border: 1px solid rgb(255 255 255 / 0.07);
-  border-radius: 7px;
+  background: transparent;
+  border: none;
+  border-radius: var(--dtp-radius-s);
 }
 
+/* The pill is the only filled thing — the track stays open. */
 .dtp-seg-thumb {
   position: absolute;
-  top: 3px;
-  left: 3px;
-  width: calc(50% - 3px);
-  height: calc(100% - 6px);
-  background: var(--dtp-bg-fill);
-  border-radius: 4px;
-  transition:
-    transform 160ms cubic-bezier(0.3, 0.8, 0.4, 1),
-    background-color 160ms ease;
+  top: 2px;
+  bottom: 2px;
+  left: 2px;
+  width: calc(50% - 2px);
+  background: var(--dtp-surface-strong);
+  border-radius: var(--dtp-radius-xs);
+  transition: transform 200ms cubic-bezier(0.3, 0.8, 0.4, 1);
 }
 
 .dtp-seg[aria-checked="true"] .dtp-seg-thumb {
-  background: var(--dtp-text);
   transform: translateX(100%);
 }
 
@@ -737,20 +781,16 @@
 .dtp-seg-on {
   position: relative;
   z-index: 1;
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 500;
   color: var(--dtp-text-faint);
   text-align: center;
-  transition: color 160ms ease;
+  transition: color 200ms ease;
 }
 
 .dtp-seg[aria-checked="false"] .dtp-seg-off,
 .dtp-seg[aria-checked="true"] .dtp-seg-on {
   color: var(--dtp-text);
-}
-
-.dtp-seg[aria-checked="true"] .dtp-seg-on {
-  color: #0a0a0a;
 }
 
 /* select (native) */
@@ -768,8 +808,9 @@
   height: 24px;
   padding: 0 18px 0 4px;
   font-family: var(--dtp-font);
-  font-size: 12px;
-  color: var(--dtp-text);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--dtp-text-dim);
   text-align: right;
   text-align-last: right;
   appearance: none;
@@ -777,11 +818,17 @@
   background: transparent;
   border: none;
   border-radius: var(--dtp-radius-xs);
+  transition: color 150ms ease;
+}
+
+.dtp-row:hover .dtp-select,
+.dtp-row[data-ov="true"] .dtp-select {
+  color: var(--dtp-text);
 }
 
 .dtp-select option {
   color: var(--dtp-text);
-  background: var(--dtp-bg-raised);
+  background: var(--dtp-bg);
 }
 
 .dtp-selectwrap svg {
@@ -803,19 +850,21 @@
   position: relative;
   z-index: 1;
   display: flex;
-  gap: 7px;
+  gap: 8px;
   align-items: center;
   margin-left: auto;
 }
 
 .dtp-hex {
   font-family: var(--dtp-mono);
-  font-size: 12px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--dtp-text-dim);
   text-transform: uppercase;
 }
 
-.dtp-row[data-ov="true"] .dtp-hex {
+.dtp-row[data-ov="true"] .dtp-hex,
+.dtp-row:hover .dtp-hex {
   color: var(--dtp-text);
 }
 
@@ -862,7 +911,7 @@
   background: var(--dtp-border-strong);
   border-radius: 2px;
   opacity: 0;
-  transition: opacity 120ms ease;
+  transition: opacity 150ms ease;
 }
 
 .dtp-resize:hover::after {
@@ -882,22 +931,22 @@
   height: 32px;
   padding: 0 13px;
   font-family: var(--dtp-font);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
   color: var(--dtp-text);
   cursor: pointer;
-  background: color-mix(in srgb, var(--dtp-bg-raised) 92%, transparent);
+  background: color-mix(in srgb, var(--dtp-bg) 88%, transparent);
   border: 1px solid var(--dtp-border);
   border-radius: var(--dtp-radius-s);
-  box-shadow: 0 4px 12px rgb(0 0 0 / 0.4);
-  backdrop-filter: blur(6px);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 0.25);
+  backdrop-filter: blur(20px);
   transition:
-    background-color 120ms ease,
-    border-color 120ms ease;
+    background-color 150ms ease,
+    border-color 150ms ease;
 }
 
 .dtp-capsule:hover {
-  background: var(--dtp-bg-hover);
+  background: var(--dtp-bg);
   border-color: var(--dtp-border-strong);
 }
 

--- a/packages/ui/src/components/app-dialog.tsx
+++ b/packages/ui/src/components/app-dialog.tsx
@@ -37,8 +37,11 @@ function AppDialogContent({
   return (
     <DialogContent
       className={cn(
-        "dark flex max-h-[calc(100dvh-2rem)] flex-col gap-0 overflow-hidden rounded-lg border border-border bg-project-chrome-surface p-0 text-foreground shadow-2xl ring-0 backdrop-blur-[20px]",
-        "max-w-[calc(100vw-2rem)] data-[size=default]:sm:max-w-[502px] data-[size=lg]:sm:max-w-3xl data-[size=sm]:sm:max-w-sm data-[size=xl]:sm:max-w-5xl",
+        // Caps are relative to the containing block, not the viewport — same
+        // convention as DialogContent, and it keeps the dialog inside whatever
+        // box it is mounted in.
+        "dark flex max-h-[calc(100%-2rem)] flex-col gap-0 overflow-hidden rounded-lg border border-border bg-project-chrome-surface p-0 text-foreground shadow-2xl ring-0 backdrop-blur-[20px]",
+        "max-w-[calc(100%-2rem)] data-[size=default]:sm:max-w-[502px] data-[size=lg]:sm:max-w-3xl data-[size=sm]:sm:max-w-sm data-[size=xl]:sm:max-w-5xl",
         className
       )}
       data-size={size}


### PR DESCRIPTION
Two changes to the dev tweaks panel, both landing in `@workspace/dev-tweaks`.

## Contain frame mode by insetting `<body>` itself

Frame mode used to dock the page into a wrapper card, which left every viewport-anchored thing outside it: `position: fixed` elements measured against the window, and every overlay React portals into `document.body` — dialogs, sheets, menus, tooltips, toasts — escaped the card entirely.

`<body>` is the card now. `contain: layout` makes the body the containing block for its fixed descendants *and* for everything portalled into it, so overlays land inside the card with no change in the host's components. It also makes the body a formatting context root, stopping body-to-viewport overflow propagation, so `overflow: hidden` clips at the card's rounded corners. `<html>` carries the scrim.

The panel cannot live inside a contained body, so it rides the top layer (`popover="manual"`); show/hide is still opacity and transform, so the transitions are unchanged, and platforms without popover support no-op. The card wears the host's own body background, so `--dtp-card-bg` leaves the bridge contract. The one production change is `AppDialogContent`, whose `100dvh`/`100vw` caps become `100%` — the convention `DialogContent` already uses, and correct against viewport and card alike.

## Reskin the panel on a translucent glass material

The row-chip stack was five separately mixed grays on a near-black ground, which left every chip needing an inset hairline just to have an edge and the slider fill nearly invisible against the row it painted into.

It takes [dialkit](https://github.com/joshpuckett/dialkit)'s material instead. The ground lifts from `#0a0a0a` to `#212121` behind a 20px blur, and every surface above it becomes white at a low alpha — `.05` at rest, `.10` on hover, `.11` for a fill — so the panel reads as one material lit at four levels and the chips define themselves without rims. Text collapses to three alpha levels plus one for disabled.

- **Type** goes up with it: labels and values 12 → 13px/500, panel title 13 → 15px/600, group titles 13px/600. That also fixes a hierarchy inversion — "Active" and "This screen" used to whisper in 11px uppercase above group titles set larger than them.
- **Groups** lose the hover fill and the uppercase section label and separate on a shared hairline; the disclosure caret moves to the right edge of both section and group headers.
- **Slider** picks up dialkit's two signature moves: the thumb becomes a 3×20 rounded bar that grows in from `scaleX(.25)` on hover and brightens while dragging, and step ticks fade in beneath the fill — one per step while the range is coarse (≤ 10 steps), otherwise a 10% grid — so the fill swallows them as it advances. Both are pure CSS: base-ui positions the thumb with the `translate` property, leaving `transform` free for the grow, and already carries `data-dragging`.
- **Switch** drops its dark track so only the pill is filled, and the checked label stays white rather than inverting to black.

Geist stays — the font is ours, not dialkit's — as do amber (mock) and blue (focus), which carry meaning.

## Verification

Both changes were checked in Chrome against the real stylesheet.

For frame mode: a `fixed inset: 0` node appended to `document.body` measures identical to the card rather than the window, a bottom-right toast anchors to the card's corner, and the top-layer panel still measures against the viewport.

For the reskin, with base-ui's inline geometry reproduced by hand: the slider indicator measures full row height at the right fraction of the track (189.44px = 64% of 296), a collapsed group's body measures zero, and ticks plus thumb appear only on hover.

Package tests (16), `bun typecheck` and `bun check` all pass. The panel is dev/demo only — production builds still tree-shake it away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)