### PR TITLE
feat(ui): add APP_POSTGRES_SKIP_MIGRATIONS to skip boot-time migrations

### DIFF
--- a/apps/ui/src/lib/app-postgres/migrate.ts
+++ b/apps/ui/src/lib/app-postgres/migrate.ts
@@ -37,10 +37,21 @@ function resolveMigrationsFolder(): string {
  * app-owned Postgres state — there are no runtime CREATE TABLE fallbacks.
  *
  * No `DATABASE_URL` → skipped, so builds and DB-less dev setups still boot.
+ * `APP_POSTGRES_SKIP_MIGRATIONS=1` → skipped, for deployments that point at a
+ * database owned by another release (demo/preview envs sharing the main app's
+ * Postgres) where this build must never apply DDL. The schema then may not
+ * match this build; persistence-backed features can fail at runtime.
  * A failure is rethrown to the caller (instrumentation fails the boot in
  * production rather than serving with a half-migrated schema).
  */
 export async function runAppPostgresMigrations(): Promise<void> {
+  const skip = process.env.APP_POSTGRES_SKIP_MIGRATIONS?.trim().toLowerCase();
+  if (skip === "1" || skip === "true") {
+    console.warn(
+      "[app-postgres] APP_POSTGRES_SKIP_MIGRATIONS is set; skipping schema migrations. The database schema may not match this build."
+    );
+    return;
+  }
   const url = process.env.DATABASE_URL?.trim();
   if (!url) {
     console.warn(

--- a/apps/ui/src/lib/app-postgres/skip-migrations.test.ts
+++ b/apps/ui/src/lib/app-postgres/skip-migrations.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { runAppPostgresMigrations } from "./migrate";
+
+const savedSkip = process.env.APP_POSTGRES_SKIP_MIGRATIONS;
+const savedUrl = process.env.DATABASE_URL;
+
+afterEach(() => {
+  if (savedSkip === undefined) {
+    delete process.env.APP_POSTGRES_SKIP_MIGRATIONS;
+  } else {
+    process.env.APP_POSTGRES_SKIP_MIGRATIONS = savedSkip;
+  }
+  if (savedUrl === undefined) {
+    delete process.env.DATABASE_URL;
+  } else {
+    process.env.DATABASE_URL = savedUrl;
+  }
+});
+
+describe("runAppPostgresMigrations skip switch", () => {
+  test.each([
+    "1",
+    "true",
+    "TRUE",
+    " 1 ",
+  ])("APP_POSTGRES_SKIP_MIGRATIONS=%p returns without touching the database", async (value) => {
+    process.env.APP_POSTGRES_SKIP_MIGRATIONS = value;
+    // Unreachable on purpose: connecting would hang/throw, so resolving
+    // proves the skip happened before any pool was created.
+    process.env.DATABASE_URL =
+      "postgresql://nobody:nothing@skip-migrations.invalid:5432/none";
+    await expect(runAppPostgresMigrations()).resolves.toBeUndefined();
+  });
+
+  test("unset DATABASE_URL still skips without error", async () => {
+    delete process.env.APP_POSTGRES_SKIP_MIGRATIONS;
+    delete process.env.DATABASE_URL;
+    await expect(runAppPostgresMigrations()).resolves.toBeUndefined();
+  });
+});

--- a/charts/brain-system/values.yaml
+++ b/charts/brain-system/values.yaml
@@ -114,6 +114,10 @@ ui:
     APP_URL: ""
     GTM_ID: ""
     DATABASE_URL: ""
+    # Set to "1" when DATABASE_URL points at a database owned by another
+    # release (demo/preview envs sharing the main app's Postgres): the UI then
+    # skips its boot-time schema migrations instead of applying DDL there.
+    APP_POSTGRES_SKIP_MIGRATIONS: ""
     JWT_INTERNAL: ""
     GITHUB_APP_ID: ""
     GITHUB_APP_PRIVATE_KEY: ""


### PR DESCRIPTION
## Why

Demo/preview environments can point the UI at a database owned by another release (the main staging app's Postgres). Booting there must never run this build's migrations:

- a Drizzle journal mismatch crash-loops the pod (`relation "deploy_task_agent_calls" already exists`, seen on a live preview env today), and
- a "successful" run would apply this branch's DDL to a database the release does not own.

## What

- `runAppPostgresMigrations()` returns early with a warning when `APP_POSTGRES_SKIP_MIGRATIONS=1` (or `true`) is set.
- The production invariant is unchanged: without the explicit switch, a migration failure still aborts the boot rather than serving a half-migrated schema.
- `charts/brain-system/values.yaml` documents the switch as an empty-by-default `ui.env` key.
- Unit tests cover the accepted values and the existing no-`DATABASE_URL` skip.

## Verification

- `bun test src/lib/app-postgres/skip-migrations.test.ts` — 5 pass
- `bun typecheck`, `bun check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)