### PR TITLE
feat(demo): mock project data switchable from the dev tweaks panel

### DIFF
--- a/apps/ui/next.config.mjs
+++ b/apps/ui/next.config.mjs
@@ -15,6 +15,9 @@ const nextConfig = {
     // NEXT_PUBLIC_* var compiles to a runtime lookup and would keep the
     // panel chunk in the bundle.
     NEXT_PUBLIC_DEV_TWEAKS: process.env.NEXT_PUBLIC_DEV_TWEAKS ?? "",
+    // Same treatment for the demo data mock: inlined so regular builds
+    // compile the mock hook to an inert stub and drop the generators.
+    NEXT_PUBLIC_DEMO_MOCK: process.env.NEXT_PUBLIC_DEMO_MOCK ?? "",
   },
   logging: {
     serverFunctions: false,

--- a/apps/ui/src/features/projects/demo/demo-projects.test.ts
+++ b/apps/ui/src/features/projects/demo/demo-projects.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+
+import { generateDemoProjects } from "@/features/projects/demo/demo-projects";
+
+describe("generateDemoProjects", () => {
+  test("is deterministic for the same seed and count", () => {
+    const a = generateDemoProjects({ count: 12, seed: 1 });
+    const b = generateDemoProjects({ count: 12, seed: 1 });
+    expect(a.projects).toEqual(b.projects);
+    expect([...a.iconKeys.entries()]).toEqual([...b.iconKeys.entries()]);
+  });
+
+  test("growing the count appends without reshuffling earlier rows", () => {
+    const small = generateDemoProjects({ count: 12, seed: 7 });
+    const large = generateDemoProjects({ count: 50, seed: 7 });
+    expect(large.projects.slice(0, 12)).toEqual(small.projects);
+  });
+
+  test("changing the seed regenerates ids and names", () => {
+    const a = generateDemoProjects({ count: 12, seed: 1 });
+    const b = generateDemoProjects({ count: 12, seed: 2 });
+    expect(a.projects[0]?.id).not.toBe(b.projects[0]?.id);
+    const namesA = a.projects.map((project) => project.name).join("|");
+    const namesB = b.projects.map((project) => project.name).join("|");
+    expect(namesA).not.toBe(namesB);
+  });
+
+  test("keeps the boundary samples at their fixed indices", () => {
+    const { projects } = generateDemoProjects({ count: 12, seed: 5 });
+    expect(projects[2]?.name).toBe(
+      "customer-feedback-sentiment-analysis-pipeline-legacy-migration-v2"
+    );
+    expect(projects[6]?.name).toBe("内部运营数据看板");
+    expect(projects[9]?.name).toBe("ml");
+  });
+
+  test("names and ids stay unique at the maximum count", () => {
+    const { iconKeys, projects } = generateDemoProjects({
+      count: 200,
+      seed: 3,
+    });
+    expect(projects).toHaveLength(200);
+    expect(new Set(projects.map((project) => project.id)).size).toBe(200);
+    expect(new Set(projects.map((project) => project.name)).size).toBe(200);
+    for (const project of projects) {
+      expect(iconKeys.has(project.id)).toBe(true);
+    }
+  });
+
+  test("clamps count to the supported range", () => {
+    expect(generateDemoProjects({ count: -5, seed: 1 }).projects).toHaveLength(
+      0
+    );
+    expect(
+      generateDemoProjects({ count: 10_000, seed: 1 }).projects
+    ).toHaveLength(200);
+  });
+});

--- a/apps/ui/src/features/projects/demo/demo-projects.ts
+++ b/apps/ui/src/features/projects/demo/demo-projects.ts
@@ -1,0 +1,206 @@
+// biome-ignore-all lint/suspicious/noBitwiseOperators: the demo dataset hash intentionally mixes 32-bit integers so the same knob values always regenerate the same projects.
+import type { ProjectExplorerProject } from "@/features/projects/explorer/project-explorer.types";
+import type {
+  ProjectShortcutIconKey,
+  ProjectShortcutIconKeyMap,
+} from "@/features/projects/project-shortcut-icons";
+
+/**
+ * Baked-in default for the "Mock data" switch in the dev tweaks panel (see
+ * `next.config.mjs`): demo builds set `NEXT_PUBLIC_DEMO_MOCK=1` so the app
+ * opens with the mock already on; everywhere else the switch starts off and
+ * can be flipped at runtime from the panel.
+ */
+export const DEMO_PROJECTS_MOCK = process.env.NEXT_PUBLIC_DEMO_MOCK === "1";
+
+export const DEMO_PROJECTS_DEFAULT_COUNT = 12;
+export const DEMO_PROJECTS_DEFAULT_INITIAL_PINS = 3;
+export const DEMO_PROJECTS_DEFAULT_SEED = 1;
+export const DEMO_PROJECTS_MAX_COUNT = 200;
+
+const DEMO_NAME_POOL = [
+  "orders-api",
+  "checkout-web",
+  "billing-service",
+  "auth-gateway",
+  "analytics-etl",
+  "notification-hub",
+  "search-indexer",
+  "image-resizer",
+  "landing-page",
+  "docs-site",
+  "inventory-sync",
+  "payment-webhooks",
+  "user-profile-api",
+  "recommendation-engine",
+  "session-cache",
+  "email-digest",
+  "feature-flags",
+  "audit-log-collector",
+  "mobile-bff",
+  "admin-console",
+  "pricing-engine",
+  "geo-lookup",
+  "report-scheduler",
+  "media-transcoder",
+  "crm-bridge",
+  "webhook-relay",
+  "ab-testing",
+  "fraud-monitor",
+  "invoice-generator",
+  "chat-support-bot",
+  "data-warehouse-sync",
+  "status-page",
+  "cdn-purger",
+  "license-server",
+  "survey-widget",
+  "backup-runner",
+] as const;
+
+/**
+ * Boundary samples pinned to fixed indices so the default scene (12 projects,
+ * first 3 pinned) always shows them above the fold: a name long enough to
+ * exercise truncation (and it lands in the Pinned group), a CJK name, and a
+ * minimal two-character name.
+ */
+const DEMO_EDGE_NAMES: Readonly<Record<number, string>> = {
+  2: "customer-feedback-sentiment-analysis-pipeline-legacy-migration-v2",
+  6: "内部运营数据看板",
+  9: "ml",
+};
+
+const DEMO_DESCRIPTION_POOL = [
+  "Handles order intake and fulfillment events.",
+  "Customer-facing checkout flow.",
+  "Aggregates usage into daily invoices.",
+  "OAuth2 token exchange and session issuing.",
+  "Nightly batch loads into the warehouse.",
+  "Fan-out for email, SMS and in-app pushes.",
+  "Full-text index rebuild workers.",
+  "On-the-fly thumbnail generation.",
+  "Marketing site, statically rendered.",
+  "Internal developer documentation.",
+] as const;
+
+const DEMO_ICON_KEYS = [
+  "docker",
+  "postgresql",
+  "redis",
+  "mysql",
+  "mongodb",
+  "database",
+] as const satisfies readonly ProjectShortcutIconKey[];
+
+/** Newest demo project's creation instant; older rows step back from here. */
+const DEMO_EPOCH_MS = Date.UTC(2026, 7, 12, 9, 0, 0);
+const DEMO_AGE_STEP_MS = 13 * 60 * 60 * 1000;
+const DEMO_AGE_JITTER_MS = 9 * 60 * 60 * 1000;
+
+/** Deterministic unit-interval hash of (seed, index, salt). */
+function demoUnit(seed: number, index: number, salt: number): number {
+  let h = (seed * 374_761_393 + index * 668_265_263 + salt * 2_246_822_519) | 0;
+  h = Math.imul(h ^ (h >>> 13), 1_274_126_177);
+  h ^= h >>> 16;
+  return (h >>> 0) / 4_294_967_296;
+}
+
+function demoProjectName(seed: number, index: number): string {
+  const edge = DEMO_EDGE_NAMES[index];
+  if (edge !== undefined) {
+    return edge;
+  }
+  const offset = Math.floor(demoUnit(seed, 0, 1) * DEMO_NAME_POOL.length);
+  const poolIndex = (index + offset) % DEMO_NAME_POOL.length;
+  const round = Math.floor((index + offset) / DEMO_NAME_POOL.length);
+  const base = DEMO_NAME_POOL[poolIndex] ?? DEMO_NAME_POOL[0];
+  return round === 0 ? base : `${base}-${round + 1}`;
+}
+
+function demoProjectStatus(
+  seed: number,
+  index: number
+): ProjectExplorerProject["status"] {
+  const r = demoUnit(seed, index, 2);
+  if (r < 0.6) {
+    return "positive";
+  }
+  if (r < 0.78) {
+    return "progress";
+  }
+  if (r < 0.9) {
+    return "neutral";
+  }
+  if (r < 0.95) {
+    return undefined;
+  }
+  return "negative";
+}
+
+function demoProjectIconKey(
+  seed: number,
+  index: number
+): ProjectShortcutIconKey {
+  const r = demoUnit(seed, index, 3);
+  if (r < 0.5) {
+    return "docker";
+  }
+  const rest = DEMO_ICON_KEYS.length - 1;
+  const pick = 1 + Math.min(rest - 1, Math.floor(((r - 0.5) / 0.5) * rest));
+  return DEMO_ICON_KEYS[pick] ?? "docker";
+}
+
+function demoProjectCreatedAt(seed: number, index: number): string {
+  const jitter = demoUnit(seed, index, 4) * DEMO_AGE_JITTER_MS;
+  return new Date(
+    DEMO_EPOCH_MS - index * DEMO_AGE_STEP_MS - Math.floor(jitter)
+  ).toISOString();
+}
+
+function demoProjectDescription(seed: number, index: number): string {
+  const r = demoUnit(seed, index, 5);
+  if (r >= 0.6) {
+    return "";
+  }
+  const pick = Math.floor((r / 0.6) * DEMO_DESCRIPTION_POOL.length);
+  return DEMO_DESCRIPTION_POOL[pick] ?? "";
+}
+
+export interface DemoProjectsDataset {
+  iconKeys: ProjectShortcutIconKeyMap;
+  projects: ProjectExplorerProject[];
+}
+
+/**
+ * Deterministic dataset for demo builds: the same `(seed, count)` always
+ * yields the same projects, and growing `count` only appends — earlier rows
+ * (ids, names, statuses) never reshuffle, so pins survive count changes.
+ */
+export function generateDemoProjects(input: {
+  count: number;
+  seed: number;
+}): DemoProjectsDataset {
+  const count = Math.min(
+    DEMO_PROJECTS_MAX_COUNT,
+    Math.max(0, Math.trunc(input.count))
+  );
+  const seed = Math.trunc(input.seed);
+  const projects: ProjectExplorerProject[] = [];
+  const iconKeys = new Map<string, ProjectShortcutIconKey>();
+
+  for (let index = 0; index < count; index += 1) {
+    const id = `demo-${seed}-${index}`;
+    const status = demoProjectStatus(seed, index);
+    const description = demoProjectDescription(seed, index);
+    projects.push({
+      createdAt: demoProjectCreatedAt(seed, index),
+      ...(description === "" ? {} : { description }),
+      id,
+      name: demoProjectName(seed, index),
+      resourceName: id,
+      ...(status === undefined ? {} : { status }),
+    });
+    iconKeys.set(id, demoProjectIconKey(seed, index));
+  }
+
+  return { iconKeys, projects };
+}

--- a/apps/ui/src/features/projects/demo/use-demo-projects-mock.ts
+++ b/apps/ui/src/features/projects/demo/use-demo-projects-mock.ts
@@ -1,0 +1,189 @@
+"use client";
+
+import { type DevTweaksGroupDef, useDevTweaks } from "@workspace/dev-tweaks";
+import { atom, useAtom } from "jotai";
+import { useCallback, useEffect, useMemo } from "react";
+import {
+  DEMO_PROJECTS_DEFAULT_COUNT,
+  DEMO_PROJECTS_DEFAULT_INITIAL_PINS,
+  DEMO_PROJECTS_DEFAULT_SEED,
+  DEMO_PROJECTS_MAX_COUNT,
+  DEMO_PROJECTS_MOCK,
+  type DemoProjectsDataset,
+  generateDemoProjects,
+} from "@/features/projects/demo/demo-projects";
+import type { ProjectExplorerProject } from "@/features/projects/explorer/project-explorer.types";
+import {
+  MAX_PINNED_PROJECTS,
+  type PinnedProjectIdResult,
+  prunePinnedProjectIds,
+  type TogglePinnedProjectIdStatus,
+  togglePinnedProjectId,
+} from "@/features/projects/pinned-projects";
+import type { ProjectShortcutIconKeyMap } from "@/features/projects/project-shortcut-icons";
+
+const DEMO_PROJECTS_TWEAKS = {
+  controls: {
+    // Build-time default: demo builds (NEXT_PUBLIC_DEMO_MOCK=1) open with the
+    // mock already on, so viewers never have to find this switch; everywhere
+    // else it starts off and the panel is the way in.
+    enabled: {
+      label: "Mock data",
+      type: "switch",
+      value: DEMO_PROJECTS_MOCK,
+    },
+    initialPins: {
+      label: "Initial pins (changing resets manual pins)",
+      max: MAX_PINNED_PROJECTS,
+      min: 0,
+      step: 1,
+      type: "slider",
+      value: DEMO_PROJECTS_DEFAULT_INITIAL_PINS,
+    },
+    projectCount: {
+      label: "Projects",
+      max: DEMO_PROJECTS_MAX_COUNT,
+      min: 0,
+      step: 1,
+      type: "slider",
+      value: DEMO_PROJECTS_DEFAULT_COUNT,
+    },
+    seed: {
+      label: "Data seed (change to regenerate)",
+      step: 1,
+      type: "number",
+      value: DEMO_PROJECTS_DEFAULT_SEED,
+    },
+  },
+  feature: "projects",
+  kind: "mock",
+  note: "Generated dataset for the sidebar and project explorer, replacing every remote read while on. Deterministic: growing the count appends rows without reshuffling, so pins survive; changing the seed rebuilds the dataset and resets pins. Pin/unpin stays live on the explorer rows.",
+  title: "Demo · Project data",
+} as const satisfies DevTweaksGroupDef;
+
+interface DemoPinnedState {
+  /** `${seed}:${initialPins}` the ids were captured under. */
+  basis: string;
+  ids: string[];
+}
+
+const DEMO_PINS_STORAGE_KEY = "demo-projects.pins.v1";
+
+/** Shared across the sidebar and the explorer via the app's default store. */
+const demoPinnedAtom = atom<DemoPinnedState | null>(null);
+let demoPinnedHydrated = false;
+
+const EMPTY_DATASET: DemoProjectsDataset = {
+  iconKeys: new Map(),
+  projects: [],
+};
+
+function readStoredDemoPins(): DemoPinnedState | null {
+  try {
+    const raw = window.sessionStorage.getItem(DEMO_PINS_STORAGE_KEY);
+    if (raw === null) {
+      return null;
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== "object") {
+      return null;
+    }
+    const candidate = parsed as { basis?: unknown; ids?: unknown };
+    if (typeof candidate.basis !== "string" || !Array.isArray(candidate.ids)) {
+      return null;
+    }
+    return {
+      basis: candidate.basis,
+      ids: candidate.ids.filter((id): id is string => typeof id === "string"),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredDemoPins(state: DemoPinnedState): void {
+  try {
+    window.sessionStorage.setItem(DEMO_PINS_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Session persistence is best-effort; the in-memory atom still works.
+  }
+}
+
+export interface DemoProjectsMockModel {
+  pinnedProjectIds: readonly string[];
+  projectShortcutIconKeys: ProjectShortcutIconKeyMap;
+  projects: ProjectExplorerProject[];
+  togglePinnedProject: (
+    projectId: string
+  ) => Promise<PinnedProjectIdResult<TogglePinnedProjectIdStatus>>;
+}
+
+/**
+ * Demo data source for the projects read model, switchable at runtime from
+ * the dev tweaks panel ("Demo · Project data" › "Mock data"). Returns the
+ * generated model while the switch is on and `null` while it is off. In
+ * builds without the panel the hook is inert and only a demo build's baked-in
+ * default (`NEXT_PUBLIC_DEMO_MOCK=1`) can turn it on.
+ */
+export function useDemoProjectsMock(): DemoProjectsMockModel | null {
+  const { values } = useDevTweaks("demo-projects", DEMO_PROJECTS_TWEAKS);
+  const enabled = values.enabled;
+  const count = Math.round(values.projectCount);
+  const initialPins = Math.round(values.initialPins);
+  const seed = Math.trunc(values.seed);
+  const [stored, setStored] = useAtom(demoPinnedAtom);
+
+  useEffect(() => {
+    if (!enabled || demoPinnedHydrated) {
+      return;
+    }
+    demoPinnedHydrated = true;
+    const fromStorage = readStoredDemoPins();
+    if (fromStorage !== null) {
+      setStored(fromStorage);
+    }
+  }, [enabled, setStored]);
+
+  const { iconKeys, projects } = useMemo(
+    () => (enabled ? generateDemoProjects({ count, seed }) : EMPTY_DATASET),
+    [count, enabled, seed]
+  );
+
+  const basis = `${seed}:${initialPins}`;
+  const pinnedProjectIds = useMemo(() => {
+    const source =
+      stored !== null && stored.basis === basis
+        ? stored.ids
+        : projects.slice(0, initialPins).map((project) => project.id);
+    return prunePinnedProjectIds(
+      source,
+      new Set(projects.map((project) => project.id))
+    );
+  }, [basis, initialPins, projects, stored]);
+
+  const togglePinnedProject = useCallback(
+    (projectId: string) => {
+      const result = togglePinnedProjectId(pinnedProjectIds, projectId);
+      if (result.status === "added" || result.status === "removed") {
+        const next = { basis, ids: result.ids };
+        setStored(next);
+        writeStoredDemoPins(next);
+      }
+      return Promise.resolve(result);
+    },
+    [basis, pinnedProjectIds, setStored]
+  );
+
+  return useMemo(
+    () =>
+      enabled
+        ? {
+            pinnedProjectIds,
+            projectShortcutIconKeys: iconKeys,
+            projects,
+            togglePinnedProject,
+          }
+        : null,
+    [enabled, iconKeys, pinnedProjectIds, projects, togglePinnedProject]
+  );
+}

--- a/apps/ui/src/features/projects/explorer/use-projects-explorer.ts
+++ b/apps/ui/src/features/projects/explorer/use-projects-explorer.ts
@@ -17,6 +17,7 @@ import {
   brainProjectsToExplorerProjects,
   isProjectDisplayNameTaken,
 } from "@/features/projects/brain-projects";
+import { useDemoProjectsMock } from "@/features/projects/demo/use-demo-projects-mock";
 import type {
   ProjectDeleteReason,
   ProjectExplorerActions,
@@ -120,6 +121,8 @@ interface ProjectsExplorerReadModel {
     aps: K8sGetResponse | undefined;
     dbs: K8sGetResponse | undefined;
   };
+  /** True while the demo mock replaces remote data (dev tweaks "Mock data"). */
+  demoActive: boolean;
   /** Revalidate the projects list (e.g. after creating a project). */
   refreshProjects: () => Promise<unknown>;
   states: ProjectExplorerStates;
@@ -130,19 +133,28 @@ interface ProjectsExplorerResult extends ProjectsExplorerReadModel {
 }
 
 function useProjectsExplorerModel(options: ProjectsExplorerReadModelOptions) {
-  const kubeconfig = options.kubeconfig.trim();
-  const ns = options.ns;
-  const hasKubeconfig = kubeconfig !== "";
+  // While the demo mock is on it replaces every remote read with the
+  // generated dataset. Real credentials may exist (the desktop iframe injects
+  // them), so the mock must win explicitly: blanking kubeconfig/ns keeps
+  // every SWR key below null and no request ever fires.
+  const demo = useDemoProjectsMock();
+  const kubeconfig = demo === null ? options.kubeconfig.trim() : "";
+  const ns = demo === null ? options.ns : "";
+  const hasKubeconfig = demo !== null || kubeconfig !== "";
   const credentialKey = useMemo(
     () => kubeconfigCredentialKey(kubeconfig),
     [kubeconfig]
   );
   const {
     limit: pinnedProjectLimit,
-    pinnedProjectIds,
+    pinnedProjectIds: remotePinnedProjectIds,
     prunePinnedProjects,
-    togglePinnedProject,
+    togglePinnedProject: toggleRemotePinnedProject,
   } = usePinnedProjects({ kubeconfig, namespace: ns });
+  const pinnedProjectIds =
+    demo === null ? remotePinnedProjectIds : demo.pinnedProjectIds;
+  const togglePinnedProject =
+    demo === null ? toggleRemotePinnedProject : demo.togglePinnedProject;
 
   const projectsQuery = useMemo(() => ({ namespace: ns }), [ns]);
 
@@ -190,7 +202,7 @@ function useProjectsExplorerModel(options: ProjectsExplorerReadModelOptions) {
     ]);
   }, [apsData, dbsData]);
 
-  const projectShortcutIconKeys = useMemo(
+  const remoteProjectShortcutIconKeys = useMemo(
     () =>
       projectShortcutIconKeysFromWorkloads({
         aps: apsData,
@@ -198,11 +210,18 @@ function useProjectsExplorerModel(options: ProjectsExplorerReadModelOptions) {
       }),
     [apsData, dbsData]
   );
+  const projectShortcutIconKeys =
+    demo === null
+      ? remoteProjectShortcutIconKeys
+      : demo.projectShortcutIconKeys;
   useProjectShortcutIconPreload(projectShortcutIconKeys);
 
   const projects = useMemo<ProjectExplorerProject[]>(
-    () => brainProjectsToExplorerProjects(rawProjects, statusByProjectId),
-    [rawProjects, statusByProjectId]
+    () =>
+      demo === null
+        ? brainProjectsToExplorerProjects(rawProjects, statusByProjectId)
+        : demo.projects,
+    [demo, rawProjects, statusByProjectId]
   );
 
   useEffect(() => {
@@ -246,6 +265,7 @@ function useProjectsExplorerModel(options: ProjectsExplorerReadModelOptions) {
 
   return {
     data,
+    demoActive: demo !== null,
     hasKubeconfig,
     kubeconfig,
     mutate,
@@ -260,10 +280,11 @@ function useProjectsExplorerModel(options: ProjectsExplorerReadModelOptions) {
 export function useProjectsExplorerReadModel(
   options: ProjectsExplorerReadModelOptions
 ): ProjectsExplorerReadModel {
-  const { data, mutate, states } = useProjectsExplorerModel(options);
+  const { data, demoActive, mutate, states } =
+    useProjectsExplorerModel(options);
   return useMemo(
-    () => ({ data, refreshProjects: mutate, states }),
-    [data, mutate, states]
+    () => ({ data, demoActive, refreshProjects: mutate, states }),
+    [data, demoActive, mutate, states]
   );
 }
 
@@ -274,6 +295,7 @@ export function useProjectsExplorer(
   const onNewProjectOverride = options.onNewProject;
   const {
     data,
+    demoActive,
     hasKubeconfig,
     kubeconfig,
     mutate,
@@ -292,12 +314,16 @@ export function useProjectsExplorer(
   );
 
   const onNewProject = useCallback(() => {
+    if (demoActive) {
+      toast.info("Demo mode — project creation is disabled.");
+      return;
+    }
     if (onNewProjectOverride) {
       onNewProjectOverride();
       return;
     }
     openAssistantPane();
-  }, [onNewProjectOverride]);
+  }, [demoActive, onNewProjectOverride]);
 
   const onProjectUpdate = useCallback(
     async (
@@ -408,22 +434,28 @@ export function useProjectsExplorer(
     [hasKubeconfig, pinnedProjectLimit, togglePinnedProject]
   );
 
-  const actions = useMemo(
-    (): ProjectExplorerActions => ({
+  const actions = useMemo((): ProjectExplorerActions => {
+    // The demo mock keeps pinning as the only row interaction: mock project
+    // ids have no real page or backend record, and the list hides the
+    // affordances whose handlers are absent (open, edit, delete).
+    if (demoActive) {
+      return { onNewProject, onProjectPinToggle };
+    }
+    return {
       onNewProject,
       onProjectClick,
       onProjectDelete,
       onProjectPinToggle,
       onProjectUpdate,
-    }),
-    [
-      onNewProject,
-      onProjectClick,
-      onProjectDelete,
-      onProjectPinToggle,
-      onProjectUpdate,
-    ]
-  );
+    };
+  }, [
+    demoActive,
+    onNewProject,
+    onProjectClick,
+    onProjectDelete,
+    onProjectPinToggle,
+    onProjectUpdate,
+  ]);
 
-  return { actions, data, states, refreshProjects: mutate };
+  return { actions, data, demoActive, states, refreshProjects: mutate };
 }

--- a/apps/ui/src/features/projects/project-index/project-index.tsx
+++ b/apps/ui/src/features/projects/project-index/project-index.tsx
@@ -56,7 +56,7 @@ export function ProjectIndex() {
   const kubeconfig = useAtomValue(kubeconfigAtom).trim();
   const ns = useAtomValue(namespaceAtom);
 
-  const { actions, states, refreshProjects } = useProjectsExplorer({
+  const { actions, demoActive, states, refreshProjects } = useProjectsExplorer({
     kubeconfig,
     ns,
   });
@@ -186,9 +186,15 @@ export function ProjectIndex() {
   );
   useProjectSidePaneSurface(projectListSidePaneSurface);
 
+  // While the demo mock is on, keep the hook's own onNewProject (a "disabled
+  // in demo" toast) instead of opening the creation pane — submitting it
+  // would create a real project that the mock list can never show.
   const explorerActions = useMemo(
-    () => ({ ...actions, onNewProject: openProjectCreationPane }),
-    [actions, openProjectCreationPane]
+    () =>
+      demoActive
+        ? actions
+        : { ...actions, onNewProject: openProjectCreationPane },
+    [actions, demoActive, openProjectCreationPane]
   );
   const creationPaneOpen = creationSideEntry != null;
   const skillsPaneOpen = projectSideRouteEntry?.kind === "skillsWorkflow";


### PR DESCRIPTION
## What

Adds a **Demo · Project data** mock group to the dev tweaks panel: a *Mock data* switch plus knobs for project count (0–200), initial pins, and a data seed.

- While the switch is on, the projects read model swaps every remote read (projects, pins, icons/status) for a deterministic generated dataset; kubeconfig/ns are blanked so **no request fires**, even inside the desktop iframe.
- Pin/unpin stays live against sessionStorage-backed local state, reusing the real toggle logic and the 8-pin limit.
- The dataset is deterministic per (seed, count): growing the count only appends (pins survive), changing the seed regenerates and resets pins. Boundary samples (over-long name, CJK name, two-char name) sit at fixed indices in the default 12-project scene.
- While mocked, explorer rows keep pinning as their only interaction — open/edit/delete/creation are withheld (mock ids have no page or backend record).
- `NEXT_PUBLIC_DEMO_MOCK=1` (inlined like `NEXT_PUBLIC_DEV_TWEAKS`) only bakes the switch's **default** to on so demo builds open already mocked; regular builds default off, and production builds without the panel can't reach the switch at all. Builds without the flag are unchanged.

Pairs with #270, which threads the flag through the Docker/CI build path.

## Notes

- Cherry-picked from the sidebar branch minus its `app-sidebar.tsx` wiring: the current sidebar shows mock projects through the shared read model unchanged (rows stay links); the "mock rows don't navigate" refinement targets the reworked sidebar and rides that branch.
- Tests: `apps/ui/src/features/projects/demo/demo-projects.test.ts` (determinism, append-only growth, seed regeneration, edge samples, uniqueness, clamping) — 6/6. `bun typecheck` and `bun check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)