### PR TITLE
feat(deploy): add GitHub repo deep-link with auto-deploy

### DIFF
--- a/apps/ui/src/app/deploy/page.tsx
+++ b/apps/ui/src/app/deploy/page.tsx
@@ -1,14 +1,21 @@
 import { redirect } from "next/navigation";
+import { githubDeployProjectPath } from "@/features/deploy/github-deploy-link";
 import { templateDeployProjectPath } from "@/features/deploy/template-deploy-link";
 
 export default async function DeployPage({
   searchParams,
 }: {
   searchParams: Promise<{
+    autoDeploy?: string | string[];
+    githubRepo?: string | string[];
     templateForm?: string | string[];
     templateName?: string | string[];
   }>;
 }) {
-  const { templateForm, templateName } = await searchParams;
+  const { autoDeploy, githubRepo, templateForm, templateName } =
+    await searchParams;
+  if (githubRepo !== undefined) {
+    redirect(githubDeployProjectPath(githubRepo, autoDeploy));
+  }
   redirect(templateDeployProjectPath(templateName, templateForm));
 }

--- a/apps/ui/src/app/deploy/page.tsx
+++ b/apps/ui/src/app/deploy/page.tsx
@@ -14,7 +14,9 @@ export default async function DeployPage({
 }) {
   const { autoDeploy, githubRepo, templateForm, templateName } =
     await searchParams;
-  if (githubRepo !== undefined) {
+  // Only a single, non-empty repo value may claim the GitHub deep link; an
+  // empty or repeated `githubRepo` must not steal a parallel template link.
+  if (typeof githubRepo === "string" && githubRepo.trim() !== "") {
     redirect(githubDeployProjectPath(githubRepo, autoDeploy));
   }
   redirect(templateDeployProjectPath(templateName, templateForm));

--- a/apps/ui/src/features/deploy/github-deploy-link.test.ts
+++ b/apps/ui/src/features/deploy/github-deploy-link.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { parseProjectSideRouteState } from "@/features/panes/side-url-codec";
+import { githubDeployProjectPath } from "./github-deploy-link";
+import { GITHUB_REPOSITORY_URL_MAX_LENGTH } from "./github-repo-url";
+
+function sideFromPath(path: string) {
+  const url = new URL(path, "https://brain.test");
+  return parseProjectSideRouteState({ side: url.searchParams.get("side") })
+    .side;
+}
+
+test("GitHub deploy link opens a direct creation flow with a canonical repo", () => {
+  assert.deepEqual(
+    sideFromPath(
+      githubDeployProjectPath("https://github.com/acme/api.git", "1")
+    ),
+    {
+      autoDeploy: true,
+      entryMode: "githubDirect",
+      githubRepo: "https://github.com/acme/api",
+      kind: "projectCreation",
+    }
+  );
+});
+
+test("GitHub deploy link defaults to manual deployment", () => {
+  assert.deepEqual(
+    sideFromPath(githubDeployProjectPath("https://github.com/acme/api")),
+    {
+      entryMode: "githubDirect",
+      githubRepo: "https://github.com/acme/api",
+      kind: "projectCreation",
+    }
+  );
+});
+
+test("GitHub deploy link fails closed for malformed public values", () => {
+  for (const value of [
+    undefined,
+    null,
+    "   ",
+    ["https://github.com/acme/api", "https://github.com/acme/other"],
+    "https://github.com/acme/api/tree/main",
+    "https://token:secret@github.com/acme/api",
+    `https://github.com/acme/${"x".repeat(GITHUB_REPOSITORY_URL_MAX_LENGTH)}`,
+  ]) {
+    assert.deepEqual(sideFromPath(githubDeployProjectPath(value)), {
+      entryMode: "githubDirect",
+      kind: "projectCreation",
+    });
+  }
+});
+
+test("GitHub deploy link ignores an invalid autoDeploy flag", () => {
+  assert.deepEqual(
+    sideFromPath(
+      githubDeployProjectPath("https://github.com/acme/api", ["1", "1"])
+    ),
+    {
+      entryMode: "githubDirect",
+      githubRepo: "https://github.com/acme/api",
+      kind: "projectCreation",
+    }
+  );
+});

--- a/apps/ui/src/features/deploy/github-deploy-link.ts
+++ b/apps/ui/src/features/deploy/github-deploy-link.ts
@@ -1,0 +1,42 @@
+import { serializeProjectSideSurfaceEntry } from "@/features/panes/url-codec";
+import {
+  GITHUB_REPOSITORY_URL_MAX_LENGTH,
+  normalizeGithubRepoUrl,
+} from "./github-repo-url";
+
+const GITHUB_REPOSITORY_URL_PREFIX_RE = /^https:\/\/github\.com\//i;
+
+function publicGithubRepoUrl(value: string | string[] | null | undefined) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const raw = value.trim();
+  if (
+    raw === "" ||
+    raw.length > GITHUB_REPOSITORY_URL_MAX_LENGTH ||
+    !GITHUB_REPOSITORY_URL_PREFIX_RE.test(raw)
+  ) {
+    return null;
+  }
+  return normalizeGithubRepoUrl(raw);
+}
+
+export function githubDeployProjectPath(
+  githubRepo: string | string[] | null | undefined,
+  autoDeploy?: string | string[] | null
+): string {
+  const normalizedRepo = publicGithubRepoUrl(githubRepo);
+  const shouldAutoDeploy = autoDeploy === "1" && normalizedRepo != null;
+  const side = serializeProjectSideSurfaceEntry({
+    entryMode: "githubDirect",
+    githubRepo: normalizedRepo ?? undefined,
+    kind: "projectCreation",
+    ...(shouldAutoDeploy ? { autoDeploy: true } : {}),
+  });
+  const searchParams = new URLSearchParams();
+  if (side != null) {
+    searchParams.set("side", side);
+  }
+  const query = searchParams.toString();
+  return query === "" ? "/project" : `/project?${query}`;
+}

--- a/apps/ui/src/features/deploy/github-deployer/github-deployer.context.tsx
+++ b/apps/ui/src/features/deploy/github-deployer/github-deployer.context.tsx
@@ -39,11 +39,15 @@ export function useGithubDeployer(): GithubDeployerValue {
 
 export function GithubDeployerRoot({
   actions = {},
+  autoDeploy = false,
   children,
+  initialRepoUrl = "",
   states,
 }: {
   actions?: GithubDeployerActions;
+  autoDeploy?: boolean;
   children?: ReactNode;
+  initialRepoUrl?: string;
   states: GithubDeployerStates;
 }) {
   const [selectedRepoId, setSelectedRepoId] = useState(
@@ -109,13 +113,23 @@ export function GithubDeployerRoot({
   const value = useMemo(
     (): GithubDeployerValue => ({
       actions: resolvedActions,
+      autoDeploy,
+      initialRepoUrl,
       requestDisconnect,
       requestDeploy,
       selectedRepoId,
       setSelectedRepoId,
       states,
     }),
-    [requestDisconnect, requestDeploy, resolvedActions, selectedRepoId, states]
+    [
+      autoDeploy,
+      initialRepoUrl,
+      requestDisconnect,
+      requestDeploy,
+      resolvedActions,
+      selectedRepoId,
+      states,
+    ]
   );
 
   const recommendedTemplateLabel =

--- a/apps/ui/src/features/deploy/github-deployer/github-deployer.test.tsx
+++ b/apps/ui/src/features/deploy/github-deployer/github-deployer.test.tsx
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { render } from "@testing-library/react/pure";
+import { fireEvent, render } from "@testing-library/react/pure";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import {
@@ -230,6 +230,100 @@ test("GithubDeployer auto deploys a restored GitHub URL only once", async () => 
       );
     });
     assert.equal(deployCalls, 1);
+  } finally {
+    if (rendered) {
+      await actAndDrain(() => {
+        rendered?.unmount();
+      });
+    }
+    restoreActEnvironment(previousActEnvironment);
+    await dom.restore();
+  }
+});
+
+test("GithubDeployer auto deploy stays one-shot after the URL is edited", async () => {
+  const dom = installTestDom();
+  const previousActEnvironment = setActEnvironment(true);
+  let deployCalls = 0;
+  const onDeploy = () => {
+    deployCalls += 1;
+  };
+  const authorizedProps = {
+    actions: { onDeploy },
+    autoDeploy: true,
+    initialRepoUrl: "https://github.com/acme/api",
+    states: {
+      isAuthorized: true,
+      repos: [],
+    },
+  } as const;
+  let rendered: ReturnType<typeof render> | undefined;
+  try {
+    await actAndDrain(() => {
+      rendered = render(
+        <GithubDeployer.Root {...authorizedProps}>
+          <GithubDeployer.UrlInput />
+        </GithubDeployer.Root>
+      );
+    });
+    assert.equal(deployCalls, 1);
+
+    const input = rendered?.container.querySelector('input[type="url"]');
+    if (input == null) {
+      throw new Error("repository URL input is present");
+    }
+    await actAndDrain(() => {
+      fireEvent.change(input, {
+        target: { value: "https://github.com/acme/other" },
+      });
+    });
+    assert.equal(deployCalls, 1);
+  } finally {
+    if (rendered) {
+      await actAndDrain(() => {
+        rendered?.unmount();
+      });
+    }
+    restoreActEnvironment(previousActEnvironment);
+    await dom.restore();
+  }
+});
+
+test("GithubDeployer auto deploy fails closed for an unrequested repo", async () => {
+  const dom = installTestDom();
+  const previousActEnvironment = setActEnvironment(true);
+  let deployCalls = 0;
+  const onDeploy = () => {
+    deployCalls += 1;
+  };
+  const authorizedProps = {
+    actions: { onDeploy },
+    autoDeploy: true,
+    initialRepoUrl: "https://github.com/acme/api/tree/main",
+    states: {
+      isAuthorized: true,
+      repos: [],
+    },
+  } as const;
+  let rendered: ReturnType<typeof render> | undefined;
+  try {
+    await actAndDrain(() => {
+      rendered = render(
+        <GithubDeployer.Root {...authorizedProps}>
+          <GithubDeployer.UrlInput />
+        </GithubDeployer.Root>
+      );
+    });
+    const input = rendered?.container.querySelector('input[type="url"]');
+    if (input == null) {
+      throw new Error("repository URL input is present");
+    }
+    await actAndDrain(() => {
+      fireEvent.change(input, {
+        target: { value: "https://github.com/acme/api" },
+      });
+    });
+    assert.equal(deployCalls, 0);
   } finally {
     if (rendered) {
       await actAndDrain(() => {

--- a/apps/ui/src/features/deploy/github-deployer/github-deployer.test.tsx
+++ b/apps/ui/src/features/deploy/github-deployer/github-deployer.test.tsx
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { render } from "@testing-library/react/pure";
 import { renderToStaticMarkup } from "react-dom/server";
 
+import {
+  actAndDrain,
+  installTestDom,
+  restoreActEnvironment,
+  setActEnvironment,
+} from "@/features/project-canvas/react-test-harness";
 import { GithubDeployer, githubUrlToRepo } from "./github-deployer";
 
 const noop = () => undefined;
@@ -146,6 +153,14 @@ test("githubUrlToRepo rejects GitHub URLs that are not repository roots", () => 
     name: "example",
     url: "https://github.com/sealai/example",
   });
+  assert.equal(
+    githubUrlToRepo("https://token:secret@github.com/sealai/example"),
+    null
+  );
+  assert.equal(
+    githubUrlToRepo("https://github.com/sealai/example?token=secret"),
+    null
+  );
 });
 
 test("GithubDeployer shows authorized empty repository state", () => {
@@ -162,6 +177,68 @@ test("GithubDeployer shows authorized empty repository state", () => {
   assert.doesNotMatch(html, CONFIGURE_BUTTON_RE);
   assert.match(html, REPO_EMPTY_RE);
   assert.doesNotMatch(html, AUTH_BUTTON_RE);
+});
+
+test("GithubDeployer auto deploys a restored GitHub URL only once", async () => {
+  const dom = installTestDom();
+  const previousActEnvironment = setActEnvironment(true);
+  let deployCalls = 0;
+  const onDeploy = () => {
+    deployCalls += 1;
+  };
+  const initialProps = {
+    actions: { onDeploy },
+    autoDeploy: true,
+    initialRepoUrl: "https://github.com/acme/api",
+    states: {
+      isAuthorized: false,
+      repos: [],
+    },
+  } as const;
+  const authorizedProps = {
+    ...initialProps,
+    states: {
+      isAuthorized: true,
+      repos: [],
+    },
+  } as const;
+  let rendered: ReturnType<typeof render> | undefined;
+  try {
+    await actAndDrain(() => {
+      rendered = render(
+        <GithubDeployer.Root {...initialProps}>
+          <GithubDeployer.UrlInput />
+        </GithubDeployer.Root>
+      );
+    });
+    assert.equal(deployCalls, 0);
+
+    await actAndDrain(() => {
+      rendered?.rerender(
+        <GithubDeployer.Root {...authorizedProps}>
+          <GithubDeployer.UrlInput />
+        </GithubDeployer.Root>
+      );
+    });
+    assert.equal(deployCalls, 1);
+
+    await actAndDrain(() => {
+      rendered?.rerender(
+        <GithubDeployer.Root {...authorizedProps}>
+          <GithubDeployer.UrlInput />
+        </GithubDeployer.Root>
+      );
+    });
+    assert.equal(deployCalls, 1);
+  } finally {
+    if (rendered) {
+      await actAndDrain(() => {
+        rendered?.unmount();
+      });
+    }
+    restoreActEnvironment(previousActEnvironment);
+    await dom.restore();
+  }
 });
 
 test("GithubDeployer shows repository load errors after authorization", () => {

--- a/apps/ui/src/features/deploy/github-deployer/github-deployer.test.tsx
+++ b/apps/ui/src/features/deploy/github-deployer/github-deployer.test.tsx
@@ -356,3 +356,45 @@ test("GithubDeployer shows repository load errors after authorization", () => {
   assert.match(html, BAD_CREDENTIALS_RE);
   assert.doesNotMatch(html, AUTH_BUTTON_RE);
 });
+
+test("GithubDeployer auto deploy fires on authorized first paint while template options still load", async () => {
+  const dom = installTestDom();
+  const previousActEnvironment = setActEnvironment(true);
+  let deployCalls = 0;
+  const onDeploy = () => {
+    deployCalls += 1;
+  };
+  const authorizedProps = {
+    actions: { onDeploy, onDeployTemplate: () => undefined },
+    autoDeploy: true,
+    initialRepoUrl: "https://github.com/acme/api",
+    states: {
+      isAuthorized: true,
+      repos: [],
+      templateOptionsLoading: true,
+    },
+  } as const;
+  let rendered: ReturnType<typeof render> | undefined;
+  try {
+    await actAndDrain(() => {
+      rendered = render(
+        <GithubDeployer.Root {...authorizedProps}>
+          <GithubDeployer.UrlInput />
+        </GithubDeployer.Root>
+      );
+    });
+    // The deep-link auto path deliberately skips the "Use existing template?"
+    // dialog: template matching happens inside the deployment task's Devbox
+    // skill, so an authorized first paint deploys immediately even while the
+    // catalog is still loading.
+    assert.equal(deployCalls, 1);
+  } finally {
+    if (rendered) {
+      await actAndDrain(() => {
+        rendered?.unmount();
+      });
+    }
+    restoreActEnvironment(previousActEnvironment);
+    await dom.restore();
+  }
+});

--- a/apps/ui/src/features/deploy/github-deployer/github-deployer.tsx
+++ b/apps/ui/src/features/deploy/github-deployer/github-deployer.tsx
@@ -15,8 +15,16 @@ import {
   Search,
   ShieldCheck,
 } from "lucide-react";
-import { type ComponentProps, type ReactNode, useMemo, useState } from "react";
+import {
+  type ComponentProps,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { DeploymentSettings } from "../deployment-settings";
+import { githubUrlToRepo as parseGithubUrlToRepo } from "../github-repo-url";
 import {
   GithubDeployerContext,
   GithubDeployerRoot,
@@ -28,47 +36,8 @@ import type { GithubDeployerRepo } from "./github-deployer.types";
 const GITHUB_MARK_PATH =
   "M12 2c5.5228 0 10 4.47715 10 10 0 4.5716 -3.0686 8.4239 -7.2578 9.6162v-3.0117c0 -0.7275 -0.1595 -1.4465 -0.4678 -2.1055 2.1883 -0.7822 4.2783 -2.4447 4.2783 -4.4355 0 -1.2663 -0.4671 -2.75174 -1.5127 -3.63186V6l-2.9462 0.98828c-0.6589 -0.16036 -1.3628 -0.24706 -2.0938 -0.24707 -0.731 0 -1.4349 0.08673 -2.09375 0.24707L6.95996 6v2.43164c-1.04555 0.88009 -1.51163 2.36566 -1.51172 3.63186 0 1.9907 2.08913 3.6533 4.27735 4.4355 -0.26358 0.5635 -0.41862 1.1711 -0.45801 1.7901 -0.13854 0.0283 -0.25191 0.0415 -0.34473 0.04 -0.20756 -0.0033 -0.36606 -0.06 -0.51953 -0.1562 -1.11532 -0.7 -1.54401 -1.9835 -3.05566 -2.1543 -0.19076 -0.0214 -0.3474 0.1371 -0.34766 0.3291 0 0.1922 0.15921 0.3423 0.34473 0.3925 1.44216 0.39 1.42755 3.2266 3.54785 3.2598 0.11976 0.0019 0.24101 -0.0069 0.36426 -0.0186v1.6348C5.06807 20.4236 2 16.5713 2 12 2 6.47715 6.47715 2 12 2";
 
-const URL_PROTOCOL_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
-const GIT_SUFFIX_RE = /\.git$/i;
 const INITIAL_REPO_LIMIT = 4;
 const REPO_LIMIT_STEP = 4;
-
-export function githubUrlToRepo(input: string): GithubDeployerRepo | null {
-  const raw = input.trim();
-  if (raw === "") {
-    return null;
-  }
-
-  const withProtocol = URL_PROTOCOL_RE.test(raw) ? raw : `https://${raw}`;
-
-  let url: URL;
-  try {
-    url = new URL(withProtocol);
-  } catch {
-    return null;
-  }
-
-  if (url.hostname.toLowerCase() !== "github.com") {
-    return null;
-  }
-
-  const [owner, repoSegment, extraPath] = url.pathname
-    .split("/")
-    .map((part) => part.trim())
-    .filter(Boolean);
-  const repo = repoSegment?.replace(GIT_SUFFIX_RE, "");
-  if (!(owner && repo) || extraPath != null) {
-    return null;
-  }
-
-  const fullName = `${owner}/${repo}`;
-  return {
-    fullName,
-    id: `github-url:${fullName}`,
-    name: repo,
-    url: `https://github.com/${fullName}`,
-  };
-}
 
 function GithubIcon({ className }: { className?: string }) {
   return (
@@ -161,11 +130,14 @@ function GithubDeployerAuthButton({ className }: { className?: string }) {
 function GithubDeployerUrlInput({ className }: { className?: string }) {
   const {
     actions: { onDeploy, onDeployTemplate },
+    autoDeploy,
+    initialRepoUrl,
     requestDeploy,
     states: { deployedRepo, isAuthorized, isLoading, templateOptionsLoading },
   } = useGithubDeployer();
-  const [repoUrl, setRepoUrl] = useState("");
-  const parsedRepo = useMemo(() => githubUrlToRepo(repoUrl), [repoUrl]);
+  const [repoUrl, setRepoUrl] = useState(initialRepoUrl);
+  const autoDeployRepoIdRef = useRef<string | null>(null);
+  const parsedRepo = useMemo(() => parseGithubUrlToRepo(repoUrl), [repoUrl]);
   const showInvalid = repoUrl.trim() !== "" && !parsedRepo;
   const isTemplateMatchingPending = Boolean(
     onDeployTemplate && templateOptionsLoading
@@ -173,6 +145,22 @@ function GithubDeployerUrlInput({ className }: { className?: string }) {
   const canDeploy = Boolean(
     isAuthorized && parsedRepo && onDeploy && !isTemplateMatchingPending
   );
+
+  useEffect(() => {
+    if (
+      !autoDeploy ||
+      deployedRepo ||
+      !isAuthorized ||
+      isLoading ||
+      parsedRepo == null ||
+      onDeploy == null ||
+      autoDeployRepoIdRef.current === parsedRepo.id
+    ) {
+      return;
+    }
+    autoDeployRepoIdRef.current = parsedRepo.id;
+    onDeploy(parsedRepo);
+  }, [autoDeploy, deployedRepo, isAuthorized, isLoading, onDeploy, parsedRepo]);
 
   if (deployedRepo || !isAuthorized) {
     return null;
@@ -600,6 +588,8 @@ GithubDeployerTitle.displayName = "GithubDeployer.Title";
 GithubDeployerUrlInput.displayName = "GithubDeployer.UrlInput";
 
 export const GithubDeployer = GithubDeployerBase;
+
+export const githubUrlToRepo = parseGithubUrlToRepo;
 
 export type {
   GithubDeployerActions,

--- a/apps/ui/src/features/deploy/github-deployer/github-deployer.tsx
+++ b/apps/ui/src/features/deploy/github-deployer/github-deployer.tsx
@@ -24,7 +24,10 @@ import {
   useState,
 } from "react";
 import { DeploymentSettings } from "../deployment-settings";
-import { githubUrlToRepo as parseGithubUrlToRepo } from "../github-repo-url";
+import {
+  normalizeGithubRepoUrl,
+  githubUrlToRepo as parseGithubUrlToRepo,
+} from "../github-repo-url";
 import {
   GithubDeployerContext,
   GithubDeployerRoot,
@@ -136,8 +139,14 @@ function GithubDeployerUrlInput({ className }: { className?: string }) {
     states: { deployedRepo, isAuthorized, isLoading, templateOptionsLoading },
   } = useGithubDeployer();
   const [repoUrl, setRepoUrl] = useState(initialRepoUrl);
-  const autoDeployRepoIdRef = useRef<string | null>(null);
+  const autoDeployStateRef = useRef<
+    "cancelled" | "eligible" | "pending" | "triggered"
+  >("pending");
   const parsedRepo = useMemo(() => parseGithubUrlToRepo(repoUrl), [repoUrl]);
+  const requestedRepoUrl = useMemo(
+    () => normalizeGithubRepoUrl(initialRepoUrl),
+    [initialRepoUrl]
+  );
   const showInvalid = repoUrl.trim() !== "" && !parsedRepo;
   const isTemplateMatchingPending = Boolean(
     onDeployTemplate && templateOptionsLoading
@@ -147,20 +156,33 @@ function GithubDeployerUrlInput({ className }: { className?: string }) {
   );
 
   useEffect(() => {
+    if (!autoDeploy || parsedRepo == null) {
+      return;
+    }
+    if (autoDeployStateRef.current === "pending") {
+      autoDeployStateRef.current =
+        requestedRepoUrl === parsedRepo.url ? "eligible" : "cancelled";
+    }
     if (
-      !autoDeploy ||
+      autoDeployStateRef.current !== "eligible" ||
       deployedRepo ||
       !isAuthorized ||
       isLoading ||
-      parsedRepo == null ||
-      onDeploy == null ||
-      autoDeployRepoIdRef.current === parsedRepo.id
+      onDeploy == null
     ) {
       return;
     }
-    autoDeployRepoIdRef.current = parsedRepo.id;
+    autoDeployStateRef.current = "triggered";
     onDeploy(parsedRepo);
-  }, [autoDeploy, deployedRepo, isAuthorized, isLoading, onDeploy, parsedRepo]);
+  }, [
+    autoDeploy,
+    deployedRepo,
+    isAuthorized,
+    isLoading,
+    onDeploy,
+    parsedRepo,
+    requestedRepoUrl,
+  ]);
 
   if (deployedRepo || !isAuthorized) {
     return null;

--- a/apps/ui/src/features/deploy/github-deployer/github-deployer.types.ts
+++ b/apps/ui/src/features/deploy/github-deployer/github-deployer.types.ts
@@ -76,6 +76,8 @@ export interface GithubDeployerResolvedActions {
 
 export interface GithubDeployerValue {
   actions: GithubDeployerResolvedActions;
+  autoDeploy: boolean;
+  initialRepoUrl: string;
   requestDeploy: (repo: GithubDeployerRepo) => void;
   requestDisconnect: () => void;
   selectedRepoId: string;

--- a/apps/ui/src/features/deploy/github-repo-url.ts
+++ b/apps/ui/src/features/deploy/github-repo-url.ts
@@ -1,0 +1,59 @@
+import type { GithubDeployerRepo } from "./github-deployer/github-deployer.types";
+
+export const GITHUB_REPOSITORY_URL_MAX_LENGTH = 512;
+
+const URL_PROTOCOL_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+const GIT_SUFFIX_RE = /\.git$/i;
+
+/** Parse a GitHub repository root accepted by both manual and link flows. */
+export function githubUrlToRepo(input: string): GithubDeployerRepo | null {
+  const raw = input.trim();
+  if (raw === "" || raw.length > GITHUB_REPOSITORY_URL_MAX_LENGTH) {
+    return null;
+  }
+
+  const withProtocol = URL_PROTOCOL_RE.test(raw) ? raw : `https://${raw}`;
+
+  let url: URL;
+  try {
+    url = new URL(withProtocol);
+  } catch {
+    return null;
+  }
+
+  if (
+    url.protocol !== "https:" ||
+    url.hostname.toLowerCase() !== "github.com" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.port !== "" ||
+    url.search !== "" ||
+    url.hash !== ""
+  ) {
+    return null;
+  }
+
+  const [owner, repoSegment, extraPath] = url.pathname
+    .split("/")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const repo = repoSegment?.replace(GIT_SUFFIX_RE, "");
+  if (!(owner && repo) || extraPath != null) {
+    return null;
+  }
+
+  const fullName = `${owner}/${repo}`;
+  return {
+    fullName,
+    id: `github-url:${fullName}`,
+    name: repo,
+    url: `https://github.com/${fullName}`,
+  };
+}
+
+export function normalizeGithubRepoUrl(
+  value: string | null | undefined
+): string | null {
+  const repo = typeof value === "string" ? githubUrlToRepo(value) : null;
+  return repo?.url ?? null;
+}

--- a/apps/ui/src/features/panes/surface-state.ts
+++ b/apps/ui/src/features/panes/surface-state.ts
@@ -28,7 +28,16 @@ export type ProjectGlobalSidePaneEntry =
   | { kind: "githubDeployment"; projectId: string }
   | {
       kind: "projectCreation";
-      entryMode: Exclude<ProjectCreationPaneEntryMode, "templateDirect">;
+      entryMode: Exclude<
+        ProjectCreationPaneEntryMode,
+        "githubDirect" | "templateDirect"
+      >;
+    }
+  | {
+      autoDeploy?: boolean;
+      entryMode: "githubDirect";
+      githubRepo?: string;
+      kind: "projectCreation";
     }
   | {
       kind: "projectCreation";

--- a/apps/ui/src/features/panes/url-codec.test.ts
+++ b/apps/ui/src/features/panes/url-codec.test.ts
@@ -155,6 +155,32 @@ test("project surface URL codec preserves template direct project creation", () 
   });
 });
 
+test("project surface URL codec preserves GitHub direct repo intent", () => {
+  const state = parseProjectSurfaceUrlState({
+    side: "project-creation:githubDirect:https%3A%2F%2Fgithub.com%2Facme%2Fapi:auto",
+  });
+
+  assert.deepEqual(state.side, {
+    autoDeploy: true,
+    entryMode: "githubDirect",
+    githubRepo: "https://github.com/acme/api",
+    kind: "projectCreation",
+  });
+  assert.deepEqual(serializeProjectSurfaceUrlState(state), {
+    side: "project-creation:githubDirect:https%3A%2F%2Fgithub.com%2Facme%2Fapi:auto",
+  });
+});
+
+test("project surface URL codec rejects unsafe GitHub direct intents", () => {
+  for (const side of [
+    "project-creation:githubDirect:https%3A%2F%2Fgithub.com%2Facme%2Fapi%2Ftree%2Fmain",
+    "project-creation:githubDirect:https%3A%2F%2Ftoken%3Asecret%40github.com%2Facme%2Fapi",
+    "project-creation:githubDirect:https%3A%2F%2Fgithub.com%2Facme%2Fapi:unexpected",
+  ]) {
+    assert.equal(parseProjectSurfaceUrlState({ side }).side, null);
+  }
+});
+
 test("project surface URL codec preserves a template name on direct creation", () => {
   const parsed = parseProjectSurfaceUrlState({
     side: "project-creation:templateDirect:team%3Aflow%20v1",

--- a/apps/ui/src/features/panes/url-codec.ts
+++ b/apps/ui/src/features/panes/url-codec.ts
@@ -1,3 +1,4 @@
+import { normalizeGithubRepoUrl } from "@/features/deploy/github-repo-url";
 import { normalizeTemplateName } from "@/features/deploy/template-deployment-intent";
 import type {
   ProjectDrawerSurfaceEntry,
@@ -139,6 +140,12 @@ export function serializeProjectSideSurfaceEntry(
     case "githubDeployment":
       return `github-deployment:${encodePart(entry.projectId)}`;
     case "projectCreation": {
+      if (entry.entryMode === "githubDirect") {
+        const githubRepo = normalizeGithubRepoUrl(entry.githubRepo);
+        return `project-creation:githubDirect${
+          githubRepo == null ? "" : `:${encodePart(githubRepo)}`
+        }${entry.autoDeploy === true && githubRepo != null ? ":auto" : ""}`;
+      }
       const templateName =
         entry.entryMode === "templateDirect"
           ? normalizeTemplateName(entry.templateName)
@@ -202,10 +209,48 @@ function parseResourceSideSurfaceEntry(
   }
 }
 
+function parseGithubProjectCreationSideEntry(
+  parts: readonly string[]
+): ProjectSideSurfaceEntry | null {
+  if (parts.length !== 3 && parts.length !== 4) {
+    return null;
+  }
+  const githubRepo = normalizeGithubRepoUrl(decodePart(parts[2]));
+  const autoDeploy = parts.length === 4 ? decodePart(parts[3]) : null;
+  if (githubRepo == null || (parts.length === 4 && autoDeploy !== "auto")) {
+    return null;
+  }
+  return {
+    entryMode: "githubDirect",
+    githubRepo,
+    kind: "projectCreation",
+    ...(parts.length === 4 ? { autoDeploy: true } : {}),
+  };
+}
+
+function parseTemplateProjectCreationSideEntry(
+  parts: readonly string[]
+): ProjectSideSurfaceEntry | null {
+  if (parts.length !== 3 && parts.length !== 4) {
+    return null;
+  }
+  const templateName = normalizeTemplateName(decodePart(parts[2]));
+  const templateForm = decodePart(parts[3]);
+  if (templateName == null || (parts.length === 4 && templateForm == null)) {
+    return null;
+  }
+  return {
+    entryMode: "templateDirect",
+    kind: "projectCreation",
+    templateName,
+    ...(templateForm == null ? {} : { templateForm }),
+  };
+}
+
 function parseProjectCreationSideEntry(
   parts: readonly string[]
 ): ProjectSideSurfaceEntry | null {
-  if (parts.length !== 2 && parts.length !== 3 && parts.length !== 4) {
+  if (parts.length < 2 || parts.length > 4) {
     return null;
   }
   const entryMode = decodePart(parts[1]);
@@ -218,23 +263,15 @@ function parseProjectCreationSideEntry(
   ) {
     return null;
   }
-  if (parts.length >= 3) {
-    if (entryMode !== "templateDirect") {
-      return null;
-    }
-    const templateName = normalizeTemplateName(decodePart(parts[2]));
-    const templateForm = decodePart(parts[3]);
-    if (templateName == null || (parts.length === 4 && templateForm == null)) {
-      return null;
-    }
-    return {
-      entryMode,
-      kind: "projectCreation",
-      templateName,
-      ...(templateForm == null ? {} : { templateForm }),
-    };
+  if (parts.length === 2) {
+    return { entryMode, kind: "projectCreation" };
   }
-  return { entryMode, kind: "projectCreation" };
+  if (entryMode === "githubDirect") {
+    return parseGithubProjectCreationSideEntry(parts);
+  }
+  return entryMode === "templateDirect"
+    ? parseTemplateProjectCreationSideEntry(parts)
+    : null;
 }
 
 export function parseProjectSideSurfaceEntry(

--- a/apps/ui/src/features/projects/creation/project-creation-pane.test.tsx
+++ b/apps/ui/src/features/projects/creation/project-creation-pane.test.tsx
@@ -31,15 +31,16 @@ const PROJECT_TITLE_RE = /Create New Project/;
 const GITHUB_IMPORT_RE = /GitHub Import/;
 const GITHUB_IMPORT_DESCRIPTION_RE =
   /Import repository from URL or GitHub authorization\./;
-const GITHUB_ACCOUNT_RE = /GitHub Account/;
+const GITHUB_ACCOUNT_RE = /Workspace GitHub/;
 const GITHUB_CONNECTED_RE = /GitHub connected/i;
 const GITHUB_REPO_CARD_RE = /data-slot="github-deployer-repo-card"/;
 const GITHUB_SEARCH_RE = /placeholder="Search"/;
 const GITHUB_URL_INPUT_RE = /data-slot="github-deployer-url-input"/;
-const GITHUB_AUTHORIZE_RE = /Authorize GitHub/;
+const GITHUB_AUTHORIZE_RE = /Connect GitHub/;
+const GITHUB_INITIAL_URL_RE = /value="https:\/\/github\.com\/acme\/api"/;
 const GITHUB_REPOSITORY_URL_RE = /Repository URL/;
 const GITHUB_REPOSITORY_LOCKED_RE =
-  /Please authorize your GitHub account to deploy from a GitHub repository URL\./;
+  /Connect GitHub for this workspace before deploying from a repository URL\./;
 const SCENARIO_RE = /Scenario/;
 const TWO_COLUMN_PICKER_RE = /sm:grid-cols-2/;
 const TRAIL_BACK_RE = />Back</;
@@ -117,6 +118,7 @@ test("project creation pane GitHub direct entry starts at repository selection",
         },
       }}
       entryMode="githubDirect"
+      initialGithubRepoUrl="https://github.com/acme/api"
       onClose={noop}
       resetKey={1}
     />
@@ -133,6 +135,7 @@ test("project creation pane GitHub direct entry starts at repository selection",
   assert.match(html, GITHUB_SEARCH_RE);
   assert.match(html, GITHUB_REPO_CARD_RE);
   assert.match(html, GITHUB_URL_INPUT_RE);
+  assert.match(html, GITHUB_INITIAL_URL_RE);
   assert.doesNotMatch(html, PROJECT_NAME_RE);
   assert.doesNotMatch(html, SCENARIO_RE);
   assert.doesNotMatch(html, TRAIL_BACK_RE);

--- a/apps/ui/src/features/projects/creation/project-creation-pane.tsx
+++ b/apps/ui/src/features/projects/creation/project-creation-pane.tsx
@@ -66,6 +66,8 @@ export function ProjectCreationPane({
   busy = false,
   creatorRootProps,
   entryMode = "general",
+  githubAutoDeploy = false,
+  initialGithubRepoUrl,
   onActiveSourceChange,
   onClose,
   resetKey,
@@ -85,6 +87,8 @@ export function ProjectCreationPane({
     | "templateOptionsLoading"
   >;
   entryMode?: ProjectCreationPaneEntryMode;
+  githubAutoDeploy?: boolean;
+  initialGithubRepoUrl?: string;
   onActiveSourceChange?: (source: ProjectCreatorSourceKind | null) => void;
   onClose: () => void;
   resetKey: string | number;
@@ -148,6 +152,9 @@ export function ProjectCreationPane({
       >
         <GithubDeployer.Root
           actions={githubDeployer?.actions}
+          autoDeploy={githubAutoDeploy}
+          initialRepoUrl={initialGithubRepoUrl}
+          key={`${resetKey}:${initialGithubRepoUrl ?? ""}:${githubAutoDeploy ? "auto" : "manual"}`}
           states={githubDeployer?.states ?? EMPTY_GITHUB_DEPLOYER_STATES}
         >
           <GithubDeployer.Shell />

--- a/apps/ui/src/features/projects/project-index/project-index.tsx
+++ b/apps/ui/src/features/projects/project-index/project-index.tsx
@@ -83,6 +83,14 @@ export function ProjectIndex() {
     }
     return parseTemplateForm(creationSideEntry.templateForm) ?? undefined;
   }, [creationSideEntry]);
+  const creationSideGithubRepo =
+    creationSideEntry?.entryMode === "githubDirect"
+      ? creationSideEntry.githubRepo
+      : undefined;
+  const creationSideAutoDeploy =
+    creationSideEntry?.entryMode === "githubDirect"
+      ? creationSideEntry.autoDeploy
+      : undefined;
 
   const onProjectCreated = useCallback(
     async (projectId: string | undefined, context?: ProjectCreatedContext) => {
@@ -206,6 +214,8 @@ export function ProjectIndex() {
           busy={githubDeployerLoading}
           creatorRootProps={creatorRootProps}
           entryMode={creationPaneEntryMode}
+          githubAutoDeploy={creationSideAutoDeploy}
+          initialGithubRepoUrl={creationSideGithubRepo}
           onActiveSourceChange={onCreationPaneSourceChangeWithTracking}
           onClose={() => closeProjectSideRoute()}
           resetKey={creatorResetKey}
@@ -227,6 +237,8 @@ export function ProjectIndex() {
     githubDeployerLoading,
     onCreationPaneSourceChangeWithTracking,
     skillsPaneOpen,
+    creationSideAutoDeploy,
+    creationSideGithubRepo,
   ]);
 
   return (


### PR DESCRIPTION
## Summary

Adds a GitHub repo deep-link flow: an external URL (`/deploy?githubRepo=<url>[&autoDeploy=1]`) opens project creation with the repo pre-filled, and can trigger deployment automatically once authorized.

- New `github-repo-url.ts`: shared GitHub repo URL parser/normalizer (`owner/repo`, 512-char cap, protocol/hostname/path validation), extracted from `GithubDeployerUrlInput` for reuse.
- New `github-deploy-link.ts`: builds `/project?side=project-creation:githubDirect:<repo>[:auto]`.
- `url-codec.ts` / `surface-state.ts`: serialize/parse `githubDirect` side entries with optional repo + `autoDeploy`.
- `github-deployer`: `GithubDeployerRoot` accepts `autoDeploy` / `initialRepoUrl`; URL input pre-fills from the link and auto-deploys once after authorization (guarded by a ref so it fires only once per repo).
- `project-creation-pane.tsx` / `project-index.tsx` thread the deep-link values through; pane reset key includes repo/autoDeploy so switching links resets cleanly.

Branch is based on the latest `origin/main` and contains a single commit (`931b4161`); the older superseded agent-managed deploy commits were dropped (already shipped via #257).

## Validation

- `bun test` on the 4 touched test files — 35 pass, 0 fail (includes new "auto deploys a restored GitHub URL only once")
- `bun typecheck` — 6/6 packages
- `bunx ultracite check` on all 14 changed files — clean