### PR TITLE
fix(dev-tweaks): slide the segmented pill on click

### DIFF
--- a/packages/dev-tweaks/src/panel/components/segmented-control.tsx
+++ b/packages/dev-tweaks/src/panel/components/segmented-control.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/refs -- ported panel render-update patterns kept structurally intact */
-import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 
 interface SegmentedControlOption<T extends string> {
   label: string;
@@ -24,26 +24,27 @@ export function SegmentedControl<T extends string>({
     width: number;
   } | null>(null);
 
-  const measure = useCallback(() => {
+  useLayoutEffect(() => {
     const container = containerRef.current;
     if (!container) {
       return;
     }
     const activeButton = container.querySelector(
-      '[data-active="true"]'
+      `[data-value="${value}"]`
     ) as HTMLElement | null;
     if (!activeButton) {
       return;
     }
-    setPillStyle({
+    const next = {
       left: activeButton.offsetLeft,
       width: activeButton.offsetWidth,
-    });
-  }, []);
-
-  useLayoutEffect(() => {
-    measure();
-  }, [measure]);
+    };
+    setPillStyle((prev) =>
+      prev !== null && prev.left === next.left && prev.width === next.width
+        ? prev
+        : next
+    );
+  }, [value]);
 
   // Enable transition after first render
   const shouldAnimate = hasAnimated.current;
@@ -70,6 +71,7 @@ export function SegmentedControl<T extends string>({
           <button
             className="dev-tweaks-segmented-button"
             data-active={String(isActive)}
+            data-value={option.value}
             key={option.value}
             onClick={() => onChange(option.value)}
             type="button"

--- a/packages/dev-tweaks/src/segmented-control.test.tsx
+++ b/packages/dev-tweaks/src/segmented-control.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Segmented pill follows the active option after click. Happy-dom has no
+ * layout, so button offsetLeft/offsetWidth are stubbed before the click.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { useState } from "react";
+import {
+  actAndDrain,
+  installTestDom,
+  restoreActEnvironment,
+  setActEnvironment,
+} from "./test/harness";
+
+const LAYOUT = {
+  Off: { left: 2, width: 40 },
+  On: { left: 42, width: 36 },
+} as const;
+
+function stubSegmentLayout(): void {
+  for (const button of document.querySelectorAll(
+    ".dev-tweaks-segmented-button"
+  )) {
+    const label = button.textContent;
+    const layout =
+      label === "On" || label === "Off" ? LAYOUT[label] : undefined;
+    if (!layout) {
+      continue;
+    }
+    Object.defineProperty(button, "offsetLeft", {
+      configurable: true,
+      get: () => layout.left,
+    });
+    Object.defineProperty(button, "offsetWidth", {
+      configurable: true,
+      get: () => layout.width,
+    });
+  }
+}
+
+function pillBox(): { left: string; width: string } {
+  const pill = document.querySelector(
+    ".dev-tweaks-segmented-pill"
+  ) as HTMLElement | null;
+  assert.ok(pill, "pill should be mounted after measure");
+  return { left: pill.style.left, width: pill.style.width };
+}
+
+function activeLabel(): string | null {
+  return (
+    document.querySelector('.dev-tweaks-segmented-button[data-active="true"]')
+      ?.textContent ?? null
+  );
+}
+
+test("segmented pill slides to the clicked Off/On option", async () => {
+  const dom = installTestDom();
+  const previousAct = setActEnvironment(true);
+  try {
+    const { SegmentedControl } = await import(
+      "./panel/components/segmented-control"
+    );
+    const { cleanup, render, within } = await import(
+      "@testing-library/react/pure"
+    );
+    const body = () => within(document.body);
+
+    function Harness() {
+      const [value, setValue] = useState<"off" | "on">("off");
+      return (
+        <SegmentedControl
+          onChange={setValue}
+          options={[
+            { label: "Off", value: "off" as const },
+            { label: "On", value: "on" as const },
+          ]}
+          value={value}
+        />
+      );
+    }
+
+    await actAndDrain(() => {
+      render(<Harness />);
+    });
+    stubSegmentLayout();
+
+    await actAndDrain(() => {
+      body().getByText("On").click();
+    });
+    assert.equal(activeLabel(), "On");
+    assert.deepEqual(pillBox(), { left: "42px", width: "36px" });
+
+    await actAndDrain(() => {
+      body().getByText("Off").click();
+    });
+    assert.equal(activeLabel(), "Off");
+    assert.deepEqual(pillBox(), { left: "2px", width: "40px" });
+
+    await actAndDrain(() => {
+      cleanup();
+    });
+  } finally {
+    restoreActEnvironment(previousAct);
+    await dom.restore();
+  }
+});


### PR DESCRIPTION
## Summary
- Dev tweaks Off/On (and the Type segmented controls) update the value on click, but the highlight pill stayed on the previous option.
- `SegmentedControl` only measured pill `left`/`width` on mount. It now remeasures from the active option when `value` changes, keeping the existing 0.2s slide.
- Adds a click test that stubs layout (happy-dom has none) and asserts the pill follows Off → On → Off.

## Test plan
- [x] `bun test src/segmented-control.test.tsx` in `packages/dev-tweaks`
- [x] `bun check`
- [x] Click Force Modal Off/On on `/project` and confirm the pill slides, then returns on Off