### PR TITLE
feat(chat): deep-link the blocked card's upgrade CTA to the Plan Picker

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -490,9 +490,9 @@ _Avoid_: subscription tier, plan.
 
 ### Free Chat Turns
 
-A platform-funded allowance of assistant turns per namespace (user-visible label: Free assistant messages), spendable only during the workspace's Active Free Trial; a turn is reserved when it starts and returned if it fails, so only successfully completed turns stay spent. A lifetime entitlement counter — namespace-shared, never per-user, never reset — not a rate limit; exhausting it blocks further assistant requests rather than falling through to `user` billing.
+A platform-funded allowance of assistant turns per namespace (user-visible label: Free trial messages), spendable only during the workspace's Active Free Trial; a turn is reserved when it starts and returned if it fails, so only successfully completed turns stay spent. A lifetime entitlement counter — namespace-shared, never per-user, never reset — not a rate limit; exhausting it blocks further assistant requests rather than falling through to `user` billing.
 
-_Avoid_: free tier, trial credits.
+_Avoid_: free tier, trial credits, free assistant messages, free messages.
 
 ### AI Proxy
 

--- a/apps/ui/src/app/api/chat/route.test.ts
+++ b/apps/ui/src/app/api/chat/route.test.ts
@@ -1446,7 +1446,7 @@ test("refuses a confirmed-blocked trial request with 402 and the full header set
   expect(await response.json()).toEqual({
     code: "free_chat_turns_exhausted",
     error:
-      "Free messages are used up. Upgrade your plan to keep chatting with the assistant.",
+      "Free trial messages are used up. Upgrade your plan to keep chatting with the assistant.",
   });
   expect(response.headers.get("X-Chat-Billing")).toBe("blocked");
   expect(response.headers.get("X-Chat-Free-Remaining")).toBe("0");
@@ -1566,7 +1566,7 @@ test("a lost reservation race on a confirmed trial refuses with 402 before the m
   expect(await response.json()).toEqual({
     code: "free_chat_turns_exhausted",
     error:
-      "Free messages are used up. Upgrade your plan to keep chatting with the assistant.",
+      "Free trial messages are used up. Upgrade your plan to keep chatting with the assistant.",
   });
   expect(response.headers.get("X-Chat-Billing")).toBe("blocked");
   expect(response.headers.get("X-Chat-Free-Remaining")).toBe("0");

--- a/apps/ui/src/app/api/chat/route.ts
+++ b/apps/ui/src/app/api/chat/route.ts
@@ -92,7 +92,7 @@ function freeTurnsExhaustedResponse(state: FreeTierState): Response {
     {
       code: "free_chat_turns_exhausted",
       error:
-        "Free messages are used up. Upgrade your plan to keep chatting with the assistant.",
+        "Free trial messages are used up. Upgrade your plan to keep chatting with the assistant.",
     } satisfies ChatApiErrorBody,
     { headers: chatBillingHeaders(state), status: 402 }
   );

--- a/apps/ui/src/features/billing/billing-free-turns-section.interaction.test.tsx
+++ b/apps/ui/src/features/billing/billing-free-turns-section.interaction.test.tsx
@@ -24,7 +24,7 @@ test("allowance card names the benefit and voices the expiry in the subtitle", a
         );
       });
       const text = rendered?.container.textContent ?? "";
-      assert.ok(text.includes("Free assistant messages"));
+      assert.ok(text.includes("Free trial messages"));
       assert.ok(text.includes("Included with the Free plan"));
       assert.ok(text.includes("until"));
       assert.ok(text.includes("2026"));
