### PR TITLE
fix(billing): restore invoice notice hierarchy and use AppButton for external CTAs

### DIFF
--- a/apps/ui/src/features/billing/billing-plan-surface.tsx
+++ b/apps/ui/src/features/billing/billing-plan-surface.tsx
@@ -6,10 +6,7 @@ import {
   AlertDescription,
   AlertTitle,
 } from "@workspace/ui/components/alert";
-import {
-  AppButton,
-  appButtonVariants,
-} from "@workspace/ui/components/app-button";
+import { AppButton } from "@workspace/ui/components/app-button";
 import { AppDialog } from "@workspace/ui/components/app-dialog";
 import { Badge } from "@workspace/ui/components/badge";
 import { PlanBadge } from "@workspace/ui/components/plan-badge";
@@ -291,15 +288,17 @@ function SubscriptionWarningBanner({
         <AlertDescription>{accountDebtCopy.description}</AlertDescription>
         {topUpUrl == null ? null : (
           <AlertAction className="static col-start-2 row-start-3 mt-2 flex flex-wrap gap-2 justify-self-start">
-            <a
-              className={appButtonVariants({ size: "sm", variant: "danger" })}
-              href={topUpUrl}
-              rel="noreferrer"
-              target="_blank"
-            >
-              <ExternalLink aria-hidden data-icon="inline-start" />
-              Top up in Sealos Desktop
-            </a>
+            <AppButton
+              nativeButton={false}
+              render={
+                <a href={topUpUrl} rel="noreferrer" target="_blank">
+                  <ExternalLink aria-hidden data-icon="inline-start" />
+                  Top up in Sealos Desktop
+                </a>
+              }
+              size="sm"
+              variant="danger"
+            />
           </AlertAction>
         )}
       </Alert>
@@ -366,8 +365,10 @@ function BillingInvoiceNotice({
 
   return (
     <Alert
-      className="has-data-[slot=alert-action]:pr-4 sm:has-data-[slot=alert-action]:pr-18"
-      variant="destructive"
+      className={cn(
+        "border-none has-data-[slot=alert-action]:pr-4",
+        SUBSCRIPTION_WARNING_TONES["deletion-imminent"]
+      )}
     >
       <AlertCircle aria-hidden />
       <AlertTitle>
@@ -382,15 +383,21 @@ function BillingInvoiceNotice({
       </AlertDescription>
       <AlertAction className="static col-start-2 row-start-3 mt-2 flex flex-wrap gap-2 justify-self-start">
         {canPayInvoice && current.invoicePaymentUrl != null ? (
-          <a
-            className={appButtonVariants({ size: "sm", variant: "danger" })}
-            href={current.invoicePaymentUrl}
-            rel="noreferrer"
-            target="_blank"
-          >
-            <ExternalLink aria-hidden data-icon="inline-start" />
-            Pay invoice
-          </a>
+          <AppButton
+            nativeButton={false}
+            render={
+              <a
+                href={current.invoicePaymentUrl}
+                rel="noreferrer"
+                target="_blank"
+              >
+                <ExternalLink aria-hidden data-icon="inline-start" />
+                Pay invoice
+              </a>
+            }
+            size="sm"
+            variant="danger"
+          />
         ) : null}
         {canCancelInvoice && invoiceId != null && onCancelInvoice != null ? (
           <AppButton


### PR DESCRIPTION
## Summary

- Unpaid-invoice banner: dropped `variant="destructive"` (it paints title **and** description red, flattening the hierarchy) in favor of the tone-class pattern already used by the subscription warning banner in the same file — red stays on icon/title, description returns to muted.
- `Pay invoice` and `Top up in Sealos Desktop` were raw `<a>` tags styled with `appButtonVariants`, missing the base Button layout classes (`inline-flex items-center justify-center`), so the label overflowed the pill. Both now render through `AppButton`'s `render` prop (`nativeButton={false}`), so structure and styles come from one source and track future AppButton changes.
- Removed the now-unused `appButtonVariants` import.

## Test plan

- [x] `bun check` on the touched file passes
- [x] `tsc` for `@sealai/ui` shows no new errors (the `preview-canvas-perf` failure is pre-existing on main)
- [ ] Visual check in dev server: banner hierarchy (semibold red title / muted description) and button rendering