### PR TITLE
fix(dev-tweaks): restore the package's eslint config and pass its rules

### DIFF
--- a/packages/dev-tweaks/eslint.config.js
+++ b/packages/dev-tweaks/eslint.config.js
@@ -1,0 +1,5 @@
+import { config } from "@workspace/eslint-config/base";
+
+const eslintConfig = [...config];
+
+export default eslintConfig;

--- a/packages/dev-tweaks/src/panel/panel.tsx
+++ b/packages/dev-tweaks/src/panel/panel.tsx
@@ -103,10 +103,13 @@ function PanelChrome({
   const narrow = useMediaQuery("(max-width: 1023px)");
   const reducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
   // Start from defaults on both server and first client render (hydration
-  // must match); the persisted prefs land right after mount.
+  // must match); the persisted prefs land a frame after mount — same frame as
+  // the aside's `entered` flip, so the closed panel never paints with them
+  // pending.
   const [prefs, setPrefs] = useState<PanelPrefs>(DEFAULT_PANEL_PREFS);
   useEffect(() => {
-    setPrefs(loadPanelPrefs());
+    const raf = requestAnimationFrame(() => setPrefs(loadPanelPrefs()));
+    return () => cancelAnimationFrame(raf);
   }, []);
 
   useTogglesHotkey(store);
@@ -271,10 +274,12 @@ function PanelAside({
   const panelRef = useRef<HTMLElement | null>(null);
   useTopLayer(panelRef);
   // Mount flag — lets the first open play an entrance transition even when
-  // the aside just remounted (hard mode handoff).
+  // the aside just remounted (hard mode handoff). Flipped inside rAF so the
+  // initial styles get a painted frame first and the transition always runs.
   const [entered, setEntered] = useState(false);
   useEffect(() => {
-    setEntered(true);
+    const raf = requestAnimationFrame(() => setEntered(true));
+    return () => cancelAnimationFrame(raf);
   }, []);
 
   const anchoredTop = prefs.corner === "tl" || prefs.corner === "tr";


### PR DESCRIPTION
## What

Main's **Quality** workflow has been failing since #268: the dev-tweaks package split kept the `lint` script (`eslint --max-warnings 0`) but didn't bring an `eslint.config.js`, so ESLint 9 aborts with "couldn't find an eslint.config file" and `check / typecheck / lint` goes red on every run that misses the turbo cache.

- Add `packages/dev-tweaks/eslint.config.js` (shared `@workspace/eslint-config/base`, same shape as `packages/ui`/`shared`/`api` — the devDependencies were already in place).
- Fix the two `react-hooks/set-state-in-effect` errors the config surfaces in `panel.tsx`: the mount-time prefs load and the aside's `entered` flip now run inside `requestAnimationFrame` callbacks instead of synchronously in the effect body. For the entrance transition this is also more robust (initial styles get a painted frame, so the transition can't be swallowed by a pre-paint flush); both callbacks land in the same frame and the aside is hidden until `entered` flips, so behavior is visually unchanged.

Verified: `bun lint`, `bun typecheck`, `bun check` all clean at the repo root.

Unblocks #270 and #271, whose PR checks currently trip over this pre-existing failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)