### PR TITLE
fix(deploy): respect managed gateway turn outcomes

### DIFF
--- a/apps/ui/src/features/deploy/task/gateway.test.ts
+++ b/apps/ui/src/features/deploy/task/gateway.test.ts
@@ -108,6 +108,7 @@ function installGatewayFetch(input: {
   stateActiveSequence?: boolean[];
   stateActive: boolean;
   stateOmitLastTurnStatus?: boolean;
+  stateResponseDelayMs?: number[];
   stateStatuses?: number[];
   stateTurnStatus?: string | null;
   stateTurnStatusSequence?: Array<string | null>;
@@ -116,7 +117,7 @@ function installGatewayFetch(input: {
   const paths: string[] = [];
   let interruptAttempt = 0;
   let stateRead = 0;
-  globalThis.fetch = ((
+  globalThis.fetch = (async (
     requestInput: Parameters<typeof fetch>[0],
     init?: Parameters<typeof fetch>[1]
   ) => {
@@ -161,6 +162,10 @@ function installGatewayFetch(input: {
     if (url.pathname.endsWith("/state")) {
       input.onState?.();
       const readIndex = stateRead++;
+      const delayMs = input.stateResponseDelayMs?.[readIndex] ?? 0;
+      if (delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
       const status = input.stateStatuses?.[readIndex] ?? 200;
       if (status !== 200) {
         return Response.json({ error: "state unavailable" }, { status });
@@ -428,6 +433,26 @@ describe("deployment Codex gateway interruption", () => {
         (event) => event.kind === "deploy_task.gateway_interrupt_failed"
       )
     ).toBe(true);
+  });
+
+  it("preserves timeout when the deadline interrupt settles during a state poll", async () => {
+    const paths = installGatewayFetch({
+      stateActive: false,
+      stateResponseDelayMs: [50],
+      stateTurnStatus: "interrupted",
+    });
+
+    await expect(
+      runDeployTaskGateway({
+        context: { authToken: "gateway-token", url: "https://gateway.test" },
+        deadlineAtMs: Date.now() + 25,
+        task: task(),
+      })
+    ).rejects.toBeInstanceOf(CodexGatewayTimeoutError);
+
+    expect(
+      paths.filter((path) => path.endsWith("/turn/interrupt"))
+    ).toHaveLength(1);
   });
 
   it("retries a 409 while the turn is still active", async () => {

--- a/apps/ui/src/features/deploy/task/gateway.test.ts
+++ b/apps/ui/src/features/deploy/task/gateway.test.ts
@@ -37,6 +37,7 @@ mock.module("./runner-writes", () => ({
 const {
   CodexGatewayApiError,
   CodexGatewayTimeoutError,
+  CodexGatewayTurnError,
   DEPLOY_GATEWAY_MODEL,
   resolveDeployGatewayModel,
   runDeployTaskGateway: runDeployTaskGatewayRaw,
@@ -54,10 +55,14 @@ function runDeployTaskGateway(
   });
 }
 
-function gatewayState(activeTurn: boolean) {
+function gatewayState(
+  activeTurn: boolean,
+  lastTurnStatus: string | null = activeTurn ? "inProgress" : "completed"
+) {
   return {
     activeTurn,
     cwd: "/home/devbox/project",
+    lastTurnStatus,
     ready: true,
     recentEvents: [],
     transcript: [],
@@ -66,12 +71,13 @@ function gatewayState(activeTurn: boolean) {
 
 function sessionResponse(
   activeTurn: boolean,
-  sessionId = "session-test-1"
+  sessionId = "session-test-1",
+  lastTurnStatus: string | null = activeTurn ? "inProgress" : "completed"
 ): Response {
   return Response.json({
     ok: true,
     sessionId,
-    state: gatewayState(activeTurn),
+    state: gatewayState(activeTurn, lastTurnStatus),
   });
 }
 
@@ -102,6 +108,8 @@ function installGatewayFetch(input: {
   stateActiveSequence?: boolean[];
   stateActive: boolean;
   stateStatuses?: number[];
+  stateTurnStatus?: string | null;
+  stateTurnStatusSequence?: Array<string | null>;
   turnError?: Error;
 }): string[] {
   const paths: string[] = [];
@@ -156,8 +164,14 @@ function installGatewayFetch(input: {
       if (status !== 200) {
         return Response.json({ error: "state unavailable" }, { status });
       }
+      const activeTurn =
+        input.stateActiveSequence?.[readIndex] ?? input.stateActive;
       return sessionResponse(
-        input.stateActiveSequence?.[readIndex] ?? input.stateActive
+        activeTurn,
+        "session-test-1",
+        input.stateTurnStatusSequence?.[readIndex] ??
+          input.stateTurnStatus ??
+          (activeTurn ? "inProgress" : "completed")
       );
     }
     if (url.pathname.endsWith("/turn/interrupt")) {
@@ -212,6 +226,28 @@ describe("deployment Codex gateway interruption", () => {
     expect(paths.some((path) => path.endsWith("/turn/interrupt"))).toBe(false);
     expect(
       recordedEvents.some((event) => event.kind.includes("interrupted"))
+    ).toBe(false);
+  });
+
+  it("rejects a failed terminal turn without opening a completion-required turn", async () => {
+    const paths = installGatewayFetch({
+      stateActive: false,
+      stateTurnStatus: "failed",
+    });
+
+    await expect(
+      runDeployTaskGateway({
+        context: { authToken: "gateway-token", url: "https://gateway.test" },
+        deadlineAtMs: Date.now() + 1000,
+        task: task(),
+      })
+    ).rejects.toBeInstanceOf(CodexGatewayTurnError);
+
+    expect(paths.some((path) => path.endsWith("/turn/interrupt"))).toBe(false);
+    expect(
+      recordedEvents.some(
+        (event) => event.kind === "deploy_task.gateway_turn_completed"
+      )
     ).toBe(false);
   });
 

--- a/apps/ui/src/features/deploy/task/gateway.test.ts
+++ b/apps/ui/src/features/deploy/task/gateway.test.ts
@@ -107,6 +107,7 @@ function installGatewayFetch(input: {
   sessionHeaders?: Record<string, string>[];
   stateActiveSequence?: boolean[];
   stateActive: boolean;
+  stateOmitLastTurnStatus?: boolean;
   stateStatuses?: number[];
   stateTurnStatus?: string | null;
   stateTurnStatusSequence?: Array<string | null>;
@@ -166,6 +167,15 @@ function installGatewayFetch(input: {
       }
       const activeTurn =
         input.stateActiveSequence?.[readIndex] ?? input.stateActive;
+      if (input.stateOmitLastTurnStatus) {
+        const { lastTurnStatus: _lastTurnStatus, ...state } =
+          gatewayState(activeTurn);
+        return Response.json({
+          ok: true,
+          sessionId: "session-test-1",
+          state,
+        });
+      }
       return sessionResponse(
         activeTurn,
         "session-test-1",
@@ -227,6 +237,26 @@ describe("deployment Codex gateway interruption", () => {
     expect(
       recordedEvents.some((event) => event.kind.includes("interrupted"))
     ).toBe(false);
+  });
+
+  it("accepts a settled turn when an older gateway omits lastTurnStatus", async () => {
+    const paths = installGatewayFetch({
+      stateActive: false,
+      stateOmitLastTurnStatus: true,
+    });
+
+    await runDeployTaskGateway({
+      context: { authToken: "gateway-token", url: "https://gateway.test" },
+      deadlineAtMs: Date.now() + 1000,
+      task: task(),
+    });
+
+    expect(paths.some((path) => path.endsWith("/turn/interrupt"))).toBe(false);
+    expect(
+      recordedEvents.some(
+        (event) => event.kind === "deploy_task.gateway_turn_completed"
+      )
+    ).toBe(true);
   });
 
   it("rejects a failed terminal turn without opening a completion-required turn", async () => {

--- a/apps/ui/src/features/deploy/task/gateway.ts
+++ b/apps/ui/src/features/deploy/task/gateway.ts
@@ -780,6 +780,9 @@ async function waitForGatewayTurnCompletion(input: {
     });
 
     if (!sessionState.state.activeTurn) {
+      if (Date.now() >= input.deadlineAtMs) {
+        throw new CodexGatewayTimeoutError();
+      }
       const failedStatus = failedGatewayTurnStatus(
         sessionState.state.lastTurnStatus
       );

--- a/apps/ui/src/features/deploy/task/gateway.ts
+++ b/apps/ui/src/features/deploy/task/gateway.ts
@@ -95,6 +95,41 @@ export class CodexGatewayTimeoutError extends Error {
   }
 }
 
+type CodexGatewayFailedTurnStatus =
+  | "cancelled"
+  | "failed"
+  | "interrupted"
+  | "unknown";
+
+export class CodexGatewayTurnError extends Error {
+  status: CodexGatewayFailedTurnStatus;
+
+  constructor(status: CodexGatewayFailedTurnStatus) {
+    super("Codex gateway turn did not complete successfully.");
+    this.name = "CodexGatewayTurnError";
+    this.status = status;
+  }
+}
+
+function failedGatewayTurnStatus(
+  value: string | null | undefined
+): CodexGatewayFailedTurnStatus | null {
+  switch (value?.trim().toLowerCase()) {
+    case "completed":
+      return null;
+    case "cancelled":
+    case "canceled":
+      return "cancelled";
+    case "failed":
+    case "error":
+      return "failed";
+    case "interrupted":
+      return "interrupted";
+    default:
+      return "unknown";
+  }
+}
+
 export function codexGatewayFailureDetails(
   error: unknown
 ): DeployTaskFailureDetails {
@@ -107,6 +142,9 @@ export function codexGatewayFailureDetails(
       reason:
         error.status >= 500 ? "gateway-upstream-error" : "gateway-unavailable",
     };
+  }
+  if (error instanceof CodexGatewayTurnError) {
+    return { reason: "gateway-upstream-error" };
   }
   if (
     (error instanceof DOMException && error.name === "TimeoutError") ||
@@ -737,6 +775,12 @@ async function waitForGatewayTurnCompletion(input: {
     });
 
     if (!sessionState.state.activeTurn) {
+      const failedStatus = failedGatewayTurnStatus(
+        sessionState.state.lastTurnStatus
+      );
+      if (failedStatus != null) {
+        throw new CodexGatewayTurnError(failedStatus);
+      }
       return sessionState.state;
     }
 
@@ -938,7 +982,7 @@ export async function runDeployTaskGateway(input: {
     });
     turnMayBeActive = false;
   } catch (error) {
-    if (turnMayBeActive) {
+    if (turnMayBeActive && !(error instanceof CodexGatewayTurnError)) {
       await interruptTurnOnce();
     }
     throw error;

--- a/apps/ui/src/features/deploy/task/gateway.ts
+++ b/apps/ui/src/features/deploy/task/gateway.ts
@@ -149,7 +149,18 @@ export function codexGatewayFailureDetails(
     };
   }
   if (error instanceof CodexGatewayTurnError) {
-    return { reason: "gateway-upstream-error" };
+    switch (error.status) {
+      case "cancelled":
+        return { reason: "cancelled" };
+      case "failed":
+        return { reason: "gateway-upstream-error" };
+      case "interrupted":
+        return { reason: "interrupted" };
+      case "unknown":
+        return { reason: "unknown" };
+      default:
+        return { reason: "unknown" };
+    }
   }
   if (
     (error instanceof DOMException && error.name === "TimeoutError") ||

--- a/apps/ui/src/features/deploy/task/gateway.ts
+++ b/apps/ui/src/features/deploy/task/gateway.ts
@@ -114,7 +114,12 @@ export class CodexGatewayTurnError extends Error {
 function failedGatewayTurnStatus(
   value: string | null | undefined
 ): CodexGatewayFailedTurnStatus | null {
-  switch (value?.trim().toLowerCase()) {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  switch (normalized) {
     case "completed":
       return null;
     case "cancelled":

--- a/apps/ui/src/features/deploy/task/runner.github-ai-proxy.test.ts
+++ b/apps/ui/src/features/deploy/task/runner.github-ai-proxy.test.ts
@@ -53,6 +53,7 @@ const { getDeploySkillSourceFromEnv } = requireModule(
 const {
   CodexGatewayApiError,
   CodexGatewayTimeoutError,
+  CodexGatewayTurnError,
   codexGatewayFailureDetails,
   gatewayEventProjection,
   gatewayStateSnapshot,
@@ -785,6 +786,14 @@ describe("Codex gateway failure classification", () => {
   it("classifies turn timeouts independently from upstream errors", () => {
     expect(codexGatewayFailureDetails(new CodexGatewayTimeoutError())).toEqual({
       reason: "gateway-timeout",
+    });
+  });
+
+  it("classifies a failed Codex turn as an upstream execution error", () => {
+    expect(
+      codexGatewayFailureDetails(new CodexGatewayTurnError("failed"))
+    ).toEqual({
+      reason: "gateway-upstream-error",
     });
   });
 

--- a/apps/ui/src/features/deploy/task/runner.github-ai-proxy.test.ts
+++ b/apps/ui/src/features/deploy/task/runner.github-ai-proxy.test.ts
@@ -797,6 +797,18 @@ describe("Codex gateway failure classification", () => {
     });
   });
 
+  for (const [status, reason] of [
+    ["cancelled", "cancelled"],
+    ["interrupted", "interrupted"],
+    ["unknown", "unknown"],
+  ] as const) {
+    it(`preserves the ${status} Codex turn reason`, () => {
+      expect(
+        codexGatewayFailureDetails(new CodexGatewayTurnError(status))
+      ).toEqual({ reason });
+    });
+  }
+
   it("classifies fetch failures as unavailable", () => {
     expect(codexGatewayFailureDetails(new TypeError("fetch failed"))).toEqual({
       reason: "gateway-unavailable",

--- a/apps/ui/src/features/deploy/task/runner.ts
+++ b/apps/ui/src/features/deploy/task/runner.ts
@@ -3541,17 +3541,12 @@ export function enterManagedDeploymentCompletionRequired(
   return { ...state, resumeMode: "completion-required" };
 }
 
-const MAX_COMPLETION_REQUIRED_TURNS = 2;
-
 async function continueManagedDeploymentAfterMissingControlNotification(input: {
   attempt: number;
   applying: boolean;
   lifecycleState: ManagedDeploymentLifecycleState;
   taskId: string;
 }): Promise<ManagedDeploymentLifecycleState> {
-  if (input.attempt > MAX_COMPLETION_REQUIRED_TURNS) {
-    throw deployFailureError("runner-error");
-  }
   await recordDeployTaskEvent(input.taskId, {
     kind: "deployment_task.gateway_completion_required",
     message:
@@ -3626,6 +3621,7 @@ async function runManagedDeploymentLifecycleCore(input: {
   let completionRequiredTurns = 0;
 
   while (true) {
+    throwIfDeploymentDeadlineElapsed(input.executionDeadlineAtMs);
     // No per-turn limit: every turn shares the same Agent execution window,
     // which is itself clamped to the 70-minute task deadline.
     const deadlineAtMs = input.executionDeadlineAtMs;


### PR DESCRIPTION
## 问题

GitHub 部署 Task 使用 managed Gateway turn 时，Brain 之前只判断 turn 是否仍在执行；当 Gateway turn 已结束但状态实际是 `failed` / `interrupted` / `cancelled` 时，Runner 会错误地把它当作正常完成，并继续发起 `deployment_completion_required` turn。

同时，Runner 用固定的 completion-required 次数上限终止任务，导致用户的 Agent thread 在第三轮就被标记为 `runner-error`，即使 Task 的整体执行时限仍未耗尽。

## 修改

- 显式读取并校验 Gateway 的最终 turn 状态。
- 仅将 `completed` 视为成功；失败、中断、取消和未知状态会进入对应错误路径。
- Gateway 上游失败映射为 `gateway-upstream-error`。
- 已经结束的失败 turn 不再发送多余的 interrupt。
- 移除固定的 completion-required turn 次数上限。
- completion-required 重试改为受 Task 的整体 execution deadline 约束。

## 验证

- `bun typecheck`
- `bun check`
- `bun lint`
- `cd apps/ui && bun test src/features/deploy/task`

结果：部署 Task 测试 350 passed / 0 failed。

## Review notes / follow-ups

本 PR 先修复造成线上 GitHub Task 快速失败的核心状态判断和固定三轮限制。以下两项建议后续加固：

1. completion-required 重试目前依赖 44 分钟 execution window 兜底；应增加 progress-aware backoff / no-progress budget，避免 Agent 持续无进展时产生过多 turn。
2. `lastTurnStatus` 目前是可选、自由字符串协议；应改成版本化枚举并明确旧 Gateway 的兼容策略。
