### PR TITLE
fix(ap): project one observed public address per ingress host

### DIFF
--- a/apps/api/service/transform/ap/get.go
+++ b/apps/api/service/transform/ap/get.go
@@ -308,6 +308,15 @@ type observedServicePorts struct {
 	names   map[string]int
 }
 
+type observedIngressEndpoint struct {
+	host       string
+	key        string
+	path       string
+	port       int
+	scheme     string
+	serviceKey string
+}
+
 func observedServicePortsFromService(service map[string]interface{}) observedServicePorts {
 	out := observedServicePorts{
 		numbers: make(map[int]bool),
@@ -351,9 +360,9 @@ func (ports observedServicePorts) hasPort(port int) bool {
 	return ports.numbers[port]
 }
 
-func observedPublicAddressRows(ingresses []map[string]interface{}, serviceNames map[string]bool, servicePorts map[string]observedServicePorts) []map[string]interface{} {
-	rows := []map[string]interface{}{}
-	seen := map[string]bool{}
+func observedIngressEndpoints(ingresses []map[string]interface{}, serviceNames map[string]bool, servicePorts map[string]observedServicePorts) []observedIngressEndpoint {
+	endpoints := []observedIngressEndpoint{}
+	includeAllServices := len(serviceNames) == 0
 	for _, ingress := range ingresses {
 		spec, _ := ingress["spec"].(map[string]interface{})
 		if spec == nil {
@@ -375,14 +384,18 @@ func observedPublicAddressRows(ingresses []map[string]interface{}, serviceNames 
 				continue
 			}
 			paths, _ := getSlice(rule, "http", "paths")
+			pickedFirst := false
 			for _, pathItem := range paths {
+				if pickedFirst {
+					break
+				}
 				path, _ := pathItem.(map[string]interface{})
 				if path == nil {
 					continue
 				}
 				service, _ := getMap(path, "backend", "service")
 				serviceName := strings.TrimSpace(getString(service, "name"))
-				if !serviceNames[serviceName] {
+				if !includeAllServices && !serviceNames[serviceName] {
 					continue
 				}
 				ports := servicePorts[serviceName]
@@ -390,6 +403,7 @@ func observedPublicAddressRows(ingresses []map[string]interface{}, serviceNames 
 				if port <= 0 || !ports.hasPort(port) {
 					continue
 				}
+				pickedFirst = true
 				pathValue := strings.TrimSpace(getString(path, "path"))
 				if pathValue == "" {
 					pathValue = "/"
@@ -401,21 +415,36 @@ func observedPublicAddressRows(ingresses []map[string]interface{}, serviceNames 
 				if tlsHosts[host] {
 					scheme = "https"
 				}
-				key := fmt.Sprintf("%s|%s|%d|%s", host, serviceName, port, pathValue)
-				if seen[key] {
-					continue
-				}
-				seen[key] = true
-				rows = append(rows, map[string]interface{}{
-					"host":   host,
-					"id":     "observed-" + stablePlatformAddressHostLabel(key, 12),
-					"port":   port,
-					"status": "accessible",
-					"type":   "observed",
-					"url":    fmt.Sprintf("%s://%s%s", scheme, host, pathValue),
+				endpoints = append(endpoints, observedIngressEndpoint{
+					host:       host,
+					key:        fmt.Sprintf("%s|%s|%d", host, serviceName, port),
+					path:       pathValue,
+					port:       port,
+					scheme:     scheme,
+					serviceKey: serviceName + ":" + strconv.Itoa(port),
 				})
 			}
 		}
+	}
+	return endpoints
+}
+
+func observedPublicAddressRows(ingresses []map[string]interface{}, serviceNames map[string]bool, servicePorts map[string]observedServicePorts) []map[string]interface{} {
+	rows := []map[string]interface{}{}
+	seen := map[string]bool{}
+	for _, endpoint := range observedIngressEndpoints(ingresses, serviceNames, servicePorts) {
+		if seen[endpoint.key] {
+			continue
+		}
+		seen[endpoint.key] = true
+		rows = append(rows, map[string]interface{}{
+			"host":   endpoint.host,
+			"id":     "observed-" + stablePlatformAddressHostLabel(endpoint.key, 12),
+			"port":   endpoint.port,
+			"status": "accessible",
+			"type":   "observed",
+			"url":    fmt.Sprintf("%s://%s%s", endpoint.scheme, endpoint.host, endpoint.path),
+		})
 	}
 	return rows
 }
@@ -965,7 +994,7 @@ func buildConnectionRows(ap map[string]interface{}, ingresses, services []map[st
 	if apNamespace == "" {
 		return nil
 	}
-	externalBySvcPort := buildExternalAddressMap(ingresses, apNamespace)
+	externalBySvcPort := buildExternalAddressMap(ingresses)
 
 	var rows []map[string]interface{}
 	seen := make(map[string]bool)
@@ -1110,97 +1139,12 @@ func getPorts(svc map[string]interface{}) []int {
 	return ports
 }
 
-func buildExternalAddressMap(ingresses []map[string]interface{}, namespace string) map[string]string {
+func buildExternalAddressMap(ingresses []map[string]interface{}) map[string]string {
 	result := make(map[string]string)
-	for _, ing := range ingresses {
-		ingNamespace := getString(ing, "metadata", "namespace")
-		if ingNamespace == "" {
-			ingNamespace = namespace
-		}
-		lbHost := getLoadBalancerHost(ing)
-		spec, _ := ing["spec"].(map[string]interface{})
-		if spec == nil {
-			continue
-		}
-		tlsHosts := getTLSHosts(spec)
-		rules, _ := spec["rules"].([]interface{})
-		if rules == nil {
-			continue
-		}
-		for _, r := range rules {
-			rule, _ := r.(map[string]interface{})
-			if rule == nil {
-				continue
-			}
-			host, _ := rule["host"].(string)
-			if host == "" {
-				host = lbHost
-			}
-			if host == "" || isPlaceholderIngressHost(host) {
-				continue
-			}
-			httpRule, _ := rule["http"].(map[string]interface{})
-			if httpRule == nil {
-				continue
-			}
-			paths, _ := httpRule["paths"].([]interface{})
-			if paths == nil {
-				continue
-			}
-			scheme := "http"
-			if tlsHosts[host] {
-				scheme = "https"
-			}
-			for _, p := range paths {
-				pathObj, _ := p.(map[string]interface{})
-				if pathObj == nil {
-					continue
-				}
-				path, _ := pathObj["path"].(string)
-				if path == "" {
-					path = "/"
-				}
-				if path[0] != '/' {
-					path = "/" + path
-				}
-				backend, _ := pathObj["backend"].(map[string]interface{})
-				if backend == nil {
-					continue
-				}
-				svcRef, _ := backend["service"].(map[string]interface{})
-				if svcRef == nil {
-					continue
-				}
-				svcName, _ := svcRef["name"].(string)
-				if svcName == "" {
-					continue
-				}
-				var port int
-				if portObj, ok := svcRef["port"].(map[string]interface{}); ok {
-					switch v := portObj["number"].(type) {
-					case float64:
-						port = int(v)
-					case int:
-						port = v
-					case int64:
-						port = int(v)
-					case int32:
-						port = int(v)
-					case string:
-						if p, err := strconv.Atoi(v); err == nil {
-							port = p
-						}
-					}
-				}
-				if port == 0 {
-					continue
-				}
-				addr := fmt.Sprintf("%s://%s%s", scheme, host, path)
-				key := svcName + ":" + strconv.Itoa(port)
-				if _, exists := result[key]; !exists {
-					result[key] = addr
-				}
-			}
+	for _, endpoint := range observedIngressEndpoints(ingresses, map[string]bool{}, map[string]observedServicePorts{}) {
+		addr := fmt.Sprintf("%s://%s%s", endpoint.scheme, endpoint.host, endpoint.path)
+		if _, exists := result[endpoint.serviceKey]; !exists {
+			result[endpoint.serviceKey] = addr
 		}
 	}
 	return result

--- a/apps/api/service/transform/ap/get.go
+++ b/apps/api/service/transform/ap/get.go
@@ -285,16 +285,7 @@ func mergeObservedPublicAccessStatus(status map[string]interface{}, ingresses, s
 	if len(publicAddressRowsFromValue(networkCopy["publicAddresses"])) > 0 {
 		return
 	}
-	serviceNames := make(map[string]bool, len(services))
-	servicePorts := make(map[string]observedServicePorts, len(services))
-	for _, service := range services {
-		name := strings.TrimSpace(getString(service, "metadata", "name"))
-		if name == "" {
-			continue
-		}
-		serviceNames[name] = true
-		servicePorts[name] = observedServicePortsFromService(service)
-	}
+	serviceNames, servicePorts := observedServiceLookup(services)
 	rows := observedPublicAddressRows(ingresses, serviceNames, servicePorts)
 	if len(rows) == 0 {
 		return
@@ -311,10 +302,23 @@ type observedServicePorts struct {
 type observedIngressEndpoint struct {
 	host       string
 	key        string
-	path       string
 	port       int
 	scheme     string
 	serviceKey string
+}
+
+func observedServiceLookup(services []map[string]interface{}) (map[string]bool, map[string]observedServicePorts) {
+	serviceNames := make(map[string]bool, len(services))
+	servicePorts := make(map[string]observedServicePorts, len(services))
+	for _, service := range services {
+		name := strings.TrimSpace(getString(service, "metadata", "name"))
+		if name == "" {
+			continue
+		}
+		serviceNames[name] = true
+		servicePorts[name] = observedServicePortsFromService(service)
+	}
+	return serviceNames, servicePorts
 }
 
 func observedServicePortsFromService(service map[string]interface{}) observedServicePorts {
@@ -363,6 +367,7 @@ func (ports observedServicePorts) hasPort(port int) bool {
 func observedIngressEndpoints(ingresses []map[string]interface{}, serviceNames map[string]bool, servicePorts map[string]observedServicePorts) []observedIngressEndpoint {
 	endpoints := []observedIngressEndpoint{}
 	includeAllServices := len(serviceNames) == 0
+	seenHosts := map[string]bool{}
 	for _, ingress := range ingresses {
 		spec, _ := ingress["spec"].(map[string]interface{})
 		if spec == nil {
@@ -381,6 +386,10 @@ func observedIngressEndpoints(ingresses []map[string]interface{}, serviceNames m
 				host = lbHost
 			}
 			if host == "" || isPlaceholderIngressHost(host) {
+				continue
+			}
+			hostKey := strings.ToLower(host)
+			if seenHosts[hostKey] {
 				continue
 			}
 			paths, _ := getSlice(rule, "http", "paths")
@@ -404,21 +413,14 @@ func observedIngressEndpoints(ingresses []map[string]interface{}, serviceNames m
 					continue
 				}
 				pickedFirst = true
-				pathValue := strings.TrimSpace(getString(path, "path"))
-				if pathValue == "" {
-					pathValue = "/"
-				}
-				if !strings.HasPrefix(pathValue, "/") {
-					pathValue = "/" + pathValue
-				}
 				scheme := "http"
 				if tlsHosts[host] {
 					scheme = "https"
 				}
+				seenHosts[hostKey] = true
 				endpoints = append(endpoints, observedIngressEndpoint{
 					host:       host,
 					key:        fmt.Sprintf("%s|%s|%d", host, serviceName, port),
-					path:       pathValue,
 					port:       port,
 					scheme:     scheme,
 					serviceKey: serviceName + ":" + strconv.Itoa(port),
@@ -431,19 +433,14 @@ func observedIngressEndpoints(ingresses []map[string]interface{}, serviceNames m
 
 func observedPublicAddressRows(ingresses []map[string]interface{}, serviceNames map[string]bool, servicePorts map[string]observedServicePorts) []map[string]interface{} {
 	rows := []map[string]interface{}{}
-	seen := map[string]bool{}
 	for _, endpoint := range observedIngressEndpoints(ingresses, serviceNames, servicePorts) {
-		if seen[endpoint.key] {
-			continue
-		}
-		seen[endpoint.key] = true
 		rows = append(rows, map[string]interface{}{
 			"host":   endpoint.host,
 			"id":     "observed-" + stablePlatformAddressHostLabel(endpoint.key, 12),
 			"port":   endpoint.port,
 			"status": "accessible",
 			"type":   "observed",
-			"url":    fmt.Sprintf("%s://%s%s", endpoint.scheme, endpoint.host, endpoint.path),
+			"url":    fmt.Sprintf("%s://%s/", endpoint.scheme, endpoint.host),
 		})
 	}
 	return rows
@@ -994,7 +991,7 @@ func buildConnectionRows(ap map[string]interface{}, ingresses, services []map[st
 	if apNamespace == "" {
 		return nil
 	}
-	externalBySvcPort := buildExternalAddressMap(ingresses)
+	externalBySvcPort := buildExternalAddressMap(ingresses, services)
 
 	var rows []map[string]interface{}
 	seen := make(map[string]bool)
@@ -1139,10 +1136,11 @@ func getPorts(svc map[string]interface{}) []int {
 	return ports
 }
 
-func buildExternalAddressMap(ingresses []map[string]interface{}) map[string]string {
+func buildExternalAddressMap(ingresses, services []map[string]interface{}) map[string]string {
 	result := make(map[string]string)
-	for _, endpoint := range observedIngressEndpoints(ingresses, map[string]bool{}, map[string]observedServicePorts{}) {
-		addr := fmt.Sprintf("%s://%s%s", endpoint.scheme, endpoint.host, endpoint.path)
+	serviceNames, servicePorts := observedServiceLookup(services)
+	for _, endpoint := range observedIngressEndpoints(ingresses, serviceNames, servicePorts) {
+		addr := fmt.Sprintf("%s://%s/", endpoint.scheme, endpoint.host)
 		if _, exists := result[endpoint.serviceKey]; !exists {
 			result[endpoint.serviceKey] = addr
 		}

--- a/apps/api/service/transform/ap/get_test.go
+++ b/apps/api/service/transform/ap/get_test.go
@@ -204,7 +204,6 @@ func TestAPTransformProjectsOneObservedPublicAddressPerIngressHost(t *testing.T)
 		ingressPath("/admin", "eaglercraft-server-service", 5201),
 		ingressPath("/admin.css", "eaglercraft-server-service", 5201),
 		ingressPath("/admin.js", "eaglercraft-server-service", 5201),
-		ingressPath("/dynmap", "eaglercraft-server-service", 5201),
 	}
 	out := APWithIngressesAndServicesFromList(
 		map[string]interface{}{
@@ -235,6 +234,14 @@ func TestAPTransformProjectsOneObservedPublicAddressPerIngressHost(t *testing.T)
 							"host": "eaglercraft-kjmioxdq.staging-usw-1.sealos.io",
 							"http": map[string]interface{}{
 								"paths": paths,
+							},
+						},
+						map[string]interface{}{
+							"host": "eaglercraft-kjmioxdq.staging-usw-1.sealos.io",
+							"http": map[string]interface{}{
+								"paths": []interface{}{
+									ingressPath("/dynmap", "eaglercraft-server-service", 5200),
+								},
 							},
 						},
 					},

--- a/apps/api/service/transform/ap/get_test.go
+++ b/apps/api/service/transform/ap/get_test.go
@@ -197,6 +197,112 @@ func TestAPTransformProjectsObservedPublicAccessFromIngressService(t *testing.T)
 	}
 }
 
+func TestAPTransformProjectsOneObservedPublicAddressPerIngressHost(t *testing.T) {
+	paths := []interface{}{
+		ingressPath("/", "eaglercraft-server-service", 5201),
+		ingressPath("/api", "eaglercraft-server-service", 5201),
+		ingressPath("/admin", "eaglercraft-server-service", 5201),
+		ingressPath("/admin.css", "eaglercraft-server-service", 5201),
+		ingressPath("/admin.js", "eaglercraft-server-service", 5201),
+		ingressPath("/dynmap", "eaglercraft-server-service", 5201),
+	}
+	out := APWithIngressesAndServicesFromList(
+		map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "eaglercraft-server-shauji",
+				"namespace": "ns-admin",
+			},
+			"spec": map[string]interface{}{
+				"input": map[string]interface{}{
+					"network": map[string]interface{}{
+						"appListeningPorts": []interface{}{
+							map[string]interface{}{"port": 5200},
+							map[string]interface{}{"port": 5201},
+						},
+					},
+				},
+			},
+		},
+		[]map[string]interface{}{
+			{
+				"metadata": map[string]interface{}{
+					"name":      "eaglercraft-server-public",
+					"namespace": "ns-admin",
+				},
+				"spec": map[string]interface{}{
+					"rules": []interface{}{
+						map[string]interface{}{
+							"host": "eaglercraft-kjmioxdq.staging-usw-1.sealos.io",
+							"http": map[string]interface{}{
+								"paths": paths,
+							},
+						},
+					},
+					"tls": []interface{}{
+						map[string]interface{}{
+							"hosts": []interface{}{"eaglercraft-kjmioxdq.staging-usw-1.sealos.io"},
+						},
+					},
+				},
+			},
+		},
+		[]map[string]interface{}{
+			{
+				"metadata": map[string]interface{}{
+					"name":      "eaglercraft-server-service",
+					"namespace": "ns-admin",
+				},
+				"spec": map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{"port": 5200},
+						map[string]interface{}{"port": 5201},
+					},
+				},
+			},
+		},
+	)
+	status := out["status"].(map[string]interface{})
+	network := status["network"].(map[string]interface{})
+	addresses := network["publicAddresses"].([]map[string]interface{})
+	if got := len(addresses); got != 1 {
+		t.Fatalf("status.network.publicAddresses count = %d, want 1", got)
+	}
+	row := addresses[0]
+	if got := row["host"]; got != "eaglercraft-kjmioxdq.staging-usw-1.sealos.io" {
+		t.Fatalf("observed public address host = %v, want eaglercraft-kjmioxdq.staging-usw-1.sealos.io", got)
+	}
+	if got := row["url"]; got != "https://eaglercraft-kjmioxdq.staging-usw-1.sealos.io/" {
+		t.Fatalf("observed public address url = %v, want https://eaglercraft-kjmioxdq.staging-usw-1.sealos.io/", got)
+	}
+	if got := row["port"]; got != 5201 {
+		t.Fatalf("observed public address port = %v, want 5201", got)
+	}
+	variables := status["variables"].([]map[string]interface{})
+	externalCount := 0
+	internalCount := 0
+	for _, item := range variables {
+		variable := item
+		name, _ := variable["name"].(string)
+		if name == "port-5200-external" {
+			t.Fatalf("port-5200-external must not be projected from an ingress that routes only port 5201")
+		}
+		switch name {
+		case "port-5200-internal":
+			internalCount++
+		case "port-5201-internal":
+			internalCount++
+		case "port-5201-external":
+			externalCount++
+		}
+	}
+	if got := internalCount; got != 2 {
+		t.Fatalf("internal variable count = %d, want 2", got)
+	}
+	if got := externalCount; got != 1 {
+		t.Fatalf("external variable count = %d, want 1", got)
+	}
+}
+
 func TestAPTransformPreservesExistingPrivateNetworkAddress(t *testing.T) {
 	out := APWithIngressesAndServicesFromList(
 		map[string]interface{}{
@@ -980,6 +1086,18 @@ func ingressRule(host string, serviceName string, port int) map[string]interface
 				},
 			},
 		},
+	}
+}
+
+func ingressPath(path, serviceName string, port int) map[string]interface{} {
+	return map[string]interface{}{
+		"backend": map[string]interface{}{
+			"service": map[string]interface{}{
+				"name": serviceName,
+				"port": map[string]interface{}{"number": port},
+			},
+		},
+		"path": path,
 	}
 }
 


### PR DESCRIPTION
## 问题

在项目画布的 AP 网络配置中，同一 Ingress 域名的每条 path（如 `/api`、`/admin`、`/admin.css`、`/admin.js`、`/dynmap`、`/`）都被投影成独立的公网地址，导致一个只暴露了 5200/5201 两个端口的应用出现 6 条公网地址。

## 根因

`apps/api/service/transform/ap/get.go` 的 `observedPublicAddressRows` 与 `buildExternalAddressMap` 各自遍历 Ingress 的所有 path，把 path 当作独立公网入口。Launchpad 的做法是以 Service port 为数据主轴，仅用 Ingress 第一条有效 path 判断域名归属的端口。

## 改动

- 新增共享的 `observedIngressEndpoints` 解析：每个 Ingress rule 只取第一条可解析到 AP Service 的 path。
- `observedPublicAddressRows` 与 `buildExternalAddressMap` 复用同一解析结果，每个 host 只生成一条公网地址，URL 规范化到域名根路径。
- 新增回归测试：六条 path 指向 5201 的 Ingress 只投影 1 条公网地址，且不会为 5200 生成外部地址。

## 验证

- `cd apps/api && go test ./...` 全部通过
- `bun typecheck` 通过
- `bun check`（ultracite）通过