### PR TITLE
feat(ui): stop pinning the dev-tweaks capsule in demo builds

### DIFF
--- a/apps/ui/src/features/dev-tweaks/dev-tweaks-enabled.tsx
+++ b/apps/ui/src/features/dev-tweaks/dev-tweaks-enabled.tsx
@@ -21,8 +21,6 @@ const HOST_BRIDGE_STYLE: CSSProperties = {
   "--dtp-font-sans": "var(--font-sans)",
 } as CSSProperties;
 
-const DEMO_BUILD = process.env.NEXT_PUBLIC_DEV_TWEAKS === "1";
-
 /**
  * Dev-only composition root. Mock persistence drivers register here when a
  * feature needs one (e.g. the billing cookie driver once costcenter lands);
@@ -32,12 +30,10 @@ export function DevTweaksEnabled({ children }: { children: ReactNode }) {
   return (
     <DevTweaksProvider>
       <DevTweaksPanel style={HOST_BRIDGE_STYLE}>{children}</DevTweaksPanel>
-      {/* In demo builds the capsule is the only entry to the panel, so it
-          stays present even with nothing active. */}
-      <DevTweaksIndicator
-        alwaysVisible={DEMO_BUILD}
-        style={HOST_BRIDGE_STYLE}
-      />
+      {/* The capsule is a dirty indicator only: hidden until an override is
+          active, in demo builds and local dev alike. The panel opens with
+          ⌃⌥T. */}
+      <DevTweaksIndicator style={HOST_BRIDGE_STYLE} />
     </DevTweaksProvider>
   );
 }


### PR DESCRIPTION
## What

Demo images (built with `NEXT_PUBLIC_DEV_TWEAKS=1`) rendered the bottom-left "Dev tweaks" capsule permanently, as the panel's always-on entry point. This drops the `alwaysVisible={DEMO_BUILD}` wiring in `apps/ui`'s dev-tweaks composition root, so the capsule behaves the same in demo builds as in local dev: hidden until an override is active (a pure dirty indicator). The panel itself is unchanged and opens with ⌃⌥T.

## Why

Demo deployments showed a persistent UI affordance at the bottom of every page. Keeping the capsule as a dirty indicator preserves the safety net (you still see when a tweak is active during a demo) without the permanent chrome.

## Scope

- `apps/ui/src/features/dev-tweaks/dev-tweaks-enabled.tsx` only: stop passing `alwaysVisible`, delete the now-unused `DEMO_BUILD` constant.
- `@workspace/dev-tweaks` package API (including the `alwaysVisible` prop and its test) is intentionally untouched — it stays available for other hosts.
- The dead `NEXT_PUBLIC_DEMO_MOCK` build plumbing left behind by #273 is intentionally out of scope.

## Verification

- `bun typecheck` — pass
- `bun check` — pass
- `bun test` in `packages/dev-tweaks` — 16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)