@@ -32,7 +32,7 @@ test("allowance card names the benefit and voices the expiry in the subtitle", a
       // Vocabulary red line: this surface never says "AI Credits".
       assert.equal(text.includes("AI Credits"), false);
       const bar = rendered?.getByRole("progressbar", {
-        name: "Free assistant messages used",
+        name: "Free trial messages used",
       });
       assert.ok(bar);
     } finally {
@@ -82,7 +82,7 @@ test("loading shows a right-side skeleton without usage numbers", async () => {
       });
       assert.ok(
         rendered?.container.querySelector(
-          '[aria-label="Loading free assistant messages"]'
+          '[aria-label="Loading free trial messages"]'
         )
       );
       assert.equal(
@@ -112,7 +112,7 @@ test("a failed usage lookup degrades quietly and reassures, never red", async ()
       const text = rendered?.container.textContent ?? "";
       assert.ok(
         text.includes(
-          "Usage is unavailable right now — your free messages still work."
+          "Usage is unavailable right now — your free trial messages still work."
         )
       );
       // Deliberately different from AI Credits' red error state: a status,

--- a/apps/ui/src/features/billing/billing-free-turns-section.tsx
+++ b/apps/ui/src/features/billing/billing-free-turns-section.tsx
@@ -20,7 +20,7 @@ function formatFreePlanExpiry(iso: string): string | null {
 }
 
 /**
- * The Plan view's "Free assistant messages" allowance card (ADR-0065, AIM-298
+ * The Plan view's "Free trial messages" allowance card (ADR-0065, AIM-298
  * confirmed prototype). Rendered in the credits slot under exactly the
  * Active Free Trial predicate; after upgrade the AI Credits section takes
  * its place. Usage comes from Brain's own chat session system — never
@@ -58,11 +58,12 @@ export function BillingFreeTurnsSection({
         </div>
         <div className="flex min-w-0 flex-col gap-1">
           <h2 className="font-medium text-foreground text-sm">
-            Free assistant messages
+            Free trial messages
           </h2>
           {usageUnavailable ? (
             <p className="text-muted-foreground text-sm" role="status">
-              Usage is unavailable right now — your free messages still work.
+              Usage is unavailable right now — your free trial messages still
+              work.
             </p>
           ) : (
             <p className="text-muted-foreground text-sm">
@@ -76,14 +77,14 @@ export function BillingFreeTurnsSection({
       <div className="flex shrink-0 flex-col items-start gap-2 sm:items-end">
         {usage == null && !usageUnavailable ? (
           <Skeleton
-            aria-label="Loading free assistant messages"
+            aria-label="Loading free trial messages"
             className="h-5 w-28"
           />
         ) : null}
         {usage == null ? null : (
           <div className="flex items-center gap-3">
             <div
-              aria-label="Free assistant messages used"
+              aria-label="Free trial messages used"
               aria-valuemax={100}
               aria-valuemin={0}
               aria-valuenow={usedPercent}

--- a/apps/ui/src/features/billing/billing-plan.interaction.test.tsx
+++ b/apps/ui/src/features/billing/billing-plan.interaction.test.tsx
@@ -792,19 +792,19 @@ test("an Active Free Trial renders the allowance card in the credits slot, not A
 
     try {
       const text = rendered?.container.textContent ?? "";
-      assert.ok(text.includes("Free assistant messages"));
+      assert.ok(text.includes("Free trial messages"));
       assert.ok(text.includes("Included with the Free plan"));
       assert.ok(text.includes("3 of 5 left"));
       // Same slot and hierarchy as the paid plans' AI Credits section.
       assertTextOrder(text, [
         "Current Workspace Plan",
-        "Free assistant messages",
+        "Free trial messages",
         "Account Balance",
       ]);
       assert.equal(text.includes("AI Credits:"), false);
       assert.ok(
         rendered?.getByRole("progressbar", {
-          name: "Free assistant messages used",
+          name: "Free trial messages used",
         })
       );
     } finally {
@@ -836,7 +836,7 @@ test("a PAUSED Free workspace renders no allowance card and never asks Brain for
 
     try {
       const text = rendered?.container.textContent ?? "";
-      assert.equal(text.includes("Free assistant messages"), false);
+      assert.equal(text.includes("Free trial messages"), false);
       assert.equal(requestedPaths.includes("/api/chat/free-turns"), false);
     } finally {
       await restore();
@@ -857,10 +857,10 @@ test("a failed usage lookup degrades the allowance card quietly", async () => {
 
     try {
       const text = rendered?.container.textContent ?? "";
-      assert.ok(text.includes("Free assistant messages"));
+      assert.ok(text.includes("Free trial messages"));
       assert.ok(
         text.includes(
-          "Usage is unavailable right now — your free messages still work."
+          "Usage is unavailable right now — your free trial messages still work."
         )
       );
       assert.equal(text.includes("of 5 left"), false);

--- a/apps/ui/src/features/billing/billing-plan.tsx
+++ b/apps/ui/src/features/billing/billing-plan.tsx
@@ -293,7 +293,7 @@ function accountBalanceContent(input: {
 }
 
 /**
- * The credits slot: the trial's "Free assistant messages" allowance card and
+ * The credits slot: the trial's "Free trial messages" allowance card and
  * the paid plans' AI Credits section share it, so upgrading naturally swaps
  * one for the other (ADR-0065). PAYG renders neither.
  */

--- a/apps/ui/src/features/chat/chat-billing-cards.interaction.test.tsx
+++ b/apps/ui/src/features/chat/chat-billing-cards.interaction.test.tsx
@@ -45,7 +45,7 @@ test("card arbitration is blocked > error > counter, nothing on user billing", a
 test("counter card keeps identical wording at every remaining count and links to plans", async () => {
   await withTestDom(async (act) => {
     const { ChatBillingCardSlot } = await cardModules();
-    const navigations: number[] = [];
+    const navigations: string[] = [];
     let rendered: ReturnType<typeof render> | undefined;
     try {
       await act(() => {
@@ -53,14 +53,16 @@ test("counter card keeps identical wording at every remaining count and links to
           <ChatBillingCardSlot
             errored={false}
             freeTier={TRIAL_MID}
-            onNavigateToBilling={() => navigations.push(1)}
+            onNavigateToBilling={(destination) => navigations.push(destination)}
           />
         );
       });
       const text = rendered?.container.textContent ?? "";
       assert.ok(text.includes("3 of 5 free trial messages left"));
       assert.ok(
-        rendered?.getByRole("progressbar", { name: "Free trial messages remaining" })
+        rendered?.getByRole("progressbar", {
+          name: "Free trial messages remaining",
+        })
       );
 
       await act(() => {
@@ -68,7 +70,7 @@ test("counter card keeps identical wording at every remaining count and links to
           <ChatBillingCardSlot
             errored={false}
             freeTier={TRIAL_LAST}
-            onNavigateToBilling={() => navigations.push(1)}
+            onNavigateToBilling={(destination) => navigations.push(destination)}
           />
         );
       });
@@ -81,7 +83,8 @@ test("counter card keeps identical wording at every remaining count and links to
       const viewPlans = rendered?.getByRole("button", { name: "View plans" });
       assert.ok(viewPlans);
       fireEvent.click(viewPlans as HTMLElement);
-      assert.deepEqual(navigations, [1]);
+      // "View plans" lands on the Plan view without deep-linking the picker.
+      assert.deepEqual(navigations, ["plans"]);
     } finally {
       await act(() => rendered?.unmount());
     }
@@ -91,7 +94,7 @@ test("counter card keeps identical wording at every remaining count and links to
 test("blocked card carries the upgrade CTA and outranks an error", async () => {
   await withTestDom(async (act) => {
     const { ChatBillingCardSlot } = await cardModules();
-    const navigations: number[] = [];
+    const navigations: string[] = [];
     let rendered: ReturnType<typeof render> | undefined;
     try {
       await act(() => {
@@ -99,7 +102,7 @@ test("blocked card carries the upgrade CTA and outranks an error", async () => {
           <ChatBillingCardSlot
             errored
             freeTier={BLOCKED}
-            onNavigateToBilling={() => navigations.push(1)}
+            onNavigateToBilling={(destination) => navigations.push(destination)}
           />
         );
       });
@@ -112,7 +115,8 @@ test("blocked card carries the upgrade CTA and outranks an error", async () => {
       const upgrade = rendered?.getByRole("button", { name: "Upgrade plan" });
       assert.ok(upgrade);
       fireEvent.click(upgrade as HTMLElement);
-      assert.deepEqual(navigations, [1]);
+      // The blocked CTA deep-links the Plan Picker open (`?mode=upgrade`).
+      assert.deepEqual(navigations, ["upgrade"]);
     } finally {
       await act(() => rendered?.unmount());
     }

--- a/apps/ui/src/features/chat/chat-billing-cards.interaction.test.tsx
+++ b/apps/ui/src/features/chat/chat-billing-cards.interaction.test.tsx
@@ -58,9 +58,9 @@ test("counter card keeps identical wording at every remaining count and links to
         );
       });
       const text = rendered?.container.textContent ?? "";
-      assert.ok(text.includes("3 of 5 free messages left"));
+      assert.ok(text.includes("3 of 5 free trial messages left"));
       assert.ok(
-        rendered?.getByRole("progressbar", { name: "Free messages remaining" })
+        rendered?.getByRole("progressbar", { name: "Free trial messages remaining" })
       );
 
       await act(() => {
@@ -75,7 +75,7 @@ test("counter card keeps identical wording at every remaining count and links to
       // The last count keeps the exact same sentence shape — informed, not
       // alarmed (user story 3).
       const lastText = rendered?.container.textContent ?? "";
-      assert.ok(lastText.includes("1 of 5 free messages left"));
+      assert.ok(lastText.includes("1 of 5 free trial messages left"));
       assert.equal(lastText.includes("Last"), false);
 
       const viewPlans = rendered?.getByRole("button", { name: "View plans" });
@@ -104,7 +104,7 @@ test("blocked card carries the upgrade CTA and outranks an error", async () => {
         );
       });
       const text = rendered?.container.textContent ?? "";
-      assert.ok(text.includes("Free messages used up"));
+      assert.ok(text.includes("Free trial messages used up"));
       assert.ok(text.includes("Upgrade to keep chatting with the assistant."));
       // The error card lost the arbitration: "try again" would be a lie.
       assert.equal(text.includes("Message not sent"), false);
@@ -165,7 +165,7 @@ test("error card replaces the counter card on a trial (one card at a time)", asy
       });
       const text = rendered?.container.textContent ?? "";
       assert.ok(text.includes("Message not sent"));
-      assert.equal(text.includes("free messages left"), false);
+      assert.equal(text.includes("free trial messages left"), false);
     } finally {
       await act(() => rendered?.unmount());
     }

--- a/apps/ui/src/features/chat/chat-billing-cards.tsx
+++ b/apps/ui/src/features/chat/chat-billing-cards.tsx
@@ -44,7 +44,7 @@ function RemainingPips({
 }) {
   return (
     <div
-      aria-label="Free messages remaining"
+      aria-label="Free trial messages remaining"
       aria-valuemax={limit}
       aria-valuemin={0}
       aria-valuenow={remaining}
@@ -82,7 +82,7 @@ function CounterCard({
         <GiftTile />
         <div className="flex min-w-0 flex-col gap-1">
           <p className="text-muted-foreground text-xs">
-            {freeTier.remaining} of {freeTier.limit} free messages left
+            {freeTier.remaining} of {freeTier.limit} free trial messages left
           </p>
           <RemainingPips
             limit={freeTier.limit}
@@ -111,7 +111,7 @@ function BlockedCard({
         <GiftTile />
         <div className="flex min-w-0 flex-col gap-0.5">
           <p className="font-medium text-foreground text-xs">
-            Free messages used up
+            Free trial messages used up
           </p>
           <p className="text-muted-foreground text-xs">
             Upgrade to keep chatting with the assistant.

--- a/apps/ui/src/features/chat/chat-billing-cards.tsx
+++ b/apps/ui/src/features/chat/chat-billing-cards.tsx
@@ -9,6 +9,13 @@ import type { FreeTierState } from "./persistence/types";
 export type ChatBillingCard = "blocked" | "counter" | "error";
 
 /**
+ * Where a chat billing CTA lands in the Billing Area: `upgrade` deep-links
+ * the Plan Picker open (`/billing?mode=upgrade`, the App Sidebar precedent),
+ * `plans` lands on the Plan view without opening it.
+ */
+export type ChatBillingDestination = "plans" | "upgrade";
+
+/**
  * Card-slot arbitration for the Project Assistant Pane (ADR-0065): exactly
  * one card renders at a time, blocked > error > counter. `blocked` outranks
  * the error card because "try again" is a lie once the server refuses chat;
@@ -71,7 +78,7 @@ function CounterCard({
   onNavigateToBilling,
 }: {
   freeTier: FreeTierState;
-  onNavigateToBilling: () => void;
+  onNavigateToBilling: (destination: ChatBillingDestination) => void;
 }) {
   return (
     <div
@@ -90,7 +97,11 @@ function CounterCard({
           />
         </div>
       </div>
-      <AppButton onClick={onNavigateToBilling} size="sm" variant="quiet">
+      <AppButton
+        onClick={() => onNavigateToBilling("plans")}
+        size="sm"
+        variant="quiet"
+      >
         View plans
       </AppButton>
     </div>
@@ -100,7 +111,7 @@ function CounterCard({
 function BlockedCard({
   onNavigateToBilling,
 }: {
-  onNavigateToBilling: () => void;
+  onNavigateToBilling: (destination: ChatBillingDestination) => void;
 }) {
   return (
     <div
@@ -118,7 +129,7 @@ function BlockedCard({
           </p>
         </div>
       </div>
-      <AppButton onClick={onNavigateToBilling} size="sm">
+      <AppButton onClick={() => onNavigateToBilling("upgrade")} size="sm">
         Upgrade plan
       </AppButton>
     </div>
@@ -158,8 +169,12 @@ export function ChatBillingCardSlot({
 }: {
   errored: boolean;
   freeTier: FreeTierState | null;
-  /** Both CTAs land on the Billing Area Plan view (full-page navigation). */
-  onNavigateToBilling: () => void;
+  /**
+   * Both CTAs are full-page navigations into the Billing Area: the blocked
+   * card's "Upgrade plan" deep-links the Plan Picker open (`upgrade`), the
+   * counter's "View plans" lands on the Plan view (`plans`).
+   */
+  onNavigateToBilling: (destination: ChatBillingDestination) => void;
 }) {
   const card = resolveChatBillingCard({
     billing: freeTier?.billing ?? null,

--- a/apps/ui/src/features/shell/project-workspace-layout.tsx
+++ b/apps/ui/src/features/shell/project-workspace-layout.tsx
@@ -40,9 +40,13 @@ import {
   claimBrainAiEngagementFromSession,
   trackBrainGtmEvent,
 } from "@/features/analytics/brain-gtm";
+import { recordBillingReturnRoute } from "@/features/billing/billing-return-route";
 import { Chat } from "@/features/chat/chat";
 import type { ChatHeaderThreadHistory } from "@/features/chat/chat.types";
-import { ChatBillingCardSlot } from "@/features/chat/chat-billing-cards";
+import {
+  ChatBillingCardSlot,
+  type ChatBillingDestination,
+} from "@/features/chat/chat-billing-cards";
 import {
   fetchAssistantSession,
   fetchAssistantThreadMessages,
@@ -717,9 +721,17 @@ function ProjectAssistantChatSession({
 
   // Full-page navigation: returning from the Billing Area remounts the pane
   // and re-fetches the session, which is the only way out of `blocked`.
-  const navigateToBilling = useCallback(() => {
-    router.push("/billing");
-  }, [router]);
+  // Recording the return route lets the Billing Area close button land back
+  // on this project instead of the sidebar's last entry point.
+  const navigateToBilling = useCallback(
+    (destination: ChatBillingDestination) => {
+      recordBillingReturnRoute();
+      router.push(
+        destination === "upgrade" ? "/billing?mode=upgrade" : "/billing"
+      );
+    },
+    [router]
+  );
 
   return (
     <Chat.Root>


### PR DESCRIPTION
## What

When Free trial messages run out, the chat's blocked card shows an "Upgrade plan" CTA. It used to push a bare `/billing`, leaving the user to find the plan picker themselves. It now navigates to `/billing?mode=upgrade`, so the Plan Picker dialog opens on arrival — the same tested deep link the App Sidebar upgrade button already uses.

- The counter card's "View plans" keeps landing on the Plan view without opening the picker: with turns remaining the intent is browsing, not buying.
- Both chat CTAs now record the billing return route first, so the Billing Area close button lands back on the project the user was chatting in, remounts the pane, and clears `blocked` per ADR-0065 (previously it fell back to the sidebar's last entry point or home).
- The allowance's user-visible label is unified as **"Free trial messages"** across every surface (chat cards, the 402 response, the Plan view's allowance card). It was previously "Free messages" in chat and "Free assistant messages" in billing; CONTEXT.md now fixes the label and retires both older variants.

## Commits

1. `feat(ui)` — label rename across chat + billing surfaces, tests, and CONTEXT.md.
2. `feat(chat)` — CTA deep link + return-route recording, with destination-level test assertions.

## Testing

- `bun check` clean.
- Focused suites green: chat billing cards 6/6, free-turns section 4/4, billing plan 15/15, chat API route 43/43.
- Pre-existing failures unrelated to this branch (reproduced on clean main): the `preview-canvas-perf` typecheck error, 4 cross-file isolation failures when the three billing/chat interaction suites run together, and 2 `app-sidebar.test.ts` failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AvJNCVneDGm5wbnK7uScT