### PR TITLE
feat(projects): adopt external Template Instances as Brain Projects

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -278,6 +278,12 @@ The split lifecycle boundary between permanent Deployment Task history and its e
 
 _Avoid_: task purge, clear history, archive task, Devbox retention as task retention.
 
+### Template Instance Adoption
+
+Claiming an already-applied Sealos Template Instance into Brain as a Project after the cluster already has the Instance. Brain creates the Project row and writes Brain bookkeeping labels onto the instance's namespaced resources; it does not inject `extraLabels` at create time (that remains the GitHub Deployment Task path). Namespace comes only from the request kubeconfig. Identity is the Instance UID, not the instance name — a reused name with a new UID is a new Project. The mapping's adopting/adopted/failed status is internal bookkeeping, never a user-visible Project status. Brain labels written here follow ADR 0027: they mark ownership, they do not classify AP or DB.
+
+_Avoid_: import template, claim instance, extraLabels backfill, adopt as a Deployment Task.
+
 ### GitHub Connection
 
 A personal OAuth authorization that lets one Workspace Actor list and deploy from their own GitHub repositories within a namespace — never a shared namespace credential another actor may select. Disconnecting forgets the connection locally; the GitHub-side authorization survives until revoked on GitHub, and account choice happens at connect time, never at disconnect.

--- a/apps/ui/drizzle/0017_template_instance_adoptions.sql
+++ b/apps/ui/drizzle/0017_template_instance_adoptions.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "sealai_project"."template_instance_adoptions" (
+	"namespace" text NOT NULL,
+	"instance_uid" text NOT NULL,
+	"instance_name" text NOT NULL,
+	"project_id" text NOT NULL,
+	"template_name" text DEFAULT '' NOT NULL,
+	"status" text NOT NULL,
+	"discovered_count" integer DEFAULT 0 NOT NULL,
+	"labeled_count" integer DEFAULT 0 NOT NULL,
+	"last_error" text,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "template_instance_adoptions_pk" PRIMARY KEY("namespace","instance_uid"),
+	CONSTRAINT "template_instance_adoptions_status_valid" CHECK ("sealai_project"."template_instance_adoptions"."status" IN ('adopting', 'adopted', 'failed'))
+);
+--> statement-breakpoint
+CREATE INDEX "template_instance_adoptions_namespace_project_id_idx" ON "sealai_project"."template_instance_adoptions" USING btree ("namespace","project_id");

