### PR TITLE
feat(ui): honor CODEX_GATEWAY_MODEL for GitHub deploy sessions

### DIFF
--- a/apps/ui/src/features/deploy/task/gateway.test.ts
+++ b/apps/ui/src/features/deploy/task/gateway.test.ts
@@ -37,8 +37,11 @@ mock.module("./runner-writes", () => ({
 const {
   CodexGatewayApiError,
   CodexGatewayTimeoutError,
+  DEPLOY_GATEWAY_MODEL,
+  resolveDeployGatewayModel,
   runDeployTaskGateway: runDeployTaskGatewayRaw,
 } = requireModule("./gateway") as typeof import("./gateway");
+const originalCodexGatewayModel = process.env.CODEX_GATEWAY_MODEL;
 
 function runDeployTaskGateway(
   input: Omit<Parameters<typeof runDeployTaskGatewayRaw>[0], "resumeMode"> & {
@@ -177,16 +180,23 @@ describe("deployment Codex gateway interruption", () => {
     recordedEvents.length = 0;
     updateDeployTaskStateImpl = () => Promise.resolve();
     console.warn = () => undefined;
+    delete process.env.CODEX_GATEWAY_MODEL;
   });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
     console.warn = originalWarn;
+    delete process.env.CODEX_GATEWAY_MODEL;
   });
 
   afterAll(() => {
     globalThis.fetch = originalFetch;
     console.warn = originalWarn;
+    if (originalCodexGatewayModel === undefined) {
+      delete process.env.CODEX_GATEWAY_MODEL;
+    } else {
+      process.env.CODEX_GATEWAY_MODEL = originalCodexGatewayModel;
+    }
     mock.module("./runner-writes", () => ({ ...realRunnerWrites }));
   });
 
@@ -499,9 +509,32 @@ describe("deployment Codex gateway interruption", () => {
     });
 
     expect(sessionBodies).toHaveLength(1);
+    expect(sessionBodies[0]?.model).toBe(DEPLOY_GATEWAY_MODEL);
     expect(sessionBodies[0]?.toolProfile).toBeUndefined();
     expect(sessionBodies[0]?.threadId).toBeUndefined();
     expect(sessionHeaders[0]?.["x-sealai-control-token"]).toBeUndefined();
+  });
+
+  it("uses CODEX_GATEWAY_MODEL for a new session when it is set", async () => {
+    process.env.CODEX_GATEWAY_MODEL = "  gpt-custom-deploy  ";
+    const sessionBodies: Record<string, unknown>[] = [];
+    installGatewayFetch({
+      sessionBodies,
+      stateActive: false,
+    });
+
+    await runDeployTaskGateway({
+      context: { authToken: "gateway-token", url: "https://gateway.test" },
+      deadlineAtMs: Date.now() + 1000,
+      task: task(),
+    });
+
+    expect(sessionBodies[0]?.model).toBe("gpt-custom-deploy");
+  });
+
+  it("treats a blank CODEX_GATEWAY_MODEL as unset", () => {
+    process.env.CODEX_GATEWAY_MODEL = "   ";
+    expect(resolveDeployGatewayModel()).toBe(DEPLOY_GATEWAY_MODEL);
   });
 
   it("resumes the recorded Codex Thread when a session is lost", async () => {

--- a/apps/ui/src/features/deploy/task/gateway.ts
+++ b/apps/ui/src/features/deploy/task/gateway.ts
@@ -19,6 +19,12 @@ import {
 
 const CODEX_GATEWAY_STARTUP_RETRY_MS = 1000;
 export const DEPLOY_GATEWAY_MODEL = "gpt-5.5";
+
+export function resolveDeployGatewayModel(): string {
+  const configured = process.env.CODEX_GATEWAY_MODEL?.trim();
+  return configured ? configured : DEPLOY_GATEWAY_MODEL;
+}
+
 const GATEWAY_SESSION_IDENTIFIER_REGEX =
   /^(?:session[-_][A-Za-z0-9][A-Za-z0-9._:-]{0,95}|[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
 const GATEWAY_TIMESTAMP_MAX_LENGTH = 24;
@@ -403,7 +409,7 @@ async function createGatewaySession(
     "/api/sessions",
     {
       body: JSON.stringify({
-        model: DEPLOY_GATEWAY_MODEL,
+        model: resolveDeployGatewayModel(),
         ...(options?.threadId == null ? {} : { threadId: options.threadId }),
       }),
       method: "POST",

--- a/apps/ui/src/features/deploy/task/runner.github-ai-proxy.test.ts
+++ b/apps/ui/src/features/deploy/task/runner.github-ai-proxy.test.ts
@@ -353,6 +353,11 @@ describe("deployment AI Proxy credentials", () => {
     });
   });
 
+  it("falls back to gpt-5.5 when CODEX_GATEWAY_MODEL is unset", () => {
+    delete process.env.CODEX_GATEWAY_MODEL;
+    expect(buildCodexGatewayEnv().CODEX_GATEWAY_MODEL).toBe("gpt-5.5");
+  });
+
   it("resumes the recorded Devbox without requesting AI Proxy credentials", async () => {
     const requests: Request[] = [];
     let getCount = 0;

--- a/apps/ui/src/features/deploy/task/runner.ts
+++ b/apps/ui/src/features/deploy/task/runner.ts
@@ -89,9 +89,9 @@ import {
 } from "./failure-summary";
 import {
   codexGatewayFailureDetails,
-  DEPLOY_GATEWAY_MODEL,
   type GatewayContext,
   getCodexGatewayContextFromDevboxInfo,
+  resolveDeployGatewayModel,
   runDeployTaskGateway,
 } from "./gateway";
 import type { ManagedDeployResumeMode } from "./gateway-prompt";
@@ -1045,7 +1045,9 @@ export interface CodexGatewayOpenAiCredentials {
 export function buildCodexGatewayEnv(
   credentials?: CodexGatewayOpenAiCredentials
 ): Record<string, string> {
-  const env: Record<string, string> = {};
+  const env: Record<string, string> = {
+    CODEX_GATEWAY_MODEL: resolveDeployGatewayModel(),
+  };
   const apiKey = credentials
     ? credentials.apiKey
     : (compactEnvValue(process.env.CODEX_GATEWAY_OPENAI_API_KEY) ??
@@ -1054,17 +1056,12 @@ export function buildCodexGatewayEnv(
     ? credentials.baseUrl
     : (compactEnvValue(process.env.CODEX_GATEWAY_OPENAI_BASE_URL) ??
       compactEnvValue(process.env.SYSTEM_OPENAI_API_BASE_URL));
-  const model =
-    compactEnvValue(process.env.CODEX_GATEWAY_MODEL) ?? DEPLOY_GATEWAY_MODEL;
 
   if (apiKey != null) {
     env.CODEX_GATEWAY_OPENAI_API_KEY = apiKey;
   }
   if (baseUrl != null) {
     env.CODEX_GATEWAY_OPENAI_BASE_URL = baseUrl;
-  }
-  if (model != null) {
-    env.CODEX_GATEWAY_MODEL = model;
   }
 
   return env;


### PR DESCRIPTION
## Summary
- GitHub deploy session creation now reads `CODEX_GATEWAY_MODEL` instead of hardcoding `gpt-5.5`, using the same resolver as Devbox env injection.
- Blank or unset values still fall back to `gpt-5.5`.

## Usage
把 `CODEX_GATEWAY_MODEL` 设成你要的 model id 即可，空白或不设仍是 `gpt-5.5`。

Set it on the Brain UI process (`apps/ui/.env` locally, or Helm `ui.env.CODEX_GATEWAY_MODEL`). Restart the UI after changing it. New GitHub deploy sessions pick it up; in-flight sessions do not.

## Test plan
- [ ] Unset `CODEX_GATEWAY_MODEL`, start a GitHub deploy, confirm the Codex gateway session uses `gpt-5.5`
- [ ] Set `CODEX_GATEWAY_MODEL` to another model id on the UI, restart, start a new GitHub deploy, confirm the session uses that id
- [ ] Set it to whitespace only and confirm it still falls back to `gpt-5.5`


Made with [Cursor](https://cursor.com)