--- a/apps/ui/drizzle/meta/0017_snapshot.json
+++ b/apps/ui/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,3033 @@
+{
+  "id": "7804d409-c455-4a2c-8d79-0e2fba430650",
+  "prevId": "23111d98-496c-4380-b767-5541faabf467",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "sealai_assistant.assistant_chat_messages": {
+      "name": "assistant_chat_messages",
+      "schema": "sealai_assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assistant_chat_messages_chat_id_idx": {
+          "name": "assistant_chat_messages_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assistant_chat_messages_chat_id_created_idx": {
+          "name": "assistant_chat_messages_chat_id_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assistant_chat_messages_chat_id_assistant_chats_id_fk": {
+          "name": "assistant_chat_messages_chat_id_assistant_chats_id_fk",
+          "tableFrom": "assistant_chat_messages",
+          "tableTo": "assistant_chats",
+          "schemaTo": "sealai_assistant",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.assistant_chats": {
+      "name": "assistant_chats",
+      "schema": "sealai_assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_actor": {
+          "name": "workspace_actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Chat'"
+        },
+        "title_ai_generated": {
+          "name": "title_ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assistant_chats_updated_at_idx": {
+          "name": "assistant_chats_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assistant_chats_namespace_actor_updated_at_idx": {
+          "name": "assistant_chats_namespace_actor_updated_at_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_actor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.assistant_devbox_runtimes": {
+      "name": "assistant_devbox_runtimes",
+      "schema": "sealai_assistant",
+      "columns": {
+        "upstream_id": {
+          "name": "upstream_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_name": {
+          "name": "runtime_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pause_due_at": {
+          "name": "pause_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_due_at": {
+          "name": "delete_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_lease_owner": {
+          "name": "cleanup_lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_lease_expires_at": {
+          "name": "cleanup_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assistant_devbox_runtimes_pause_due_idx": {
+          "name": "assistant_devbox_runtimes_pause_due_idx",
+          "columns": [
+            {
+              "expression": "pause_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_assistant\".\"assistant_devbox_runtimes\".\"paused_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assistant_devbox_runtimes_delete_due_idx": {
+          "name": "assistant_devbox_runtimes_delete_due_idx",
+          "columns": [
+            {
+              "expression": "delete_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_assistant\".\"assistant_devbox_runtimes\".\"delete_due_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.assistant_entitlements": {
+      "name": "assistant_entitlements",
+      "schema": "sealai_assistant",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "free_turns_used": {
+          "name": "free_turns_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assistant_entitlements_updated_at_idx": {
+          "name": "assistant_entitlements_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.github_app_install_sessions": {
+      "name": "github_app_install_sessions",
+      "schema": "sealai_assistant",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_actor": {
+          "name": "workspace_actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "owner_identity_version": {
+          "name": "owner_identity_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "return_path": {
+          "name": "return_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_app_install_sessions_expires_at_idx": {
+          "name": "github_app_install_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_app_install_sessions_namespace_idx": {
+          "name": "github_app_install_sessions_namespace_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.github_connections": {
+      "name": "github_connections",
+      "schema": "sealai_assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github_app'"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'User'"
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_connections_updated_at_idx": {
+          "name": "github_connections_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_namespace_updated_at_idx": {
+          "name": "github_connections_namespace_updated_at_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_namespace_unique_idx": {
+          "name": "github_connections_namespace_unique_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_connections_installation_idx": {
+          "name": "github_connections_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.github_oauth_connections": {
+      "name": "github_oauth_connections",
+      "schema": "sealai_assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_actor": {
+          "name": "workspace_actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "owner_identity_version": {
+          "name": "owner_identity_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "github_login": {
+          "name": "github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bearer'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_oauth_connections_updated_at_idx": {
+          "name": "github_oauth_connections_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_oauth_connections_github_login_idx": {
+          "name": "github_oauth_connections_github_login_idx",
+          "columns": [
+            {
+              "expression": "github_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_oauth_connections_current_owner_unique_idx": {
+          "name": "github_oauth_connections_current_owner_unique_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_actor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sealai_assistant\".\"github_oauth_connections\".\"owner_identity_version\" = 2",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.identity_fingerprints": {
+      "name": "identity_fingerprints",
+      "schema": "sealai_assistant",
+      "columns": {
+        "cr_name": {
+          "name": "cr_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_uid": {
+          "name": "user_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minted_at": {
+          "name": "minted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_assistant.identity_uid_canonicalizations": {
+      "name": "identity_uid_canonicalizations",
+      "schema": "sealai_assistant",
+      "columns": {
+        "user_uid": {
+          "name": "user_uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canonical_user_uid": {
+          "name": "canonical_user_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "identity_uid_canonicalizations_canonical_idx": {
+          "name": "identity_uid_canonicalizations_canonical_idx",
+          "columns": [
+            {
+              "expression": "canonical_user_uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_deployment.deploy_task_agent_calls": {
+      "name": "deploy_task_agent_calls",
+      "schema": "sealai_deployment",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_epoch": {
+          "name": "lease_epoch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claim_owner": {
+          "name": "claim_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "deploy_task_agent_calls_pending_idx": {
+          "name": "deploy_task_agent_calls_pending_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_deployment\".\"deploy_task_agent_calls\".\"state\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deploy_task_agent_calls_task_id_deploy_tasks_id_fk": {
+          "name": "deploy_task_agent_calls_task_id_deploy_tasks_id_fk",
+          "tableFrom": "deploy_task_agent_calls",
+          "tableTo": "deploy_tasks",
+          "schemaTo": "sealai_deployment",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "deploy_task_agent_calls_pk": {
+          "name": "deploy_task_agent_calls_pk",
+          "columns": ["task_id", "call_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "deploy_task_agent_calls_lease_epoch_nonnegative": {
+          "name": "deploy_task_agent_calls_lease_epoch_nonnegative",
+          "value": "\"sealai_deployment\".\"deploy_task_agent_calls\".\"lease_epoch\" >= 0"
+        },
+        "deploy_task_agent_calls_tool_name_valid": {
+          "name": "deploy_task_agent_calls_tool_name_valid",
+          "value": "\"sealai_deployment\".\"deploy_task_agent_calls\".\"tool_name\" IN ('template_ready', 'deployment_completed')"
+        },
+        "deploy_task_agent_calls_state_valid": {
+          "name": "deploy_task_agent_calls_state_valid",
+          "value": "\"sealai_deployment\".\"deploy_task_agent_calls\".\"state\" IN ('pending', 'running', 'succeeded', 'failed')"
+        },
+        "deploy_task_agent_calls_request_hash_valid": {
+          "name": "deploy_task_agent_calls_request_hash_valid",
+          "value": "char_length(\"sealai_deployment\".\"deploy_task_agent_calls\".\"request_hash\") = 64"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "sealai_deployment.deploy_task_events": {
+      "name": "deploy_task_events",
+      "schema": "sealai_deployment",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nextval('sealai_deployment.deploy_task_events_seq'::regclass)"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deploy_task_events_task_created_at_idx": {
+          "name": "deploy_task_events_task_created_at_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deploy_task_events_task_id_deploy_tasks_id_fk": {
+          "name": "deploy_task_events_task_id_deploy_tasks_id_fk",
+          "tableFrom": "deploy_task_events",
+          "tableTo": "deploy_tasks",
+          "schemaTo": "sealai_deployment",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "deploy_task_events_pk": {
+          "name": "deploy_task_events_pk",
+          "columns": ["task_id", "seq"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_deployment.deploy_task_messages": {
+      "name": "deploy_task_messages",
+      "schema": "sealai_deployment",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deploy_task_messages_task_id_idx": {
+          "name": "deploy_task_messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_task_messages_task_created_idx": {
+          "name": "deploy_task_messages_task_created_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deploy_task_messages_task_id_deploy_tasks_id_fk": {
+          "name": "deploy_task_messages_task_id_deploy_tasks_id_fk",
+          "tableFrom": "deploy_task_messages",
+          "tableTo": "deploy_tasks",
+          "schemaTo": "sealai_deployment",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_deployment.deploy_tasks": {
+      "name": "deploy_tasks",
+      "schema": "sealai_deployment",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_uid": {
+          "name": "project_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creating_actor": {
+          "name": "creating_actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marketing_attribution": {
+          "name": "marketing_attribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_binding": {
+          "name": "credential_binding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_connection_id": {
+          "name": "github_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_from": {
+          "name": "created_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_name": {
+          "name": "runtime_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_paused_at": {
+          "name": "runtime_paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_cleanup_lease_owner": {
+          "name": "runtime_cleanup_lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_cleanup_lease_expires_at": {
+          "name": "runtime_cleanup_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_url": {
+          "name": "gateway_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_session_id": {
+          "name": "gateway_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_thread_id": {
+          "name": "gateway_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_turn_id": {
+          "name": "gateway_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gateway_state_snapshot": {
+          "name": "gateway_state_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_turn_count": {
+          "name": "agent_turn_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "agent_protocol": {
+          "name": "agent_protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mcp-v1'"
+        },
+        "agent_control_token_hash": {
+          "name": "agent_control_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_control_token_revoked_at": {
+          "name": "agent_control_token_revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_template_digest": {
+          "name": "agent_template_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_input_schema_digest": {
+          "name": "agent_input_schema_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_checkpoint_id": {
+          "name": "agent_checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_input_revision": {
+          "name": "agent_input_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "agent_completion_receipt": {
+          "name": "agent_completion_receipt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_details": {
+          "name": "failure_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_summary": {
+          "name": "artifact_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "canvas_projection": {
+          "name": "canvas_projection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "timeline_snapshot": {
+          "name": "timeline_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocking_inputs": {
+          "name": "blocking_inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "preview_url": {
+          "name": "preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_url": {
+          "name": "result_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_epoch": {
+          "name": "lease_epoch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_claimed_at": {
+          "name": "lease_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retried_from_task_id": {
+          "name": "retried_from_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deploy_tasks_agent_control_token_hash_idx": {
+          "name": "deploy_tasks_agent_control_token_hash_idx",
+          "columns": [
+            {
+              "expression": "agent_control_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"agent_control_token_hash\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_namespace_updated_at_idx": {
+          "name": "deploy_tasks_namespace_updated_at_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_project_uid_updated_at_idx": {
+          "name": "deploy_tasks_project_uid_updated_at_idx",
+          "columns": [
+            {
+              "expression": "project_uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_status_updated_at_idx": {
+          "name": "deploy_tasks_status_updated_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_leased_expiry_idx": {
+          "name": "deploy_tasks_leased_expiry_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"status\" IN ('running', 'applying')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_queued_created_idx": {
+          "name": "deploy_tasks_queued_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_terminal_completed_idx": {
+          "name": "deploy_tasks_terminal_completed_idx",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"status\" IN ('completed', 'failed', 'cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_runtime_paused_idx": {
+          "name": "deploy_tasks_runtime_paused_idx",
+          "columns": [
+            {
+              "expression": "runtime_paused_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"runtime_provider\" = 'devbox' AND lower(coalesce(\"sealai_deployment\".\"deploy_tasks\".\"runtime_state\", '')) IN ('paused', 'archived')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deploy_tasks_one_active_clone_idx": {
+          "name": "deploy_tasks_one_active_clone_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retried_from_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sealai_deployment\".\"deploy_tasks\".\"retried_from_task_id\" IS NOT NULL AND \"sealai_deployment\".\"deploy_tasks\".\"status\" IN ('queued', 'running', 'blocked', 'applying')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "deploy_tasks_agent_turn_count_nonnegative": {
+          "name": "deploy_tasks_agent_turn_count_nonnegative",
+          "value": "\"sealai_deployment\".\"deploy_tasks\".\"agent_turn_count\" >= 0"
+        },
+        "deploy_tasks_agent_input_revision_nonnegative": {
+          "name": "deploy_tasks_agent_input_revision_nonnegative",
+          "value": "\"sealai_deployment\".\"deploy_tasks\".\"agent_input_revision\" >= 0"
+        },
+        "deploy_tasks_agent_protocol_valid": {
+          "name": "deploy_tasks_agent_protocol_valid",
+          "value": "\"sealai_deployment\".\"deploy_tasks\".\"agent_protocol\" IN ('mcp-v1')"
+        },
+        "deploy_tasks_agent_control_token_hash_valid": {
+          "name": "deploy_tasks_agent_control_token_hash_valid",
+          "value": "\"sealai_deployment\".\"deploy_tasks\".\"agent_control_token_hash\" IS NULL OR char_length(\"sealai_deployment\".\"deploy_tasks\".\"agent_control_token_hash\") = 64"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "sealai_onboarding.onboarding_profiles": {
+      "name": "onboarding_profiles",
+      "schema": "sealai_onboarding",
+      "columns": {
+        "user_uid": {
+          "name": "user_uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dismissed_at_step": {
+          "name": "dismissed_at_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_type": {
+          "name": "role_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_other_text": {
+          "name": "role_other_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_context": {
+          "name": "usage_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_other_text": {
+          "name": "usage_other_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_tags": {
+          "name": "priority_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_display_order": {
+          "name": "priority_display_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_other_text": {
+          "name": "priority_other_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_goal_text": {
+          "name": "open_goal_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_cancellation_survey.cancellation_survey_responses": {
+      "name": "cancellation_survey_responses",
+      "schema": "sealai_cancellation_survey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace": {
+          "name": "workspace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_domain": {
+          "name": "region_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_name": {
+          "name": "plan_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end_at": {
+          "name": "current_period_end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_uid": {
+          "name": "user_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_keys": {
+          "name": "reason_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_marketing.attribution_subjects": {
+      "name": "attribution_subjects",
+      "schema": "sealai_marketing",
+      "columns": {
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_touch": {
+          "name": "first_touch",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_touch": {
+          "name": "last_touch",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gclid": {
+          "name": "gclid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gbraid": {
+          "name": "gbraid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wbraid": {
+          "name": "wbraid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ad_personalization": {
+          "name": "ad_personalization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unspecified'"
+        },
+        "ad_user_data_consent": {
+          "name": "ad_user_data_consent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unspecified'"
+        },
+        "click_id_candidates": {
+          "name": "click_id_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_provenance": {
+          "name": "consent_provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "attribution_subjects_pk": {
+          "name": "attribution_subjects_pk",
+          "columns": ["subject_type", "subject_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_marketing.lifecycle_events": {
+      "name": "lifecycle_events",
+      "schema": "sealai_marketing",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_touch": {
+          "name": "first_touch",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_touch": {
+          "name": "last_touch",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gclid": {
+          "name": "gclid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gbraid": {
+          "name": "gbraid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wbraid": {
+          "name": "wbraid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ad_personalization": {
+          "name": "ad_personalization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unspecified'"
+        },
+        "ad_user_data_consent": {
+          "name": "ad_user_data_consent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unspecified'"
+        },
+        "click_id_candidates": {
+          "name": "click_id_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_provenance": {
+          "name": "consent_provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashed_user_data": {
+          "name": "hashed_user_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(24, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lifecycle_events_action_transaction_idx": {
+          "name": "lifecycle_events_action_transaction_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sealai_marketing\".\"lifecycle_events\".\"transaction_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_notification.notification_messages": {
+      "name": "notification_messages",
+      "schema": "sealai_notification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uid": {
+          "name": "user_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_uid": {
+          "name": "project_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_messages_live_dedupe_key_idx": {
+          "name": "notification_messages_live_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sealai_notification\".\"notification_messages\".\"released_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_messages_namespace_created_at_idx": {
+          "name": "notification_messages_namespace_created_at_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_messages_user_uid_created_at_idx": {
+          "name": "notification_messages_user_uid_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_messages_created_at_idx": {
+          "name": "notification_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_notification.notification_read_receipts": {
+      "name": "notification_read_receipts",
+      "schema": "sealai_notification",
+      "columns": {
+        "user_uid": {
+          "name": "user_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_key": {
+          "name": "message_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_read_receipts_message_id_idx": {
+          "name": "notification_read_receipts_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_read_receipts_message_id_notification_messages_id_fk": {
+          "name": "notification_read_receipts_message_id_notification_messages_id_fk",
+          "tableFrom": "notification_read_receipts",
+          "tableTo": "notification_messages",
+          "schemaTo": "sealai_notification",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "notification_read_receipts_user_uid_message_key_pk": {
+          "name": "notification_read_receipts_user_uid_message_key_pk",
+          "columns": ["user_uid", "message_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_canvas_layouts": {
+      "name": "project_canvas_layouts",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_uid": {
+          "name": "project_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name_snapshot": {
+          "name": "project_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "nodes": {
+          "name": "nodes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_canvas_layouts_updated_at_idx": {
+          "name": "project_canvas_layouts_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_canvas_layouts_pk": {
+          "name": "project_canvas_layouts_pk",
+          "columns": ["namespace", "project_uid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_delete_operations": {
+      "name": "project_delete_operations",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_uid": {
+          "name": "actor_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_id": {
+          "name": "preview_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_delete_operations_expires_at_idx": {
+          "name": "project_delete_operations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_delete_operations_pk": {
+          "name": "project_delete_operations_pk",
+          "columns": ["namespace", "project_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_delete_previews": {
+      "name": "project_delete_previews",
+      "schema": "sealai_project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_uid": {
+          "name": "actor_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_summary": {
+          "name": "resource_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_delete_previews_expires_at_idx": {
+          "name": "project_delete_previews_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_delete_previews_target_idx": {
+          "name": "project_delete_previews_target_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_delete_previews_pk": {
+          "name": "project_delete_previews_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_management_audit_events": {
+      "name": "project_management_audit_events",
+      "schema": "sealai_project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_uid": {
+          "name": "actor_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_summary": {
+          "name": "resource_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_management_audit_events_target_idx": {
+          "name": "project_management_audit_events_target_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_management_audit_events_pk": {
+          "name": "project_management_audit_events_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.project_navigation_preferences": {
+      "name": "project_navigation_preferences",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_project_ids": {
+          "name": "pinned_project_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_navigation_preferences_updated_at_idx": {
+          "name": "project_navigation_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "project_navigation_preferences_pk": {
+          "name": "project_navigation_preferences_pk",
+          "columns": ["namespace"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.projects": {
+      "name": "projects",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_namespace_lower_display_name_idx": {
+          "name": "projects_namespace_lower_display_name_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"display_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_updated_at_idx": {
+          "name": "projects_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "projects_pk": {
+          "name": "projects_pk",
+          "columns": ["namespace", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "sealai_project.template_instance_adoptions": {
+      "name": "template_instance_adoptions",
+      "schema": "sealai_project",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_uid": {
+          "name": "instance_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_name": {
+          "name": "instance_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_name": {
+          "name": "template_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discovered_count": {
+          "name": "discovered_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "labeled_count": {
+          "name": "labeled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_instance_adoptions_namespace_project_id_idx": {
+          "name": "template_instance_adoptions_namespace_project_id_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "template_instance_adoptions_pk": {
+          "name": "template_instance_adoptions_pk",
+          "columns": ["namespace", "instance_uid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "template_instance_adoptions_status_valid": {
+          "name": "template_instance_adoptions_status_valid",
+          "value": "\"sealai_project\".\"template_instance_adoptions\".\"status\" IN ('adopting', 'adopted', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "sealai_assistant": "sealai_assistant",
+    "sealai_deployment": "sealai_deployment",
+    "sealai_onboarding": "sealai_onboarding",
+    "sealai_cancellation_survey": "sealai_cancellation_survey",
+    "sealai_marketing": "sealai_marketing",
+    "sealai_notification": "sealai_notification",
+    "sealai_project": "sealai_project"
+  },
+  "sequences": {
+    "sealai_deployment.deploy_task_events_seq": {
+      "name": "deploy_task_events_seq",
+      "schema": "sealai_deployment",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/ui/drizzle/meta/_journal.json
+++ b/apps/ui/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1788319231977,
       "tag": "0016_cancellation_survey",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1788337614503,
+      "tag": "0017_template_instance_adoptions",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/ui/src/app/api/projects/adopt-template-instance/route.test.ts
+++ b/apps/ui/src/app/api/projects/adopt-template-instance/route.test.ts
@@ -1,0 +1,215 @@
+import { mock } from "bun:test";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+const HEADER_WHITESPACE_RE = /\s+/;
+
+class TemplateInstanceAdoptionError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "TemplateInstanceAdoptionError";
+    this.status = status;
+  }
+}
+
+interface AdoptInput {
+  instanceName: string;
+  namespace: string;
+}
+
+interface AdoptResult {
+  adoption: {
+    discoveredCount: number;
+    instanceName: string;
+    instanceUid: string;
+    labeledCount: number;
+    status: "adopted";
+    warnings: string[];
+  };
+  project: {
+    createdAt: string;
+    description: string;
+    displayName: string;
+    id: string;
+    namespace: string;
+    updatedAt: string;
+  };
+}
+
+const adopt: { impl: (input: AdoptInput) => Promise<AdoptResult> } = {
+  impl: () => Promise.reject(new Error("adoptTemplateInstance is not stubbed")),
+};
+
+mock.module("server-only", () => ({}));
+mock.module("@/lib/project-persistence/adopt-template-instance", () => ({
+  TemplateInstanceAdoptionError,
+  adoptTemplateInstance: (input: AdoptInput) => adopt.impl(input),
+}));
+mock.module("@/lib/request-kubeconfig-auth", () => ({
+  authorizeKubeconfigNamespace: (input: { encodedKubeconfig?: string }) => {
+    const encodedKubeconfig = input.encodedKubeconfig ?? "";
+    if (encodedKubeconfig === "") {
+      return Promise.resolve({
+        code: "authentication_required" as const,
+        ok: false as const,
+      });
+    }
+    if (encodedKubeconfig === "invalid-kc") {
+      return Promise.resolve({
+        code: "invalid_kubeconfig" as const,
+        ok: false as const,
+      });
+    }
+    if (encodedKubeconfig === "unresolved-kc") {
+      return Promise.resolve({
+        code: "namespace_unresolved" as const,
+        ok: false as const,
+      });
+    }
+    if (encodedKubeconfig === "forbidden-kc") {
+      return Promise.resolve({
+        code: "verification_failed" as const,
+        message: "Kubeconfig is not authorized for this namespace.",
+        ok: false as const,
+        status: 403,
+      });
+    }
+    return Promise.resolve({
+      encodedKubeconfig,
+      kubeconfig: "decoded",
+      namespace: "ns-from-kubeconfig",
+      ok: true as const,
+    });
+  },
+  encodedKubeconfigFromRequest: (request: Request) => {
+    const value = request.headers.get("authorization")?.trim() ?? "";
+    const [scheme, ...rest] = value.split(HEADER_WHITESPACE_RE);
+    if (scheme?.toLowerCase() !== "bearer") {
+      return "";
+    }
+    return rest.join(" ").trim();
+  },
+}));
+
+const { POST } = await import("./route");
+
+function request(input: { body?: unknown; kubeconfig?: string }): Request {
+  const headers = new Headers({ "Content-Type": "application/json" });
+  if (input.kubeconfig !== undefined) {
+    headers.set("Authorization", `Bearer ${input.kubeconfig}`);
+  }
+  return new Request(
+    "https://brain.test/api/projects/adopt-template-instance",
+    {
+      body: JSON.stringify(input.body ?? { instanceName: "memos" }),
+      headers,
+      method: "POST",
+    }
+  );
+}
+
+test("missing kubeconfig is 401", async () => {
+  const response = await POST(request({}) as never);
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), {
+    error: "Authentication is required.",
+  });
+});
+
+test("invalid kubeconfig is 400", async () => {
+  const response = await POST(request({ kubeconfig: "invalid-kc" }) as never);
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { error: "Invalid kubeconfig." });
+});
+
+test("unresolved kubeconfig namespace is 400", async () => {
+  const response = await POST(
+    request({ kubeconfig: "unresolved-kc" }) as never
+  );
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    error: "Could not resolve namespace from kubeconfig.",
+  });
+});
+
+test("namespace authorization failure is 403", async () => {
+  const response = await POST(request({ kubeconfig: "forbidden-kc" }) as never);
+  assert.equal(response.status, 403);
+  assert.deepEqual(await response.json(), {
+    error: "Namespace is not accessible.",
+  });
+});
+
+test("invalid body is 400", async () => {
+  const response = await POST(request({ body: {}, kubeconfig: "ok" }) as never);
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    error: "Invalid project request.",
+  });
+});
+
+test("body namespace is ignored; kubeconfig namespace is used", async () => {
+  let capturedNamespace = "";
+  adopt.impl = (input) => {
+    capturedNamespace = input.namespace;
+    return Promise.resolve({
+      adoption: {
+        discoveredCount: 1,
+        instanceName: input.instanceName,
+        instanceUid: "uid-1",
+        labeledCount: 1,
+        status: "adopted",
+        warnings: [],
+      },
+      project: {
+        createdAt: "2026-01-01T00:00:00.000Z",
+        description: "",
+        displayName: "memos",
+        id: "project-1",
+        namespace: input.namespace,
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+  };
+
+  const response = await POST(
+    request({
+      body: {
+        instanceName: "memos",
+        namespace: "ns-from-body",
+      },
+      kubeconfig: "ok",
+    }) as never
+  );
+  assert.equal(response.status, 200);
+  assert.equal(capturedNamespace, "ns-from-kubeconfig");
+  const payload = (await response.json()) as {
+    adoption: { status: string };
+    project: { id: string; namespace: string };
+  };
+  assert.equal(payload.adoption.status, "adopted");
+  assert.equal(payload.project.namespace, "ns-from-kubeconfig");
+});
+
+test("adoption errors keep their status and { error } shape", async () => {
+  adopt.impl = () =>
+    Promise.reject(
+      new TemplateInstanceAdoptionError(404, "Template instance not found.")
+    );
+  const response = await POST(request({ kubeconfig: "ok" }) as never);
+  assert.equal(response.status, 404);
+  assert.deepEqual(await response.json(), {
+    error: "Template instance not found.",
+  });
+});
+
+test("unexpected persistence failures are 503", async () => {
+  adopt.impl = () => Promise.reject(new Error("ECONNREFUSED"));
+  const response = await POST(request({ kubeconfig: "ok" }) as never);
+  assert.equal(response.status, 503);
+  assert.deepEqual(await response.json(), {
+    error: "Project persistence is unavailable.",
+  });
+});

--- a/apps/ui/src/app/api/projects/adopt-template-instance/route.ts
+++ b/apps/ui/src/app/api/projects/adopt-template-instance/route.ts
@@ -1,0 +1,115 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { ZodError, z } from "zod";
+
+import {
+  adoptTemplateInstance,
+  TemplateInstanceAdoptionError,
+} from "@/lib/project-persistence/adopt-template-instance";
+import { ProjectPersistenceError } from "@/lib/project-persistence/projects";
+import {
+  authorizeKubeconfigNamespace,
+  encodedKubeconfigFromRequest,
+} from "@/lib/request-kubeconfig-auth";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const boundedName = z.string().trim().min(1).max(253);
+const boundedDisplayName = z.string().trim().min(1).max(256);
+const optionalDescription = z.string().trim().max(256).optional();
+const optionalTemplateName = z.string().trim().max(256).optional();
+
+const adoptTemplateInstanceRequestSchema = z.object({
+  description: optionalDescription,
+  displayName: boundedDisplayName.optional(),
+  instanceName: boundedName,
+  templateName: optionalTemplateName,
+});
+
+function jsonError(message: string, status: number) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+function authorizationError(
+  authorization: Exclude<
+    Awaited<ReturnType<typeof authorizeKubeconfigNamespace>>,
+    { ok: true }
+  >
+): Response {
+  if (authorization.code === "verification_failed") {
+    if (authorization.status === 403) {
+      return jsonError("Namespace is not accessible.", 403);
+    }
+    if (authorization.status === 401) {
+      return jsonError("Authentication is required.", 401);
+    }
+    return jsonError(authorization.message, authorization.status);
+  }
+  if (authorization.code === "authentication_required") {
+    return jsonError("Authentication is required.", 401);
+  }
+  if (authorization.code === "invalid_kubeconfig") {
+    return jsonError("Invalid kubeconfig.", 400);
+  }
+  if (authorization.code === "namespace_unresolved") {
+    return jsonError("Could not resolve namespace from kubeconfig.", 400);
+  }
+  return jsonError("Namespace is not accessible.", 403);
+}
+
+function persistenceError(error: ProjectPersistenceError): Response {
+  if (error.code === "conflict") {
+    return jsonError(error.message, 409);
+  }
+  if (error.code === "not_found") {
+    return jsonError(error.message, 404);
+  }
+  return jsonError(error.message, 400);
+}
+
+function adoptionFailure(error: unknown): Response | null {
+  if (error instanceof ZodError) {
+    return jsonError("Invalid project request.", 400);
+  }
+  if (error instanceof TemplateInstanceAdoptionError) {
+    return jsonError(error.message, error.status);
+  }
+  if (error instanceof ProjectPersistenceError) {
+    return persistenceError(error);
+  }
+  return null;
+}
+
+export async function POST(request: NextRequest) {
+  let body: z.infer<typeof adoptTemplateInstanceRequestSchema>;
+  try {
+    body = adoptTemplateInstanceRequestSchema.parse(await request.json());
+  } catch (error) {
+    return adoptionFailure(error) ?? jsonError("Invalid project request.", 400);
+  }
+
+  const authorization = await authorizeKubeconfigNamespace({
+    encodedKubeconfig: encodedKubeconfigFromRequest(request),
+  });
+  if (!authorization.ok) {
+    return authorizationError(authorization);
+  }
+
+  try {
+    return NextResponse.json(
+      await adoptTemplateInstance({
+        description: body.description,
+        displayName: body.displayName,
+        encodedKubeconfig: authorization.encodedKubeconfig,
+        instanceName: body.instanceName,
+        namespace: authorization.namespace,
+        templateName: body.templateName === "" ? undefined : body.templateName,
+      })
+    );
+  } catch (error) {
+    return (
+      adoptionFailure(error) ??
+      jsonError("Project persistence is unavailable.", 503)
+    );
+  }
+}

--- a/apps/ui/src/lib/project-persistence/adopt-template-instance.test.ts
+++ b/apps/ui/src/lib/project-persistence/adopt-template-instance.test.ts
@@ -1,0 +1,901 @@
+import { mock } from "bun:test";
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { eq } from "drizzle-orm";
+
+import {
+  createDeployTaskTestHarness,
+  type DeployTaskTestHarness,
+} from "@/features/deploy/task/engine/testing/harness";
+import {
+  BRAIN_DEPLOYMENT_KIND_LABEL,
+  BRAIN_DEPLOYMENT_NAME_LABEL,
+  BRAIN_MANAGED_BY_LABEL,
+  BRAIN_MANAGED_BY_VALUE,
+  BRAIN_PROJECT_ID_LABEL,
+  BRAIN_TEMPLATE_NAME_LABEL,
+  LAUNCHPAD_APP_DEPLOY_MANAGER_LABEL,
+  LAUNCHPAD_TEMPLATE_SOURCE_LABEL,
+} from "@/lib/brain-labels";
+
+import type { TemplateInstanceAdoptionFetch } from "./adopt-template-instance";
+import type { ProjectPgDatabase } from "./db";
+import { inspectProjectManagedResources } from "./delete-guard";
+import { projects, templateInstanceAdoptions } from "./schema";
+
+mock.module("server-only", () => ({}));
+
+let harness: DeployTaskTestHarness;
+let projectDb: ProjectPgDatabase | undefined;
+
+mock.module(fileURLToPath(new URL("./db.ts", import.meta.url)), () => ({
+  getProjectDb: () => {
+    assert.ok(projectDb);
+    return projectDb;
+  },
+}));
+
+const {
+  ADOPTION_WARNING,
+  TEMPLATE_INSTANCE_ADOPTION_MAX_RESOURCES,
+  TemplateInstanceAdoptionError,
+  adoptTemplateInstance,
+} = await import("./adopt-template-instance");
+const { createProject } = await import("./projects");
+
+before(async () => {
+  harness = await createDeployTaskTestHarness();
+  projectDb = harness.db as unknown as ProjectPgDatabase;
+});
+
+after(async () => {
+  await harness.close();
+});
+
+interface ClusterObject {
+  apiVersion: string;
+  kind: string;
+  labels: Record<string, string>;
+  name: string;
+  namespace: string;
+  ownerReferences: Array<{ apiVersion: string; kind: string; uid: string }>;
+  resourceKind: string;
+  uid: string;
+}
+
+interface PatchRecord {
+  body: { metadata?: { labels?: Record<string, string> } };
+  kind: string;
+  name: string;
+  namespace: string;
+  type: string | null;
+}
+
+interface MockCluster {
+  failPatchOnce: Set<string>;
+  objects: ClusterObject[];
+  patches: PatchRecord[];
+  unknownKinds: Set<string>;
+}
+
+function unstructured(object: ClusterObject) {
+  return {
+    apiVersion: object.apiVersion,
+    kind: object.kind,
+    metadata: {
+      labels: { ...object.labels },
+      name: object.name,
+      namespace: object.namespace,
+      ownerReferences: object.ownerReferences,
+      uid: object.uid,
+    },
+  };
+}
+
+function matchesLabelSelector(
+  labels: Record<string, string>,
+  selector: string
+): boolean {
+  if (selector.trim() === "") {
+    return true;
+  }
+  return selector.split(",").every((part) => {
+    const separator = part.indexOf("=");
+    if (separator < 0) {
+      return false;
+    }
+    const key = part.slice(0, separator).trim();
+    const value = part.slice(separator + 1).trim();
+    return labels[key] === value;
+  });
+}
+
+function jsonResponse(body: unknown, status: number): Promise<Response> {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      headers: { "Content-Type": "application/json" },
+      status,
+    })
+  );
+}
+
+function createClusterFetch(
+  cluster: MockCluster
+): TemplateInstanceAdoptionFetch {
+  return (url, init) => {
+    const parsed = new URL(String(url));
+    const method = (init?.method ?? "GET").toUpperCase();
+    const kind = parsed.searchParams.get("kind") ?? "";
+    const name = parsed.searchParams.get("name") ?? "";
+    const namespace = parsed.searchParams.get("namespace") ?? "";
+    const selector = parsed.searchParams.get("label-selector") ?? "";
+
+    if (
+      parsed.pathname.includes("/api/ap/") ||
+      parsed.pathname.includes("/api/db/")
+    ) {
+      return jsonResponse({ items: [] }, 200);
+    }
+
+    if (method === "PATCH" && parsed.pathname.includes("/patch")) {
+      let body: PatchRecord["body"] = {};
+      try {
+        body = JSON.parse(String(init?.body ?? "{}")) as PatchRecord["body"];
+      } catch {
+        body = {};
+      }
+      cluster.patches.push({
+        body,
+        kind,
+        name,
+        namespace,
+        type: parsed.searchParams.get("type"),
+      });
+      if (cluster.failPatchOnce.has(name)) {
+        cluster.failPatchOnce.delete(name);
+        return jsonResponse({ error: "patch failed" }, 500);
+      }
+      const target = cluster.objects.find(
+        (object) =>
+          object.resourceKind === kind &&
+          object.name === name &&
+          object.namespace === namespace
+      );
+      if (target == null) {
+        return jsonResponse({ error: "not found" }, 404);
+      }
+      target.labels = { ...(body.metadata?.labels ?? {}) };
+      return jsonResponse(unstructured(target), 200);
+    }
+
+    if (cluster.unknownKinds.has(kind)) {
+      return jsonResponse({ error: `unknown resource "${kind}"` }, 500);
+    }
+
+    if (name !== "") {
+      const object = cluster.objects.find(
+        (entry) =>
+          entry.resourceKind === kind &&
+          entry.name === name &&
+          (entry.namespace === namespace || namespace === "")
+      );
+      if (object == null) {
+        return jsonResponse({ error: "not found" }, 404);
+      }
+      return jsonResponse(unstructured(object), 200);
+    }
+
+    const items = cluster.objects
+      .filter(
+        (object) =>
+          object.resourceKind === kind &&
+          (object.namespace === namespace || object.namespace === "") &&
+          matchesLabelSelector(object.labels, selector)
+      )
+      .map(unstructured);
+    return jsonResponse({ items }, 200);
+  };
+}
+
+function sealosInstance(input: {
+  labels?: Record<string, string>;
+  name: string;
+  namespace: string;
+  uid: string;
+}): ClusterObject {
+  return {
+    apiVersion: "app.sealos.io/v1",
+    kind: "Instance",
+    labels: {
+      [LAUNCHPAD_TEMPLATE_SOURCE_LABEL]: input.name,
+      ...input.labels,
+    },
+    name: input.name,
+    namespace: input.namespace,
+    ownerReferences: [],
+    resourceKind: "instances",
+    uid: input.uid,
+  };
+}
+
+function namespacedChild(input: {
+  apiVersion?: string;
+  kind: string;
+  labels?: Record<string, string>;
+  name: string;
+  namespace: string;
+  ownerUid?: string;
+  resourceKind: string;
+  uid: string;
+}): ClusterObject {
+  return {
+    apiVersion: input.apiVersion ?? "apps/v1",
+    kind: input.kind,
+    labels: {
+      [LAUNCHPAD_TEMPLATE_SOURCE_LABEL]: input.name.split("-")[0] ?? input.name,
+      ...input.labels,
+    },
+    name: input.name,
+    namespace: input.namespace,
+    ownerReferences:
+      input.ownerUid == null
+        ? []
+        : [
+            {
+              apiVersion: "app.sealos.io/v1",
+              kind: "Instance",
+              uid: input.ownerUid,
+            },
+          ],
+    resourceKind: input.resourceKind,
+    uid: input.uid,
+  };
+}
+
+async function projectRows(namespace: string) {
+  assert.ok(projectDb);
+  return await projectDb
+    .select()
+    .from(projects)
+    .where(eq(projects.namespace, namespace));
+}
+
+function asAdoptionError(error: unknown): { message: string; status: number } {
+  assert.equal(error instanceof TemplateInstanceAdoptionError, true);
+  return error as { message: string; status: number };
+}
+
+async function mappingRows(namespace: string) {
+  assert.ok(projectDb);
+  return await projectDb
+    .select()
+    .from(templateInstanceAdoptions)
+    .where(eq(templateInstanceAdoptions.namespace, namespace));
+}
+
+test("first adoption creates one Project and labels the Instance plus children", async () => {
+  const namespace = "ns-first";
+  const instanceName = "memos";
+  const instanceUid = "uid-memos-1";
+  const cluster: MockCluster = {
+    failPatchOnce: new Set(),
+    objects: [
+      sealosInstance({ name: instanceName, namespace, uid: instanceUid }),
+      namespacedChild({
+        kind: "Deployment",
+        labels: {
+          [LAUNCHPAD_APP_DEPLOY_MANAGER_LABEL]: "memos",
+          [LAUNCHPAD_TEMPLATE_SOURCE_LABEL]: instanceName,
+        },
+        name: "memos-deploy",
+        namespace,
+        ownerUid: instanceUid,
+        resourceKind: "deployments",
+        uid: "uid-deploy-1",
+      }),
+      namespacedChild({
+        apiVersion: "v1",
+        kind: "Service",
+        labels: {
+          [LAUNCHPAD_TEMPLATE_SOURCE_LABEL]: instanceName,
+        },
+        name: "memos-svc",
+        namespace,
+        ownerUid: instanceUid,
+        resourceKind: "services",
+        uid: "uid-svc-1",
+      }),
+      namespacedChild({
+        apiVersion: "autoscaling/v2",
+        kind: "HorizontalPodAutoscaler",
+        labels: {
+          [LAUNCHPAD_TEMPLATE_SOURCE_LABEL]: instanceName,
+        },
+        name: "memos-hpa",
+        namespace,
+        ownerUid: instanceUid,
+        resourceKind: "horizontalpodautoscalers",
+        uid: "uid-hpa-1",
+      }),
+    ],
+    patches: [],
+    unknownKinds: new Set(["certificates"]),
+  };
+
+  const result = await adoptTemplateInstance({
+    apiBaseUrl: "https://brain.test",
+    encodedKubeconfig: "kubeconfig",
+    fetchImpl: createClusterFetch(cluster),
+    instanceName,
+    namespace,
+    templateName: "memos",
+  });
+
+  assert.equal(result.adoption.status, "adopted");
+  assert.equal(result.adoption.instanceName, instanceName);
+  assert.equal(result.adoption.instanceUid, instanceUid);
+  assert.equal(result.adoption.discoveredCount, 4);
+  assert.equal(result.adoption.labeledCount, 4);
+  assert.deepEqual(result.adoption.warnings, [
+    ADOPTION_WARNING.podTemplateLabelsUnchanged,
+  ]);
+  assert.equal(result.project.namespace, namespace);
+  assert.equal(result.project.displayName, "memos");
+
+  const rows = await projectRows(namespace);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]?.id, result.project.id);
+
+  assert.equal(cluster.patches.length, 4);
+  for (const patch of cluster.patches) {
+    assert.equal(patch.type, "merge");
+    const labels = patch.body.metadata?.labels ?? {};
+    assert.equal(labels[BRAIN_MANAGED_BY_LABEL], BRAIN_MANAGED_BY_VALUE);
+    assert.equal(labels[BRAIN_PROJECT_ID_LABEL], result.project.id);
+    assert.equal(labels[BRAIN_DEPLOYMENT_KIND_LABEL], "template");
+    assert.equal(labels[BRAIN_DEPLOYMENT_NAME_LABEL], instanceName);
+    assert.equal(labels[BRAIN_TEMPLATE_NAME_LABEL], "memos");
+  }
+
+  const deployPatch = cluster.patches.find(
+    (patch) => patch.kind === "deployments"
+  );
+  assert.ok(deployPatch);
+  const deployLabels = deployPatch.body.metadata?.labels ?? {};
+  assert.equal(deployLabels[LAUNCHPAD_APP_DEPLOY_MANAGER_LABEL], "memos");
+  assert.equal(deployLabels[LAUNCHPAD_TEMPLATE_SOURCE_LABEL], instanceName);
+
+  const summary = await inspectProjectManagedResources({
+    apiBaseUrl: "https://brain.test",
+    encodedKubeconfig: "kubeconfig",
+    fetchImpl: createClusterFetch({
+      ...cluster,
+      unknownKinds: new Set(),
+    }),
+    id: result.project.id,
+    namespace,
+  });
+  assert.deepEqual(summary.template, [instanceName]);
+  assert.deepEqual(summary.templateDeployments, ["memos-deploy"]);
+});
+
+test("repeat adoption of the same UID reuses the Project and does not duplicate it", async () => {
+  const namespace = "ns-repeat";
+  const instanceName = "wordpress";
+  const instanceUid = "uid-wp-1";
+  const cluster: MockCluster = {
+    failPatchOnce: new Set(),
+    objects: [
+      sealosInstance({ name: instanceName, namespace, uid: instanceUid }),
+      namespacedChild({
+        kind: "Deployment",
+        labels: {
+          [LAUNCHPAD_TEMPLATE_SOURCE_LABEL]: instanceName,
+        },
+        name: "wordpress-deploy",
+        namespace,
+        ownerUid: instanceUid,
+        resourceKind: "deployments",
+        uid: "uid-wp-deploy",
+      }),
+    ],
+    patches: [],
+    unknownKinds: new Set(),
+  };
+  const fetchImpl = createClusterFetch(cluster);
+
+  const first = await adoptTemplateInstance({
+    apiBaseUrl: "https://brain.test",
+    encodedKubeconfig: "kubeconfig",
+    fetchImpl,
+    instanceName,
+    namespace,
+    templateName: "wordpress",
+  });
+  const second = await adoptTemplateInstance({
+    apiBaseUrl: "https://brain.test",
+    encodedKubeconfig: "kubeconfig",
+    fetchImpl,
+    instanceName,
+    namespace,
+    templateName: "wordpress",
+  });
+
+  assert.equal(second.project.id, first.project.id);
+  assert.equal((await projectRows(namespace)).length, 1);
+  assert.equal((await mappingRows(namespace)).length, 1);
+  assert.equal(second.adoption.status, "adopted");
+});
+
+test("concurrent adoptions of the same UID converge on one Project", async () => {
+  const namespace = "ns-concurrent";
+  const instanceName = "ghost";
+  const instanceUid = "uid-ghost-1";
+  const cluster: MockCluster = {
+    failPatchOnce: new Set(),
+    objects: [
+      sealosInstance({ name: instanceName, namespace, uid: instanceUid }),
+    ],
+    patches: [],
+    unknownKinds: new Set(),
+  };
+  const fetchImpl = createClusterFetch(cluster);
+  const input = {
+    apiBaseUrl: "https://brain.test",
+    encodedKubeconfig: "kubeconfig",
+    fetchImpl,
+    instanceName,
+    namespace,
+    templateName: "ghost",
+  };
+
+  const [left, right] = await Promise.all([
+    adoptTemplateInstance(input),
+    adoptTemplateInstance(input),
+  ]);
+
+  assert.equal(left.project.id, right.project.id);
+  assert.equal((await projectRows(namespace)).length, 1);
+  assert.equal((await mappingRows(namespace)).length, 1);
+});
+
+test("the same instance name with a new UID creates a new Project", async () => {
+  const namespace = "ns-new-uid";
+  const instanceName = "memos";
+  const firstCluster: MockCluster = {
+    failPatchOnce: new Set(),
+    objects: [
+      sealosInstance({ name: instanceName, namespace, uid: "uid-old" }),
+    ],
+    patches: [],
+    unknownKinds: new Set(),
+  };
+  const first = await adoptTemplateInstance({
+    apiBaseUrl: "https://brain.test",
+    encodedKubeconfig: "kubeconfig",
+    fetchImpl: createClusterFetch(firstCluster),
+    instanceName,
+    namespace,
+    templateName: "memos",
+  });
+
+  const secondCluster: MockCluster = {
+    failPatchOnce: new Set(),
+    objects: [
+      sealosInstance({ name: instanceName, namespace, uid: "uid-new" }),
+    ],
+    patches: [],
+    unknownKinds: new Set(),
+  };
+  const second = await adoptTemplateInstance({
+    apiBaseUrl: "https://brain.test",
+    encodedKubeconfig: "kubeconfig",
+    fetchImpl: createClusterFetch(secondCluster),
+    instanceName,
+    namespace,
+    templateName: "memos",
+  });
+
+  assert.notEqual(second.project.id, first.project.id);
+  assert.equal((await projectRows(namespace)).length, 2);
+  assert.equal((await mappingRows(namespace)).length, 2);
+  assert.equal(second.project.displayName, "memos-2");
+});
+
+test("missing Instance is 404 and does not create a Project", async () => {
+  const namespace = "ns-missing";
+  const cluster: MockCluster = {
+    failPatchOnce: new Set(),
+    objects: [],
+    patches: [],
+    unknownKinds: new Set(),
+  };
+
+  await assert.rejects(
+    () =>
+      adoptTemplateInstance({
+        apiBaseUrl: "https://brain.test",
+        encodedKubeconfig: "kubeconfig",
+        fetchImpl: createClusterFetch(cluster),
+        instanceName: "absent",
+        namespace,
+      }),
+    (error) => {
+      assert.equal(error instanceof TemplateInstanceAdoptionError, true);
+      assert.equal(asAdoptionError(error).status, 404);
+      assert.equal(
+        asAdoptionError(error).message,
+        "Template instance not found."
+      );
+      return true;
+    }
+  );
+  assert.equal((await projectRows(namespace)).length, 0);
+  assert.equal(cluster.patches.length, 0);
+});
+
+test("a non-Instance resource at kind=instances is 400", async () => {
+  const namespace = "ns-wrong-kind";
+  const cluster: MockCluster = {
+    failPatchOnce: new Set(),
+    objects: [
+      {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        labels: {},
+        name: "not-instance",
+        namespace,
+        ownerReferences: [],
+        resourceKind: "instances",
+        uid: "uid-wrong",
+      },
+    ],
+    patches: [],
+    unknownKinds: new Set(),
+  };
+
+  await assert.rejects(
+    () =>
+      adoptTemplateInstance({
+        apiBaseUrl: "https://brain.test",
+        encodedKubeconfig: "kubeconfig",
+        fetchImpl: createClusterFetch(cluster),
+        instanceName: "not-instance",
+        namespace,
+      }),
+    (error) => {
+      assert.equal(error instanceof TemplateInstanceAdoptionError, true);
+      assert.equal(asAdoptionError(error).status, 400);
+      assert.equal(
+        asAdoptionError(error).message,
+        "Resource is not a Sealos Template Instance."
+      );
+      return true;
+    }
+  );
+  assert.equal((await projectRows(namespace)).length, 0);
+});
+
+test("a foreign brain.io/project-id is 409 and leaves labels unchanged", async () => {
+  const namespace = "ns-conflict";
+  const instanceName = "n8n";
+  const cluster: MockCluster = {
+    failPatchOnce: new Set(),
+    objects: [
+      sealosInstance({ name: instanceName, namespace, uid: "uid-n8n" }),
+      namespacedChild({
+        kind: "Deployment",
+        labels: {
+          [BRAIN_PROJECT_ID_LABEL]: "other-project",
+          [LAUNCHPAD_TEMPLATE_SOURCE_LABEL]: instanceName,
+        },
+        name: "n8n-deploy",
+        namespace,
+        ownerUid: "uid-n8n",
+        resourceKind: "deployments",
+        uid: "uid-n8n-deploy",
+      }),
+    ],
+    patches: [],
+    unknownKinds: new Set(),
+  };
+  const original = { ...cluster.objects[1]?.labels };
+
+  await assert.rejects(
+    () =>
+      adoptTemplateInstance({
+        apiBaseUrl: "https://brain.test",
+        encodedKubeconfig: "kubeconfig",
+        fetchImpl: createClusterFetch(cluster),
+        instanceName,
+        namespace,
+      }),
+    (error) => {
+      assert.equal(error instanceof TemplateInstanceAdoptionError, true);
+      assert.equal(asAdoptionError(error).status, 409);
+      return true;
+    }
+  );
+  assert.equal((await projectRows(namespace)).length, 0);
+  assert.equal(cluster.patches.length, 0);
+  assert.deepEqual(cluster.objects[1]?.labels, original);
+});
+
+test("partial PATCH failure marks mapping failed and retry reuses the Project", async () => {
+  const namespace = "ns-partial";
+  const instanceName = "umami";
+  const instanceUid = "uid-umami";
+  const cluster: MockCluster = {
+    failPatchOnce: new Set(["umami-deploy"]),
+    objects: [
+      sealosInstance({ name: instanceName, namespace, uid: instanceUid }),
+      namespacedChild({
+        kind: "Deployment",
+        labels: {
+          [LAUNCHPAD_TEMPLATE_SOURCE_LABEL]: instanceName,
+        },
+        name: "umami-deploy",
+        namespace,
+        ownerUid: instanceUid,
+        resourceKind: "deployments",
+        uid: "uid-umami-deploy",
+      }),
+    ],
+    patches: [],
+    unknownKinds: new Set(),
+  };
+  const fetchImpl = createClusterFetch(cluster);
+
+  await assert.rejects(
+    () =>
+      adoptTemplateInstance({
+        apiBaseUrl: "https://brain.test",
+        encodedKubeconfig: "kubeconfig",
+        fetchImpl,
+        instanceName,
+        namespace,
+        templateName: "umami",
+      }),
+    (error) => {
+      assert.equal(error instanceof TemplateInstanceAdoptionError, true);
+      assert.equal(asAdoptionError(error).status, 502);
+      assert.equal(
+        asAdoptionError(error).message,
+        "Failed to label template instance resources."
+      );
+      return true;
+    }
+  );
+
+  const failedMappings = await mappingRows(namespace);
+  assert.equal(failedMappings.length, 1);
+  assert.equal(failedMappings[0]?.status, "failed");
+  const projectId = failedMappings[0]?.projectId;
+  assert.ok(projectId);
+  assert.equal((await projectRows(namespace)).length, 1);
+
+  const retry = await adoptTemplateInstance({
+    apiBaseUrl: "https://brain.test",
+    encodedKubeconfig: "kubeconfig",
+    fetchImpl,
+    instanceName,
+    namespace,
+    templateName: "umami",
+  });
+  assert.equal(retry.project.id, projectId);
+  assert.equal(retry.adoption.status, "adopted");
+  assert.equal((await projectRows(namespace)).length, 1);
+  const adopted = await mappingRows(namespace);
+  assert.equal(adopted[0]?.status, "adopted");
+});
+
+test("more than 500 discovered resources is rejected before any mutation", async () => {
+  const namespace = "ns-limit";
+  const instanceName = "huge";
+  const instanceUid = "uid-huge";
+  const children = Array.from(
+    { length: TEMPLATE_INSTANCE_ADOPTION_MAX_RESOURCES },
+    (_, index) =>
+      namespacedChild({
+        kind: "ConfigMap",
+        apiVersion: "v1",
+        labels: {
+          [LAUNCHPAD_TEMPLATE_SOURCE_LABEL]: instanceName,
+        },
+        name: `huge-cm-${index}`,
+        namespace,
+        ownerUid: instanceUid,
+        resourceKind: "configmaps",
+        uid: `uid-cm-${index}`,
+      })
+  );
+  const cluster: MockCluster = {
+    failPatchOnce: new Set(),
+    objects: [
+      sealosInstance({ name: instanceName, namespace, uid: instanceUid }),
+      ...children,
+    ],
+    patches: [],
+    unknownKinds: new Set(),
+  };
+
+  await assert.rejects(
+    () =>
+      adoptTemplateInstance({
+        apiBaseUrl: "https://brain.test",
+        encodedKubeconfig: "kubeconfig",
+        fetchImpl: createClusterFetch(cluster),
+        instanceName,
+        namespace,
+      }),
+    (error) => {
+      assert.equal(error instanceof TemplateInstanceAdoptionError, true);
+      assert.equal(asAdoptionError(error).status, 400);
+      assert.equal(
+        asAdoptionError(error).message,
+        "Template instance has too many resources to adopt."
+      );
+      return true;
+    }
+  );
+  assert.equal((await projectRows(namespace)).length, 0);
+  assert.equal((await mappingRows(namespace)).length, 0);
+  assert.equal(cluster.patches.length, 0);
+});
+
+test("resources already labeled for this Project are adopted idempotently", async () => {
+  const namespace = "ns-already";
+  const instanceName = "already";
+  const instanceUid = "uid-already";
+  const cluster: MockCluster = {
+    failPatchOnce: new Set(),
+    objects: [
+      sealosInstance({ name: instanceName, namespace, uid: instanceUid }),
+    ],
+    patches: [],
+    unknownKinds: new Set(),
+  };
+  const fetchImpl = createClusterFetch(cluster);
+  const first = await adoptTemplateInstance({
+    apiBaseUrl: "https://brain.test",
+    encodedKubeconfig: "kubeconfig",
+    fetchImpl,
+    instanceName,
+    namespace,
+  });
+  cluster.patches.length = 0;
+  const second = await adoptTemplateInstance({
+    apiBaseUrl: "https://brain.test",
+    encodedKubeconfig: "kubeconfig",
+    fetchImpl,
+    instanceName,
+    namespace,
+  });
+  assert.equal(second.project.id, first.project.id);
+  assert.equal(second.adoption.status, "adopted");
+  const labels = cluster.patches[0]?.body.metadata?.labels ?? {};
+  assert.equal(labels[BRAIN_PROJECT_ID_LABEL], first.project.id);
+});
+
+test("explicit displayName collisions are 409 and derived names follow ADR 0058", async () => {
+  const namespace = "ns-names";
+  await createProject({
+    displayName: "Taken",
+    namespace,
+  });
+
+  const collideCluster: MockCluster = {
+    failPatchOnce: new Set(),
+    objects: [
+      sealosInstance({ name: "taken-inst", namespace, uid: "uid-taken" }),
+    ],
+    patches: [],
+    unknownKinds: new Set(),
+  };
+  await assert.rejects(
+    () =>
+      adoptTemplateInstance({
+        apiBaseUrl: "https://brain.test",
+        displayName: "Taken",
+        encodedKubeconfig: "kubeconfig",
+        fetchImpl: createClusterFetch(collideCluster),
+        instanceName: "taken-inst",
+        namespace,
+      }),
+    (error) => {
+      assert.equal(
+        error instanceof Error && error.name === "ProjectPersistenceError",
+        true
+      );
+      return true;
+    }
+  );
+  assert.equal(collideCluster.patches.length, 0);
+
+  const derivedCluster: MockCluster = {
+    failPatchOnce: new Set(),
+    objects: [sealosInstance({ name: "blog-xyz", namespace, uid: "uid-blog" })],
+    patches: [],
+    unknownKinds: new Set(),
+  };
+  const derived = await adoptTemplateInstance({
+    apiBaseUrl: "https://brain.test",
+    encodedKubeconfig: "kubeconfig",
+    fetchImpl: createClusterFetch(derivedCluster),
+    instanceName: "blog-xyz",
+    namespace,
+    templateName: "blog",
+  });
+  assert.equal(derived.project.displayName, "blog");
+});
+
+test("only the Instance still succeeds with incompleteResourceSet", async () => {
+  const namespace = "ns-incomplete";
+  const cluster: MockCluster = {
+    failPatchOnce: new Set(),
+    objects: [
+      sealosInstance({ name: "solo", namespace, uid: "uid-solo" }),
+      {
+        apiVersion: "cert-manager.io/v1",
+        kind: "ClusterIssuer",
+        labels: {
+          [LAUNCHPAD_TEMPLATE_SOURCE_LABEL]: "solo",
+        },
+        name: "solo-issuer",
+        namespace: "",
+        ownerReferences: [],
+        resourceKind: "issuers",
+        uid: "uid-issuer",
+      },
+    ],
+    patches: [],
+    unknownKinds: new Set(),
+  };
+  const result = await adoptTemplateInstance({
+    apiBaseUrl: "https://brain.test",
+    encodedKubeconfig: "kubeconfig",
+    fetchImpl: createClusterFetch(cluster),
+    instanceName: "solo",
+    namespace,
+  });
+  assert.equal(result.adoption.discoveredCount, 1);
+  assert.equal(result.adoption.labeledCount, 1);
+  assert.ok(
+    result.adoption.warnings.includes(ADOPTION_WARNING.incompleteResourceSet)
+  );
+  assert.ok(
+    result.adoption.warnings.includes(ADOPTION_WARNING.clusterScopedSkipped)
+  );
+});
+
+test("missing API_URL fails closed without mutating", async () => {
+  const previous = process.env.API_URL;
+  delete process.env.API_URL;
+  try {
+    await assert.rejects(
+      () =>
+        adoptTemplateInstance({
+          encodedKubeconfig: "kubeconfig",
+          fetchImpl: () => jsonResponse({ items: [] }, 200),
+          instanceName: "x",
+          namespace: "ns-no-api",
+        }),
+      (error) => {
+        assert.equal(error instanceof TemplateInstanceAdoptionError, true);
+        assert.equal(asAdoptionError(error).status, 502);
+        assert.equal(
+          asAdoptionError(error).message,
+          "API_URL is required to adopt template instance resources."
+        );
+        return true;
+      }
+    );
+  } finally {
+    if (previous === undefined) {
+      delete process.env.API_URL;
+    } else {
+      process.env.API_URL = previous;
+    }
+  }
+});

--- a/apps/ui/src/lib/project-persistence/adopt-template-instance.ts
+++ b/apps/ui/src/lib/project-persistence/adopt-template-instance.ts
@@ -1,0 +1,815 @@
+import "server-only";
+
+import { API_ROUTES } from "@workspace/api/constants";
+import { and, eq } from "drizzle-orm";
+
+import { derivedProjectDisplayNameBase } from "@/features/projects/derived-project-display-name";
+import {
+  BRAIN_PROJECT_ID_LABEL,
+  BRAIN_TEMPLATE_NAME_LABEL,
+  LAUNCHPAD_TEMPLATE_SOURCE_LABEL,
+  templateDeploymentExtraLabels,
+} from "@/lib/brain-labels";
+import { kubeconfigBearerHeader } from "@/lib/kubeconfig-header";
+
+import { getProjectDb } from "./db";
+import {
+  type BrainProject,
+  createProject,
+  createProjectWithDerivedDisplayName,
+  deleteProject,
+  getProject,
+} from "./projects";
+import {
+  type TemplateInstanceAdoptionRow,
+  templateInstanceAdoptions,
+} from "./schema";
+
+export type TemplateInstanceAdoptionFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit
+) => Promise<Response>;
+
+export type TemplateInstanceAdoptionStatus = "adopting" | "adopted" | "failed";
+
+export const TEMPLATE_INSTANCE_ADOPTION_MAX_RESOURCES = 500;
+const LABEL_CONCURRENCY = 8;
+const SEALOS_INSTANCE_API_VERSION = "app.sealos.io/v1";
+const SEALOS_INSTANCE_KIND = "Instance";
+const TRAILING_PERIOD_RE = /\.$/;
+const UNKNOWN_RESOURCE_RE = /unknown resource/i;
+const NOT_FOUND_RE = /not found/i;
+
+const ADOPTION_RESOURCE_KINDS = [
+  "instances",
+  "deployments",
+  "statefulsets",
+  "services",
+  "ingresses",
+  "certificates",
+  "issuers",
+  "horizontalpodautoscalers",
+  "clusters",
+  "opsrequests",
+  "configmaps",
+  "secrets",
+  "persistentvolumeclaims",
+  "jobs",
+  "pods",
+] as const;
+
+const POD_TEMPLATE_RESOURCE_KINDS = new Set([
+  "cronjobs",
+  "daemonsets",
+  "deployments",
+  "jobs",
+  "statefulsets",
+]);
+
+export const ADOPTION_WARNING = {
+  clusterScopedSkipped: "clusterScopedSkipped",
+  incompleteResourceSet: "incompleteResourceSet",
+  podTemplateLabelsUnchanged: "podTemplateLabelsUnchanged",
+} as const;
+
+export class TemplateInstanceAdoptionError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "TemplateInstanceAdoptionError";
+    this.status = status;
+  }
+}
+
+export interface AdoptTemplateInstanceInput {
+  apiBaseUrl?: string;
+  description?: string;
+  displayName?: string;
+  encodedKubeconfig: string;
+  fetchImpl?: TemplateInstanceAdoptionFetch;
+  instanceName: string;
+  namespace: string;
+  templateName?: string;
+}
+
+export interface TemplateInstanceAdoptionResult {
+  adoption: {
+    discoveredCount: number;
+    instanceName: string;
+    instanceUid: string;
+    labeledCount: number;
+    status: "adopted" | "failed";
+    warnings: string[];
+  };
+  project: BrainProject;
+}
+
+interface DiscoveredObject {
+  apiVersion: string;
+  kind: string;
+  labels: Record<string, string>;
+  name: string;
+  namespace: string;
+  ownerReferences: OwnerReference[];
+  resourceKind: string;
+  uid: string;
+}
+
+interface OwnerReference {
+  apiVersion: string;
+  kind: string;
+  uid: string;
+}
+
+interface AdoptionK8sContext {
+  apiBaseUrl: string;
+  encodedKubeconfig: string;
+  fetchImpl: TemplateInstanceAdoptionFetch;
+  namespace: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function stringField(
+  record: Record<string, unknown> | null,
+  key: string
+): string {
+  if (record == null) {
+    return "";
+  }
+  const value = record[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function stringLabelMap(value: unknown): Record<string, string> {
+  const record = asRecord(value);
+  if (record == null) {
+    return {};
+  }
+  const labels: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(record)) {
+    if (typeof entry === "string") {
+      labels[key] = entry;
+    }
+  }
+  return labels;
+}
+
+function ownerReferencesFrom(value: unknown): OwnerReference[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const refs: OwnerReference[] = [];
+  for (const entry of value) {
+    const record = asRecord(entry);
+    const apiVersion = stringField(record, "apiVersion");
+    const kind = stringField(record, "kind");
+    const uid = stringField(record, "uid");
+    if (apiVersion === "" || kind === "" || uid === "") {
+      continue;
+    }
+    refs.push({ apiVersion, kind, uid });
+  }
+  return refs;
+}
+
+function parseUnstructured(
+  payload: unknown,
+  resourceKind: string
+): DiscoveredObject | null {
+  const record = asRecord(payload);
+  if (record == null) {
+    return null;
+  }
+  const metadata = asRecord(record.metadata);
+  const name = stringField(metadata, "name");
+  if (name === "") {
+    return null;
+  }
+  return {
+    apiVersion: stringField(record, "apiVersion"),
+    kind: stringField(record, "kind"),
+    labels: stringLabelMap(metadata?.labels),
+    name,
+    namespace: stringField(metadata, "namespace"),
+    ownerReferences: ownerReferencesFrom(metadata?.ownerReferences),
+    resourceKind,
+    uid: stringField(metadata, "uid"),
+  };
+}
+
+function listItems(payload: unknown): unknown[] {
+  const record = asRecord(payload);
+  if (record == null) {
+    return [];
+  }
+  return Array.isArray(record.items) ? record.items : [];
+}
+
+function responseErrorText(body: unknown): string {
+  const record = asRecord(body);
+  if (record == null) {
+    return "";
+  }
+  for (const key of ["error", "detail", "message"] as const) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim() !== "") {
+      return value.trim();
+    }
+  }
+  if (Array.isArray(record.errors)) {
+    for (const entry of record.errors) {
+      const nested = asRecord(entry);
+      const message = stringField(nested, "message");
+      if (message !== "") {
+        return message;
+      }
+    }
+  }
+  return "";
+}
+
+function isUnknownResourceFailure(status: number, body: unknown): boolean {
+  if (status === 404) {
+    return true;
+  }
+  return UNKNOWN_RESOURCE_RE.test(responseErrorText(body));
+}
+
+function isNotFoundFailure(status: number, body: unknown): boolean {
+  if (status === 404) {
+    return true;
+  }
+  const text = responseErrorText(body);
+  return NOT_FOUND_RE.test(text) && !UNKNOWN_RESOURCE_RE.test(text);
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  return await response.json().catch(() => null);
+}
+
+function apiUrl(baseUrl: string, path: string, params: URLSearchParams): URL {
+  const base = baseUrl.trim();
+  if (base === "") {
+    throw new TemplateInstanceAdoptionError(
+      502,
+      "API_URL is required to adopt template instance resources."
+    );
+  }
+  const url = new URL(path, base);
+  url.search = params.toString();
+  return url;
+}
+
+function k8sHeaders(encodedKubeconfig: string): HeadersInit {
+  return {
+    Authorization: kubeconfigBearerHeader(encodedKubeconfig),
+    "Content-Type": "application/json",
+  };
+}
+
+async function k8sGet(
+  context: AdoptionK8sContext,
+  params: Record<string, string>
+): Promise<{ body: unknown; status: number }> {
+  const response = await context.fetchImpl(
+    apiUrl(context.apiBaseUrl, API_ROUTES.k8s.get, new URLSearchParams(params)),
+    {
+      cache: "no-store",
+      headers: k8sHeaders(context.encodedKubeconfig),
+    }
+  );
+  return { body: await readJson(response), status: response.status };
+}
+
+async function k8sPatchLabels(
+  context: AdoptionK8sContext,
+  input: {
+    kind: string;
+    labels: Record<string, string>;
+    name: string;
+    namespace: string;
+  }
+): Promise<{ body: unknown; status: number }> {
+  const params = new URLSearchParams({
+    kind: input.kind,
+    name: input.name,
+    namespace: input.namespace,
+    type: "merge",
+  });
+  const response = await context.fetchImpl(
+    apiUrl(context.apiBaseUrl, API_ROUTES.k8s.patch, params),
+    {
+      body: JSON.stringify({ metadata: { labels: input.labels } }),
+      cache: "no-store",
+      headers: k8sHeaders(context.encodedKubeconfig),
+      method: "PATCH",
+    }
+  );
+  return { body: await readJson(response), status: response.status };
+}
+
+function k8sFailureMessage(
+  operation: string,
+  status: number,
+  body: unknown
+): string {
+  const detail = responseErrorText(body);
+  const fallback = `Failed to ${operation} template instance resources (${status}).`;
+  if (detail === "") {
+    return fallback;
+  }
+  return `${fallback.replace(TRAILING_PERIOD_RE, "")}: ${detail}`;
+}
+
+function belongsToInstance(
+  object: DiscoveredObject,
+  input: { instanceName: string; instanceUid: string }
+): boolean {
+  const instanceRefs = object.ownerReferences.filter(
+    (ref) =>
+      ref.apiVersion === SEALOS_INSTANCE_API_VERSION &&
+      ref.kind === SEALOS_INSTANCE_KIND
+  );
+  if (instanceRefs.some((ref) => ref.uid === input.instanceUid)) {
+    return true;
+  }
+  if (instanceRefs.some((ref) => ref.uid !== input.instanceUid)) {
+    return false;
+  }
+  return object.labels[LAUNCHPAD_TEMPLATE_SOURCE_LABEL] === input.instanceName;
+}
+
+function objectKey(object: DiscoveredObject): string {
+  if (object.uid !== "") {
+    return object.uid;
+  }
+  return `${object.resourceKind}/${object.namespace}/${object.name}`;
+}
+
+function brainAdoptionLabels(input: {
+  instanceName: string;
+  projectId: string;
+  templateName: string;
+}): Record<string, string> {
+  const labels = {
+    ...templateDeploymentExtraLabels({
+      instanceName: input.instanceName,
+      projectId: input.projectId,
+      templateName: input.templateName,
+    }),
+  };
+  if (input.templateName === "") {
+    delete labels[BRAIN_TEMPLATE_NAME_LABEL];
+  }
+  return labels;
+}
+
+function derivedDisplayNameBase(input: {
+  instanceName: string;
+  templateName: string;
+}): string {
+  return (
+    derivedProjectDisplayNameBase({
+      kind: "template",
+      templateName: input.templateName,
+    }) ??
+    derivedProjectDisplayNameBase({
+      kind: "template",
+      templateName: input.instanceName,
+    }) ??
+    input.instanceName
+  );
+}
+
+function whereAdoption(namespace: string, instanceUid: string) {
+  return and(
+    eq(templateInstanceAdoptions.namespace, namespace),
+    eq(templateInstanceAdoptions.instanceUid, instanceUid)
+  );
+}
+
+async function loadMapping(
+  namespace: string,
+  instanceUid: string
+): Promise<TemplateInstanceAdoptionRow | null> {
+  const [row] = await getProjectDb()
+    .select()
+    .from(templateInstanceAdoptions)
+    .where(whereAdoption(namespace, instanceUid))
+    .limit(1);
+  return row ?? null;
+}
+
+async function getInstance(
+  context: AdoptionK8sContext,
+  instanceName: string
+): Promise<DiscoveredObject> {
+  const { body, status } = await k8sGet(context, {
+    kind: "instances",
+    name: instanceName,
+    namespace: context.namespace,
+  });
+  if (
+    isNotFoundFailure(status, body) ||
+    isUnknownResourceFailure(status, body)
+  ) {
+    throw new TemplateInstanceAdoptionError(
+      404,
+      "Template instance not found."
+    );
+  }
+  if (status < 200 || status >= 300) {
+    throw new TemplateInstanceAdoptionError(
+      502,
+      k8sFailureMessage("inspect", status, body)
+    );
+  }
+  const instance = parseUnstructured(body, "instances");
+  if (
+    instance == null ||
+    instance.apiVersion !== SEALOS_INSTANCE_API_VERSION ||
+    instance.kind !== SEALOS_INSTANCE_KIND
+  ) {
+    throw new TemplateInstanceAdoptionError(
+      400,
+      "Resource is not a Sealos Template Instance."
+    );
+  }
+  if (instance.uid === "") {
+    throw new TemplateInstanceAdoptionError(
+      400,
+      "Template instance is missing a uid."
+    );
+  }
+  return instance;
+}
+
+async function listKind(
+  context: AdoptionK8sContext,
+  kind: string,
+  instanceName: string
+): Promise<DiscoveredObject[]> {
+  const { body, status } = await k8sGet(context, {
+    kind,
+    "label-selector": `${LAUNCHPAD_TEMPLATE_SOURCE_LABEL}=${instanceName}`,
+    namespace: context.namespace,
+  });
+  if (isUnknownResourceFailure(status, body)) {
+    return [];
+  }
+  if (status < 200 || status >= 300) {
+    throw new TemplateInstanceAdoptionError(
+      502,
+      k8sFailureMessage("inspect", status, body)
+    );
+  }
+  const objects: DiscoveredObject[] = [];
+  for (const item of listItems(body)) {
+    const parsed = parseUnstructured(item, kind);
+    if (parsed != null) {
+      objects.push(parsed);
+    }
+  }
+  return objects;
+}
+
+async function discoverResources(
+  context: AdoptionK8sContext,
+  instance: DiscoveredObject
+): Promise<{
+  clusterScopedSkipped: boolean;
+  objects: DiscoveredObject[];
+}> {
+  const byKey = new Map<string, DiscoveredObject>();
+  byKey.set(objectKey(instance), instance);
+
+  let clusterScopedSkipped = false;
+  for (const kind of ADOPTION_RESOURCE_KINDS) {
+    const listed = await listKind(context, kind, instance.name);
+    for (const object of listed) {
+      if (
+        !belongsToInstance(object, {
+          instanceName: instance.name,
+          instanceUid: instance.uid,
+        })
+      ) {
+        continue;
+      }
+      if (object.namespace === "") {
+        clusterScopedSkipped = true;
+        continue;
+      }
+      if (object.namespace !== context.namespace) {
+        continue;
+      }
+      byKey.set(objectKey(object), object);
+    }
+  }
+
+  return {
+    clusterScopedSkipped,
+    objects: [...byKey.values()],
+  };
+}
+
+function foreignProjectId(
+  objects: DiscoveredObject[],
+  projectId: string | undefined
+): boolean {
+  for (const object of objects) {
+    const labeled = object.labels[BRAIN_PROJECT_ID_LABEL]?.trim() ?? "";
+    if (labeled === "") {
+      continue;
+    }
+    if (projectId == null || labeled !== projectId) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function ensureMapping(input: {
+  description?: string;
+  displayName?: string;
+  instanceName: string;
+  instanceUid: string;
+  namespace: string;
+  templateName: string;
+}): Promise<{ mapping: TemplateInstanceAdoptionRow; project: BrainProject }> {
+  const existing = await loadMapping(input.namespace, input.instanceUid);
+  if (existing != null) {
+    const project = await getProject(input.namespace, existing.projectId);
+    if (project == null) {
+      throw new TemplateInstanceAdoptionError(
+        502,
+        "Adopted project is missing."
+      );
+    }
+    const now = new Date();
+    const [updated] = await getProjectDb()
+      .update(templateInstanceAdoptions)
+      .set({
+        instanceName: input.instanceName,
+        status: "adopting",
+        templateName: input.templateName,
+        updatedAt: now,
+      })
+      .where(whereAdoption(input.namespace, input.instanceUid))
+      .returning();
+    return { mapping: updated ?? existing, project };
+  }
+
+  const project =
+    input.displayName == null
+      ? await createProjectWithDerivedDisplayName({
+          derivedDisplayName: derivedDisplayNameBase({
+            instanceName: input.instanceName,
+            templateName: input.templateName,
+          }),
+          description: input.description,
+          namespace: input.namespace,
+        })
+      : await createProject({
+          description: input.description,
+          displayName: input.displayName,
+          namespace: input.namespace,
+        });
+
+  const now = new Date();
+  const [inserted] = await getProjectDb()
+    .insert(templateInstanceAdoptions)
+    .values({
+      createdAt: now,
+      discoveredCount: 0,
+      instanceName: input.instanceName,
+      instanceUid: input.instanceUid,
+      labeledCount: 0,
+      lastError: null,
+      namespace: input.namespace,
+      projectId: project.id,
+      status: "adopting",
+      templateName: input.templateName,
+      updatedAt: now,
+    })
+    .onConflictDoNothing()
+    .returning();
+
+  if (inserted != null) {
+    return { mapping: inserted, project };
+  }
+
+  await deleteProject({ id: project.id, namespace: input.namespace });
+  const winner = await loadMapping(input.namespace, input.instanceUid);
+  if (winner == null) {
+    throw new TemplateInstanceAdoptionError(
+      502,
+      "Failed to persist template instance adoption."
+    );
+  }
+  const winnerProject = await getProject(input.namespace, winner.projectId);
+  if (winnerProject == null) {
+    throw new TemplateInstanceAdoptionError(502, "Adopted project is missing.");
+  }
+  return { mapping: winner, project: winnerProject };
+}
+
+async function updateMapping(
+  namespace: string,
+  instanceUid: string,
+  values: Partial<
+    Pick<
+      TemplateInstanceAdoptionRow,
+      | "discoveredCount"
+      | "labeledCount"
+      | "lastError"
+      | "status"
+      | "instanceName"
+      | "templateName"
+    >
+  >
+): Promise<void> {
+  await getProjectDb()
+    .update(templateInstanceAdoptions)
+    .set({
+      ...values,
+      updatedAt: new Date(),
+    })
+    .where(whereAdoption(namespace, instanceUid));
+}
+
+async function labelObjects(
+  context: AdoptionK8sContext,
+  objects: DiscoveredObject[],
+  labels: Record<string, string>
+): Promise<{ failures: string[]; labeledCount: number }> {
+  let cursor = 0;
+  let labeledCount = 0;
+  const failures: string[] = [];
+
+  const run = async () => {
+    while (true) {
+      const index = cursor;
+      cursor += 1;
+      const object = objects[index];
+      if (object === undefined) {
+        return;
+      }
+      const merged = {
+        ...object.labels,
+        ...labels,
+      };
+      try {
+        const { body, status } = await k8sPatchLabels(context, {
+          kind: object.resourceKind,
+          labels: merged,
+          name: object.name,
+          namespace: object.namespace,
+        });
+        if (status >= 200 && status < 300) {
+          object.labels = merged;
+          labeledCount += 1;
+          continue;
+        }
+        failures.push(k8sFailureMessage("label", status, body));
+      } catch (error) {
+        failures.push(
+          error instanceof Error
+            ? error.message
+            : "Failed to label template instance resources."
+        );
+      }
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(LABEL_CONCURRENCY, objects.length) }, () =>
+      run()
+    )
+  );
+  return { failures, labeledCount };
+}
+
+function collectWarnings(input: {
+  clusterScopedSkipped: boolean;
+  objects: DiscoveredObject[];
+}): string[] {
+  const warnings: string[] = [];
+  if (
+    input.objects.length === 1 &&
+    input.objects[0]?.resourceKind === "instances"
+  ) {
+    warnings.push(ADOPTION_WARNING.incompleteResourceSet);
+  }
+  if (input.clusterScopedSkipped) {
+    warnings.push(ADOPTION_WARNING.clusterScopedSkipped);
+  }
+  if (
+    input.objects.some((object) =>
+      POD_TEMPLATE_RESOURCE_KINDS.has(object.resourceKind)
+    )
+  ) {
+    warnings.push(ADOPTION_WARNING.podTemplateLabelsUnchanged);
+  }
+  return warnings;
+}
+
+export async function adoptTemplateInstance(
+  input: AdoptTemplateInstanceInput
+): Promise<TemplateInstanceAdoptionResult> {
+  const instanceName = input.instanceName.trim();
+  const templateName = input.templateName?.trim() ?? "";
+  const context: AdoptionK8sContext = {
+    apiBaseUrl: input.apiBaseUrl ?? process.env.API_URL ?? "",
+    encodedKubeconfig: input.encodedKubeconfig,
+    fetchImpl: input.fetchImpl ?? fetch,
+    namespace: input.namespace,
+  };
+  if (context.apiBaseUrl.trim() === "") {
+    throw new TemplateInstanceAdoptionError(
+      502,
+      "API_URL is required to adopt template instance resources."
+    );
+  }
+
+  const instance = await getInstance(context, instanceName);
+  const discovered = await discoverResources(context, instance);
+  if (discovered.objects.length > TEMPLATE_INSTANCE_ADOPTION_MAX_RESOURCES) {
+    throw new TemplateInstanceAdoptionError(
+      400,
+      "Template instance has too many resources to adopt."
+    );
+  }
+
+  const existing = await loadMapping(input.namespace, instance.uid);
+  if (foreignProjectId(discovered.objects, existing?.projectId)) {
+    throw new TemplateInstanceAdoptionError(
+      409,
+      "A discovered resource is already labeled for another project."
+    );
+  }
+
+  const { project } = await ensureMapping({
+    description: input.description,
+    displayName: input.displayName,
+    instanceName: instance.name,
+    instanceUid: instance.uid,
+    namespace: input.namespace,
+    templateName,
+  });
+
+  await updateMapping(input.namespace, instance.uid, {
+    discoveredCount: discovered.objects.length,
+    instanceName: instance.name,
+    status: "adopting",
+    templateName,
+  });
+
+  const { failures, labeledCount } = await labelObjects(
+    context,
+    discovered.objects,
+    brainAdoptionLabels({
+      instanceName: instance.name,
+      projectId: project.id,
+      templateName,
+    })
+  );
+
+  if (failures.length > 0) {
+    await updateMapping(input.namespace, instance.uid, {
+      discoveredCount: discovered.objects.length,
+      labeledCount,
+      lastError: failures[0],
+      status: "failed",
+    });
+    throw new TemplateInstanceAdoptionError(
+      502,
+      "Failed to label template instance resources."
+    );
+  }
+
+  await updateMapping(input.namespace, instance.uid, {
+    discoveredCount: discovered.objects.length,
+    labeledCount,
+    lastError: null,
+    status: "adopted",
+  });
+
+  return {
+    adoption: {
+      discoveredCount: discovered.objects.length,
+      instanceName: instance.name,
+      instanceUid: instance.uid,
+      labeledCount,
+      status: "adopted",
+      warnings: collectWarnings(discovered),
+    },
+    project,
+  };
+}

--- a/apps/ui/src/lib/project-persistence/db.ts
+++ b/apps/ui/src/lib/project-persistence/db.ts
@@ -11,6 +11,7 @@ import {
   projectManagementAuditEvents,
   projectNavigationPreferences,
   projects,
+  templateInstanceAdoptions,
 } from "./schema";
 
 const projectSchema = {
@@ -20,6 +21,7 @@ const projectSchema = {
   projectCanvasLayouts,
   projectNavigationPreferences,
   projects,
+  templateInstanceAdoptions,
 };
 
 export type ProjectPgDatabase = NodePgDatabase<typeof projectSchema>;

--- a/apps/ui/src/lib/project-persistence/schema.ts
+++ b/apps/ui/src/lib/project-persistence/schema.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm";
 import {
+  check,
   index,
   integer,
   jsonb,
@@ -197,11 +198,52 @@ export const projectManagementAuditEvents = ns.table(
   ]
 );
 
+/**
+ * Maps an already-applied Sealos Template Instance (by UID) onto a Brain
+ * Project. Internal bookkeeping only — not a user-visible Project status.
+ */
+export const templateInstanceAdoptions = ns.table(
+  "template_instance_adoptions",
+  {
+    namespace: text("namespace").notNull(),
+    instanceUid: text("instance_uid").notNull(),
+    instanceName: text("instance_name").notNull(),
+    projectId: text("project_id").notNull(),
+    templateName: text("template_name").notNull().default(""),
+    status: text("status").notNull(),
+    discoveredCount: integer("discovered_count").notNull().default(0),
+    labeledCount: integer("labeled_count").notNull().default(0),
+    lastError: text("last_error"),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.namespace, table.instanceUid],
+      name: "template_instance_adoptions_pk",
+    }),
+    check(
+      "template_instance_adoptions_status_valid",
+      sql`${table.status} IN ('adopting', 'adopted', 'failed')`
+    ),
+    index("template_instance_adoptions_namespace_project_id_idx").on(
+      table.namespace,
+      table.projectId
+    ),
+  ]
+);
+
 // `sealai_project.ap_image_versions` is intentionally NOT declared here: the Go
 // API owns that table end-to-end (DDL + retention pruning) in
 // `apps/api/service/apversion/store.go`; the UI only reads it over HTTP.
 
 export type ProjectRow = typeof projects.$inferSelect;
+export type TemplateInstanceAdoptionRow =
+  typeof templateInstanceAdoptions.$inferSelect;
 export type ProjectCanvasLayoutRow = typeof projectCanvasLayouts.$inferSelect;
 export type ProjectNavigationPreferencesRow =
   typeof projectNavigationPreferences.$inferSelect;

--- a/docs/adr/0075-adopt-external-template-instances-as-brain-projects.md
+++ b/docs/adr/0075-adopt-external-template-instances-as-brain-projects.md
@@ -1,0 +1,74 @@
+# Adopt External Template Instances as Brain Projects
+
+Sealos Skills (and any other apply path that is not Brain) can create a
+Template Instance in Kubernetes without a Brain Project. Brain then cannot
+list, group, or delete those resources, because Projects live in Postgres and
+managed-resource selectors key on `brain.io/*` labels.
+
+Brain's own GitHub Deployment Task path already stamps
+`templateDeploymentExtraLabels` as Template API `extraLabels` at create time.
+That path must not be routed through this adoption API.
+
+## Decision
+
+Add `POST /api/projects/adopt-template-instance`: a **claim-after-apply**
+operation. The caller names an existing Instance; Brain creates one Project
+and merge-patches Brain bookkeeping labels onto discovered namespaced
+resources. Skills are unchanged. The GitHub extraLabels-at-create path stays
+the create-time writer it already is.
+
+**Claim-after-apply, not extraLabels-at-create.** extraLabels-at-create is
+correct when Brain is the applier and already knows the Project ID. Skills
+apply first and only then talk to Brain, so there is no Project ID to stamp
+at create. Adoption is the inverse: discover what Sealos already created,
+then claim it. Mixing the two would either double-write labels on Brain
+deploys or leave Skills-created instances invisible.
+
+**Namespace from kubeconfig only.** The body does not carry `namespace`. The
+authorized namespace is the kubeconfig current-context namespace, then
+verified. A body namespace would let a caller claim resources in a namespace
+the kubeconfig does not actually grant.
+
+**UID, not name, is identity.** Mapping is unique on `(namespace,
+instance_uid)`. Instance names are reused when an Instance is deleted and
+recreated; that new object is a new adoption and a new Project. Retrying the
+same UID is idempotent: the same Project ID is reused and labeling is
+re-run so children that appeared later still get claimed.
+
+**Bookkeeping labels per ADR 0027.** Adoption writes the existing
+`templateDeploymentExtraLabels` set (`brain.io/managed-by`,
+`brain.io/project-id`, `brain.io/deployment-kind=template`,
+`brain.io/deployment-name`, and `brain.io/template-name` when known). These
+are ownership labels for cleanup and grouping. They must not be used to
+decide whether a workload is an AP or a DB —
+`brain.io/deployment-kind=template` is not a product classification.
+
+Label patches touch `metadata.labels` only. Workload `spec.template` is left
+alone; pod-template selectors stay Sealos-native. JSON merge-patch sends the
+full labels map so Sealos-native keys are not wiped.
+
+Project Display Names follow ADR 0058: an explicit name collides as 409; an
+absent name is derived from the usable template name or the instance name.
+
+## Considered Options
+
+- **Route Brain's GitHub template deploy through this API instead of
+  extraLabels.** Rejected. That path already knows the Project ID before
+  apply; claiming afterwards would race children that appear after the
+  Instance and would split one ownership writer into two.
+- **Key the mapping on instance name.** Rejected. Recreating an Instance
+  under the same name would steal or skip the previous Project.
+- **Accept namespace in the JSON body (as `POST /api/projects` does).**
+  Rejected. This handler mutates cluster state; the only namespace it may
+  touch is the one the kubeconfig authorizes.
+- **Classify adopted APs/DBs from `brain.io/deployment-kind=template`.**
+  Rejected by ADR 0027. Product identity stays on Sealos Launchpad and
+  KubeBlocks labels.
+
+## Consequences
+
+Explorer and `GET /api/projects` are unchanged: there is no user-visible
+Project adoption status. Mapping status (`adopting` / `adopted` / `failed`)
+is internal. A failed label pass keeps the Project ID so retry cannot create
+a second Project. Resources already labeled with a different
+`brain.io/project-id` are a conflict, not an overwrite.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,6 +46,7 @@ One line per decision; the linked record is authoritative. When adding an ADR, t
 - [0072 — Classify the platform's billing denial at the apply boundary, and send the App Token on every deployment source](0072-classify-the-platform-billing-denial-at-the-apply-boundary.md) *(extends ADR-0042's apply-boundary classifier; narrows ADR-0068's "no signal" premise and closes its no-actor chokepoint)*
 - [0073 — Wall zero-allowance plans with a truthful cause](0073-wall-zero-allowance-plans-with-a-truthful-cause.md) *(revises ADR-0069's exhaustion consequence; extends ADR-0068's Paid Chat Wall)*
 - [0074 — Store Cancellation Survey Responses in Brain Postgres as Feedback, Not Billing State](0074-store-cancellation-survey-responses-in-brain-postgres-as-feedback.md) *(supplements ADR-0067)*
+- [0075 — Adopt External Template Instances as Brain Projects](0075-adopt-external-template-instances-as-brain-projects.md)
 
 ## Conventions
 

--- a/skills-template-instance-adoption.md
+++ b/skills-template-instance-adoption.md
@@ -1,0 +1,125 @@
+# Sealos Skills：Template 部署后认领 Brain Project
+
+Brain 侧接口已在分支 `feat/adopt-template-instance`（issue [labring/sealos-private#116](https://github.com/labring/sealos-private/issues/116)）。本文只写 **labring/sealos-skills** 需要做的事。
+
+## 不要改什么
+
+- 不要改 Template YAML 生成、Template API apply、镜像构建、Runtime Truth。
+- 不要让 Agent 收集并提交资源列表或重新 apply YAML。
+- 不要在 apply 前先调 Brain 建空 Project。
+- **Brain 托管部署里不要调用认领接口。** 环境变量存在 `SEALAI_DEPLOY_TASK_ID` 或 `SEALAI_PROJECT_ID` 时，Brain 已经用 `SEALAI_DEPLOY_LABELS_JSON` → Template API `extraLabels` 打过 `brain.io/*`。再认领会 409。
+
+## 要改什么
+
+在 **本地 / 非 Brain 托管** 路径上，`deploy-template.mjs`（或同一条 apply 成功路径）在 Template 部署成功、拿到 Instance 名之后，立刻 POST 一次认领。失败可重试，不要为此重做部署。
+
+建议落在 `skills/sealos-deploy`：apply 成功的脚本里直接调，不要只写在 SKILL.md 指望模型记得。
+
+## 调用契约
+
+```
+POST https://brain.<cloudDomain>/api/projects/adopt-template-instance
+Authorization: Bearer <url-encoded kubeconfig>
+Content-Type: application/json
+```
+
+`<cloudDomain>` 与现有 region 一致（例如 kubeconfig / `config.json` 里 `template.gzg.sealos.run` → `gzg.sealos.run`）。当前 Brain Helm 给 UI 配了 `domainPrefix: brain`，所以入口是 `https://brain.<cloudDomain>`。不要从请求体传 namespace。
+
+kubeconfig 必须是这次 apply 用的那份（`~/.sealos/kubeconfig` 或注入的那份），且 current-context 的 namespace 就是 Instance 所在 namespace。Brain 只信这个 namespace。
+
+### 请求体
+
+```json
+{
+  "instanceName": "<Template Instance metadata.name>",
+  "templateName": "<可选，模板名，用于 Project 显示名和 brain.io/template-name>",
+  "displayName": "<可选，显式 Project 名；冲突返回 409，不会自动改名>",
+  "description": "<可选，最多 256 字符>"
+}
+```
+
+必填只有 `instanceName`。不要传 `namespace`，传了也会被丢掉。
+
+默认：不传 `displayName`，让 Brain 按 ADR 0058 从 `templateName`（否则 Instance 名）派生，重名自动加 `-2`。
+
+### 成功（200）
+
+```json
+{
+  "project": {
+    "id": "<uuid>",
+    "namespace": "<from kubeconfig>",
+    "displayName": "...",
+    "description": "",
+    "createdAt": "...",
+    "updatedAt": "..."
+  },
+  "adoption": {
+    "status": "adopted",
+    "instanceName": "...",
+    "instanceUid": "...",
+    "discoveredCount": 4,
+    "labeledCount": 4,
+    "warnings": ["incompleteResourceSet", "podTemplateLabelsUnchanged"]
+  }
+}
+```
+
+同一 Instance UID 再 POST 一次：同一 `project.id`，并再打一遍后来才出现的子资源。Agent 重试是安全的。
+
+同名但 Kubernetes UID 变了（删了重建）：当成新部署，会新建 Project。
+
+### 错误 `{ "error": string }`
+
+| HTTP | 含义 | Skills 该做什么 |
+| --- | --- | --- |
+| 401 / 400 鉴权 | kubeconfig 缺失/无效/解析不出 namespace | 停；不要重部署 |
+| 403 | namespace 无权 | 停 |
+| 404 | Instance 还不存在 | 短等后重试认领，不要重新 apply |
+| 400 不是 Instance | 名字不是 `app.sealos.io/v1 Instance` | 停；检查传的是 Instance 名不是 App 名 |
+| 400 too many resources | 发现对象 > 500 | 停；不要拆成多次认领（UID 会绑同一个 Project，但超限根本不会认领） |
+| 409 他 Project 的 label | 资源已有别人的 `brain.io/project-id` | 停；不要覆盖 |
+| 409 显示名冲突 | 显式 `displayName` 已被占用 | 去掉 displayName 重试，或换名字 |
+| 502 | 打标失败（映射会标 failed） | 只重试认领，同一 Project ID 会续上 |
+| 503 | Brain Postgres 不可用 | 重试认领 |
+
+`warnings` 里出现 `incompleteResourceSet`：当时只发现了 Instance 本身。等几秒再 POST 一次（幂等）。根因常常是子资源还没进集群，或子资源缺少 `cloud.sealos.io/deploy-on-sealos=<instanceName>`。
+
+## 发现依赖（YAML 侧唯一相关约束）
+
+Brain **不会**扫整个 namespace。它只：
+
+1. GET `instances.app.sealos.io/<instanceName>`
+2. 在固定 allowlist kind 上 list `cloud.sealos.io/deploy-on-sealos=<instanceName>`
+3. 在这份 list 结果里再按 Instance ownerRef 过滤
+
+没有这个 label、又没出现在上述 list 里的对象，认领不到，Project 删除也管不到。
+
+当前 `docker-to-sealos` 规格要求 StatefulSet **省略** `cloud.sealos.io/deploy-on-sealos`。若 Template API 也不会补上，这些 StatefulSet 不会进 Brain。
+
+**Skills 侧最小修正：** 凡是希望被 Brain 管理的 namespaced 资源（含 Instance、AP 工作负载、DB Cluster、Service、Ingress、PVC 等）都带 `cloud.sealos.io/deploy-on-sealos=<instanceName>`。不要为此改工作负载的 `spec.template` 选择器。不要在 Skills 里写 `brain.io/*`（Project ID 当时还不存在）。
+
+不要改 Sealos 原生 AP/DB 身份 label（`cloud.sealos.io/app-deploy-manager`、KubeBlocks labels）。Brain 靠它们识别 AP/DB，靠 `brain.io/project-id` 归到 Project。
+
+## 建议的脚本行为
+
+伪代码（本地路径）：
+
+```
+if env SEALAI_DEPLOY_TASK_ID or SEALAI_PROJECT_ID:
+  skip  # Brain 托管部署已经打标
+instanceName = template deploy 返回的 Instance 名
+POST adopt { instanceName, templateName }
+if 404 or 502 or warning incompleteResourceSet:
+  wait 2–5s, POST 同一 body 最多几次
+不要因为认领失败而 delete/re-apply Instance
+```
+
+Authorization 头与现有 Template API 调用一样：Bearer + url-encoded kubeconfig。
+
+## 验收（Skills 改完）
+
+1. 本地 Codex/Claude 用 Skills 部署一个模板（非 `SEALAI_DEPLOY_TASK_ID`）：Brain 项目列表出现新 Project，Canvas 能看到 AP/DB。
+2. 同一 Instance 再认领一次：还是同一个 `project.id`。
+3. 带 `SEALAI_DEPLOY_TASK_ID` 的托管部署：Skills **不**调用该接口，任务仍只走 extraLabels。
+4. Instance 尚未就绪时认领：404 或 `incompleteResourceSet` 后重试成功，集群里没有第二个 Instance。


### PR DESCRIPTION
## Summary
- Adds `POST /api/projects/adopt-template-instance` so a Sealos Skills Template apply can be claimed as a Brain Project (Postgres row + `brain.io/*` ownership labels) without changing the GitHub extraLabels-at-create path.
- Namespace comes only from the kubeconfig; identity is Instance UID. Same UID is idempotent; a reused name with a new UID is a new Project. Explorer does not gain an adopting/failed product status.
- Skills follow-up (post-apply POST, skip when `SEALAI_DEPLOY_TASK_ID` is set, keep `cloud.sealos.io/deploy-on-sealos`) is documented in `skills-template-instance-adoption.md`.

Closes nothing in this repo. Spec: [labring/sealos-private#116](https://github.com/labring/sealos-private/issues/116). ADR 0067.

## Test plan
- [ ] `bun test src/lib/project-persistence/adopt-template-instance.test.ts src/app/api/projects/adopt-template-instance/route.test.ts` from `apps/ui`
- [ ] First adopt: one Project, Instance + children labeled, counts in the response
- [ ] Repeat same UID: same `project.id`; new UID with the same name: new Project
- [ ] Foreign `brain.io/project-id` → 409; PATCH failure → 502 then retry resumes the same Project
- [ ] Body `namespace` is ignored; missing kubeconfig is 401
- [ ] Managed GitHub deploy (`SEALAI_DEPLOY_TASK_ID`) is unchanged and must not call this API


Made with [Cursor](https://cursor.com)