### PR TITLE
feat(projects): add a Project list Dev Mock with a count slider

### DIFF
--- a/apps/ui/src/app/project/layout.tsx
+++ b/apps/ui/src/app/project/layout.tsx
@@ -1,4 +1,5 @@
 import { OnboardingGate } from "@/features/onboarding/onboarding-gate";
+import { ProjectsExplorerDevMockGate } from "@/features/projects/explorer/projects-dev-mock-gate";
 import {
   AppShellChrome,
   AppShellSidebar,
@@ -25,6 +26,7 @@ export default function ProjectLayout({
       <SealosSdkBootstrap />
       <DevboxBootstrap />
       <OnboardingGate />
+      <ProjectsExplorerDevMockGate />
       <AppSidebarCookieBridge>
         <AppShellSidebar />
         <AppShellView className="min-w-0 flex-1 basis-0">

--- a/apps/ui/src/features/projects/explorer/projects-dev-mock-gate.tsx
+++ b/apps/ui/src/features/projects/explorer/projects-dev-mock-gate.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+// Same inlined gate as dev-tweaks.tsx: a real production build statically
+// drops the dynamic import and tree-shakes the mock module away;
+// `NEXT_PUBLIC_DEV_TWEAKS=1` keeps it for demo deployments.
+const ProjectsExplorerDevMock =
+  process.env.NODE_ENV === "development" ||
+  process.env.NEXT_PUBLIC_DEV_TWEAKS === "1"
+    ? dynamic(() =>
+        import("./projects-dev-mock").then((mod) => mod.ProjectsExplorerDevMock)
+      )
+    : null;
+
+/** Mounts the Projects mock's dev-tweaks registration with the /project shell. */
+export function ProjectsExplorerDevMockGate() {
+  if (!ProjectsExplorerDevMock) {
+    return null;
+  }
+  return <ProjectsExplorerDevMock />;
+}

--- a/apps/ui/src/features/projects/explorer/projects-dev-mock.test.ts
+++ b/apps/ui/src/features/projects/explorer/projects-dev-mock.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { generateProjectsDevMockSnapshot } from "./projects-dev-mock";
+
+test("generateProjectsDevMockSnapshot is deterministic and respects count", () => {
+  const first = generateProjectsDevMockSnapshot("plain", 12);
+  const second = generateProjectsDevMockSnapshot("plain", 12);
+
+  assert.equal(first.projects.length, 12);
+  assert.deepEqual(first.projects, second.projects);
+  assert.deepEqual([...first.projectIconKeys], [...second.projectIconKeys]);
+
+  const ids = new Set(first.projects.map((project) => project.id));
+  assert.equal(ids.size, 12);
+
+  assert.equal(generateProjectsDevMockSnapshot("plain", 0).projects.length, 0);
+});
+
+test("edge scenario cycles every Project Aggregate Status tone", () => {
+  const { projects } = generateProjectsDevMockSnapshot("edge", 24);
+  const tones = new Set(projects.map((project) => project.status));
+  for (const tone of [
+    "negative",
+    "neutral",
+    "positive",
+    "progress",
+    "warning",
+  ]) {
+    assert.ok(tones.has(tone as never), `missing tone ${tone}`);
+  }
+  // `undefined` keeps the static neutral dot path exercised too.
+  assert.ok(tones.has(undefined));
+});
+
+test("every third row omits its Project Icon to exercise the fallback", () => {
+  const { projectIconKeys, projects } = generateProjectsDevMockSnapshot(
+    "plain",
+    9
+  );
+  projects.forEach((project, index) => {
+    assert.equal(projectIconKeys.has(project.id), index % 3 !== 2);
+  });
+});

--- a/apps/ui/src/features/projects/explorer/projects-dev-mock.tsx
+++ b/apps/ui/src/features/projects/explorer/projects-dev-mock.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import {
+  type DevTweaksMockSource,
+  type DevTweaksMockState,
+  useDevTweaks,
+  useDevTweaksMock,
+} from "@workspace/dev-tweaks";
+import type { CanvasNodeVisualStatusTone } from "@workspace/ui/components/canvas-node/canvas-node.types";
+import { useEffect } from "react";
+import type { ProjectIconKey } from "@/features/projects/project-icons";
+import type { ProjectExplorerProject } from "./project-explorer.types";
+import {
+  type ProjectsExplorerDevMockSnapshot,
+  setProjectsExplorerDevMockSnapshot,
+} from "./projects-explorer-dev-mock-store";
+
+/**
+ * The Project list's Dev Mock: replaces the projects read model with
+ * generated fixture rows so the `/project` index and the App Sidebar can be
+ * designed against any list size without a workspace behind them. Row count
+ * comes from a companion tweak slider; the Mock Scenario picks the flavor —
+ * `plain` is ordinary healthy rows, `edge` is long names, special characters
+ * and every Project Aggregate Status tone. While enabled, rows are inert
+ * (no navigation, no row actions) — the generated Projects do not exist.
+ */
+
+export const PROJECTS_DEV_MOCK_KEY = "projects-mock";
+
+const PROJECTS_DEV_SCENARIOS = ["plain", "edge"] as const;
+
+// In-memory source: the mock has no server side and nothing rewrites it
+// behind the panel's back, so session-only module state is the whole truth.
+let mockState: DevTweaksMockState | null = null;
+
+const projectsDevMockSource: DevTweaksMockSource = {
+  load: () => mockState,
+  set: (state) => {
+    mockState = state;
+  },
+};
+
+const PLAIN_NAMES = [
+  "api-server",
+  "web-app",
+  "landing",
+  "docs-site",
+  "pg-main",
+  "redis-cache",
+  "analytics",
+  "auth-service",
+  "image-worker",
+  "billing-sync",
+  "search-index",
+  "cron-runner",
+];
+
+const PLAIN_DESCRIPTIONS = [
+  "Public REST API and background jobs",
+  "Customer-facing storefront",
+  "",
+  "Marketing pages and the blog",
+  "Primary Postgres with nightly backups",
+  "",
+  "Event ingestion and dashboards",
+];
+
+// Ordinary rows stay healthy: mostly positive with the occasional progress
+// or neutral dot, never negative — that's the edge scenario's job.
+const PLAIN_TONES: readonly (CanvasNodeVisualStatusTone | undefined)[] = [
+  "positive",
+  "positive",
+  "progress",
+  "positive",
+  "neutral",
+  "positive",
+  undefined,
+  "positive",
+];
+
+const EDGE_NAMES = [
+  "orchestrator-of-the-seven-seas-and-the-quarterly-revenue-forecast-pipeline-v2-final-FINAL",
+  "数据中台 · 实时特征平台",
+  "🚀 rocket-ship",
+  "a",
+  "UPPERCASE-PROJECT",
+  "dots.and.dashes-and_underscores",
+  "name with spaces",
+  "<script>alert(1)</script>",
+  "réservé-café-naïve",
+];
+
+const EDGE_DESCRIPTIONS = [
+  "A description long enough to be truncated by every surface that renders it, including the one you have not thought about yet, because someone pasted a paragraph of meeting notes into the description field and nobody stopped them.",
+  "带中文描述，混合 English words and 标点符号……",
+  "",
+  "🎉🎊✨ emoji-only-ish 🚨",
+  "https://example.com/a/very/long/url/that/should/not/break/layout?with=query&params=true",
+];
+
+const EDGE_TONES: readonly (CanvasNodeVisualStatusTone | undefined)[] = [
+  "positive",
+  "negative",
+  "progress",
+  "warning",
+  "neutral",
+  undefined,
+];
+
+const ICON_POOL: readonly ProjectIconKey[] = [
+  "docker",
+  "go",
+  "grafana",
+  "java",
+  "database",
+  "elasticsearch",
+  "etcd",
+  "caddy",
+];
+
+// Fixed epoch so fixtures are deterministic across renders and reloads.
+const BASE_CREATED_AT_MS = Date.UTC(2026, 7, 1, 12);
+const CREATED_AT_STEP_MS = 9 * 60 * 60 * 1000;
+
+function pick<T>(pool: readonly T[], index: number): T {
+  return pool[index % pool.length] as T;
+}
+
+function fixtureName(names: readonly string[], index: number): string {
+  const base = pick(names, index);
+  const round = Math.floor(index / names.length);
+  return round === 0 ? base : `${base}-${round + 1}`;
+}
+
+export function generateProjectsDevMockSnapshot(
+  scenario: string,
+  count: number
+): ProjectsExplorerDevMockSnapshot {
+  const edge = scenario === "edge";
+  const names = edge ? EDGE_NAMES : PLAIN_NAMES;
+  const descriptions = edge ? EDGE_DESCRIPTIONS : PLAIN_DESCRIPTIONS;
+  const tones = edge ? EDGE_TONES : PLAIN_TONES;
+
+  const projects: ProjectExplorerProject[] = [];
+  const projectIconKeys = new Map<string, ProjectIconKey>();
+  for (let index = 0; index < count; index++) {
+    const id = `dev-mock-project-${index + 1}`;
+    const status = pick(tones, index);
+    projects.push({
+      createdAt: new Date(
+        BASE_CREATED_AT_MS - index * CREATED_AT_STEP_MS
+      ).toISOString(),
+      description: pick(descriptions, index),
+      id,
+      name: fixtureName(names, index),
+      resourceName: id,
+      ...(status === undefined ? {} : { status }),
+    });
+    // Every third row goes without an icon to exercise the fallback glyph.
+    if (index % 3 !== 2) {
+      projectIconKeys.set(id, pick(ICON_POOL, index));
+    }
+  }
+  return { projectIconKeys, projects };
+}
+
+/**
+ * The count slider registers only while the mock is enabled, so the tweak
+ * section appears and disappears with the toggle.
+ */
+function ProjectsExplorerDevMockGenerator({ scenario }: { scenario: string }) {
+  const { count } = useDevTweaks(
+    "Project · list mock",
+    { count: [8, 0, 200, 1] },
+    { id: "projects-list-mock", persist: { storage: "sessionStorage" } }
+  );
+
+  useEffect(() => {
+    setProjectsExplorerDevMockSnapshot(
+      generateProjectsDevMockSnapshot(scenario, count)
+    );
+  }, [scenario, count]);
+
+  useEffect(() => () => setProjectsExplorerDevMockSnapshot(null), []);
+
+  return null;
+}
+
+/** Registers the mock while the `/project` shell is mounted; renders nothing. */
+export function ProjectsExplorerDevMock() {
+  const mock = useDevTweaksMock(PROJECTS_DEV_MOCK_KEY, {
+    note: "Replaces the Project list with generated fixture rows",
+    scenarios: PROJECTS_DEV_SCENARIOS,
+    source: projectsDevMockSource,
+    title: "Projects mock",
+  });
+
+  return mock.enabled ? (
+    <ProjectsExplorerDevMockGenerator scenario={mock.scenario} />
+  ) : null;
+}

--- a/apps/ui/src/features/projects/explorer/projects-explorer-dev-mock-store.ts
+++ b/apps/ui/src/features/projects/explorer/projects-explorer-dev-mock-store.ts
@@ -1,0 +1,44 @@
+import type { ProjectIconKeyMap } from "@/features/projects/project-icons";
+import type { ProjectExplorerProject } from "./project-explorer.types";
+
+/**
+ * Session-only bridge between the Projects Dev Mock (dev/demo bundles only)
+ * and `useProjectsExplorerModel` (every bundle). The read model subscribes
+ * here; the gated mock module is the only writer. Kept free of
+ * `@workspace/dev-tweaks` imports so production carries just this stub with
+ * a forever-null snapshot.
+ */
+export interface ProjectsExplorerDevMockSnapshot {
+  /** Presentation-only Project Icon keys for the generated rows. */
+  projectIconKeys: ProjectIconKeyMap;
+  projects: ProjectExplorerProject[];
+}
+
+let snapshot: ProjectsExplorerDevMockSnapshot | null = null;
+const listeners = new Set<() => void>();
+
+/** `null` means the mock is off and real data flows untouched. */
+export function getProjectsExplorerDevMockSnapshot(): ProjectsExplorerDevMockSnapshot | null {
+  return snapshot;
+}
+
+export function setProjectsExplorerDevMockSnapshot(
+  next: ProjectsExplorerDevMockSnapshot | null
+): void {
+  if (next === snapshot) {
+    return;
+  }
+  snapshot = next;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function subscribeProjectsExplorerDevMock(
+  listener: () => void
+): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/apps/ui/src/features/projects/explorer/use-projects-explorer.ts
+++ b/apps/ui/src/features/projects/explorer/use-projects-explorer.ts
@@ -6,7 +6,7 @@ import { useApsK8sList, useDbsK8sList } from "@workspace/api/hooks";
 import { apItemsFromList } from "@workspace/api/lib/ap-list";
 import type { K8sGetResponse } from "@workspace/api/schemas/k8s-get";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
 import { toast } from "sonner";
 import useSWR from "swr";
 import { trackBrainGtmEventAfterSuccess } from "@/features/analytics/brain-gtm";
@@ -23,6 +23,10 @@ import type {
   ProjectExplorerProject,
   ProjectExplorerStates,
 } from "@/features/projects/explorer/project-explorer";
+import {
+  getProjectsExplorerDevMockSnapshot,
+  subscribeProjectsExplorerDevMock,
+} from "@/features/projects/explorer/projects-explorer-dev-mock-store";
 import {
   aggregateProjectStatuses,
   type ProjectWorkloadStatusInput,
@@ -119,9 +123,25 @@ interface ProjectsExplorerReadModel {
     aps: K8sGetResponse | undefined;
     dbs: K8sGetResponse | undefined;
   };
+  /**
+   * True while the Projects Dev Mock replaces the list with fixture rows;
+   * consumers render those rows inert (the generated Projects do not exist).
+   */
+  devMockActive: boolean;
   /** Revalidate the projects list (e.g. after creating a project). */
   refreshProjects: () => Promise<unknown>;
   states: ProjectExplorerStates;
+}
+
+const getDevMockServerSnapshot = () => null;
+
+/** The Projects Dev Mock snapshot, or `null` when the mock is off. */
+function useProjectsExplorerDevMock() {
+  return useSyncExternalStore(
+    subscribeProjectsExplorerDevMock,
+    getProjectsExplorerDevMockSnapshot,
+    getDevMockServerSnapshot
+  );
 }
 
 interface ProjectsExplorerResult extends ProjectsExplorerReadModel {
@@ -129,6 +149,7 @@ interface ProjectsExplorerResult extends ProjectsExplorerReadModel {
 }
 
 function useProjectsExplorerModel(options: ProjectsExplorerReadModelOptions) {
+  const devMock = useProjectsExplorerDevMock();
   const kubeconfig = options.kubeconfig.trim();
   const ns = options.ns;
   const hasKubeconfig = kubeconfig !== "";
@@ -191,30 +212,37 @@ function useProjectsExplorerModel(options: ProjectsExplorerReadModelOptions) {
 
   const projectIconKeys = useMemo(
     () =>
-      projectIconKeysFromWorkloads({
-        aps: apsData,
-        dbs: dbsData,
-      }),
-    [apsData, dbsData]
+      devMock
+        ? devMock.projectIconKeys
+        : projectIconKeysFromWorkloads({
+            aps: apsData,
+            dbs: dbsData,
+          }),
+    [apsData, dbsData, devMock]
   );
 
   const projects = useMemo<ProjectExplorerProject[]>(
-    () => brainProjectsToExplorerProjects(rawProjects, statusByProjectId),
-    [rawProjects, statusByProjectId]
+    () =>
+      devMock
+        ? devMock.projects
+        : brainProjectsToExplorerProjects(rawProjects, statusByProjectId),
+    [devMock, rawProjects, statusByProjectId]
   );
 
   useEffect(() => {
-    if (rawProjects === undefined) {
+    // Never prune against fixture IDs — the Dev Mock's generated rows would
+    // wipe the user's real Pinned Projects.
+    if (devMock !== null || rawProjects === undefined) {
       return;
     }
     prunePinnedProjects(projects.map((project) => project.id)).catch(
       () => undefined
     );
-  }, [projects, prunePinnedProjects, rawProjects]);
+  }, [devMock, projects, prunePinnedProjects, rawProjects]);
 
   const projectHistoryEmptyState = useMemo(
-    () => projectHistoryErrorEmptyState(projectsError),
-    [projectsError]
+    () => (devMock ? undefined : projectHistoryErrorEmptyState(projectsError)),
+    [devMock, projectsError]
   );
 
   const states = useMemo(
@@ -244,6 +272,7 @@ function useProjectsExplorerModel(options: ProjectsExplorerReadModelOptions) {
 
   return {
     data,
+    devMockActive: devMock !== null,
     hasKubeconfig,
     kubeconfig,
     mutate,
@@ -258,10 +287,11 @@ function useProjectsExplorerModel(options: ProjectsExplorerReadModelOptions) {
 export function useProjectsExplorerReadModel(
   options: ProjectsExplorerReadModelOptions
 ): ProjectsExplorerReadModel {
-  const { data, mutate, states } = useProjectsExplorerModel(options);
+  const { data, devMockActive, mutate, states } =
+    useProjectsExplorerModel(options);
   return useMemo(
-    () => ({ data, refreshProjects: mutate, states }),
-    [data, mutate, states]
+    () => ({ data, devMockActive, refreshProjects: mutate, states }),
+    [data, devMockActive, mutate, states]
   );
 }
 
@@ -272,6 +302,7 @@ export function useProjectsExplorer(
   const onNewProjectOverride = options.onNewProject;
   const {
     data,
+    devMockActive,
     hasKubeconfig,
     kubeconfig,
     mutate,
@@ -406,15 +437,36 @@ export function useProjectsExplorer(
     [hasKubeconfig, pinnedProjectLimit, togglePinnedProject]
   );
 
+  // Fixture rows keep every affordance (hover, pin, row menu) so the list can
+  // be designed whole, but the handlers are stand-ins: nothing navigates and
+  // nothing reaches a real endpoint with an ID that does not exist.
+  const onMockRowClick = useCallback(() => undefined, []);
+  const onMockRowMutation = useCallback(() => {
+    toast.info("Projects mock is on — row actions do nothing.");
+  }, []);
+
   const actions = useMemo(
-    (): ProjectExplorerActions => ({
-      onNewProject,
-      onProjectClick,
-      onProjectDelete,
-      onProjectPinToggle,
-      onProjectUpdate,
-    }),
+    (): ProjectExplorerActions =>
+      devMockActive
+        ? {
+            // New Project stays live; it never takes a fixture ID.
+            onNewProject,
+            onProjectClick: onMockRowClick,
+            onProjectDelete: onMockRowMutation,
+            onProjectPinToggle: onMockRowMutation,
+            onProjectUpdate: onMockRowMutation,
+          }
+        : {
+            onNewProject,
+            onProjectClick,
+            onProjectDelete,
+            onProjectPinToggle,
+            onProjectUpdate,
+          },
     [
+      devMockActive,
+      onMockRowClick,
+      onMockRowMutation,
       onNewProject,
       onProjectClick,
       onProjectDelete,
@@ -423,5 +475,5 @@ export function useProjectsExplorer(
     ]
   );
 
-  return { actions, data, states, refreshProjects: mutate };
+  return { actions, data, devMockActive, states, refreshProjects: mutate };
 }

--- a/apps/ui/src/features/shell/app-sidebar.tsx
+++ b/apps/ui/src/features/shell/app-sidebar.tsx
@@ -341,11 +341,14 @@ function AppSidebarProjectRow({
   ariaLabel,
   currentProjectId,
   iconKey,
+  inert,
   project,
 }: {
   ariaLabel?: string;
   currentProjectId: string | undefined;
   iconKey: ProjectIconKey;
+  /** Renders the row without a link (Projects Dev Mock fixture rows). */
+  inert?: boolean;
   project: { id: string; name: string };
 }) {
   const active = currentProjectId === project.id;
@@ -353,7 +356,7 @@ function AppSidebarProjectRow({
     <AppSidebarNavRow
       active={active}
       ariaLabel={ariaLabel}
-      href={`/project/${encodeURIComponent(project.id)}`}
+      href={inert ? undefined : `/project/${encodeURIComponent(project.id)}`}
       icon={<ProjectIcon active={active} iconKey={iconKey} />}
       label={project.name}
     />
@@ -404,10 +407,13 @@ const AppSidebarProjectGroupsNav = memo(function AppSidebarProjectGroupsNav({
   currentProjectId,
   groups,
   projectIconKeys,
+  rowsInert,
 }: {
   currentProjectId: string | undefined;
   groups: ReturnType<typeof createAppSidebarProjectGroups>;
   projectIconKeys: ProjectIconKeyMap | undefined;
+  /** True while the Projects Dev Mock is on: fixture rows must not navigate. */
+  rowsInert?: boolean;
 }) {
   const attachProjectsScroller = useScrollEdgeState();
   const { state } = useSidebar();
@@ -448,6 +454,7 @@ const AppSidebarProjectGroupsNav = memo(function AppSidebarProjectGroupsNav({
                     ariaLabel={`Pinned project: ${project.name}`}
                     currentProjectId={currentProjectId}
                     iconKey={projectIconKeys?.get(project.id) ?? "docker"}
+                    inert={rowsInert}
                     key={project.id}
                     project={project}
                   />
@@ -481,6 +488,7 @@ const AppSidebarProjectGroupsNav = memo(function AppSidebarProjectGroupsNav({
                   <AppSidebarProjectRow
                     currentProjectId={currentProjectId}
                     iconKey={projectIconKeys?.get(project.id) ?? "docker"}
+                    inert={rowsInert}
                     key={project.id}
                     project={project}
                   />
@@ -534,7 +542,7 @@ function AppSidebarChrome({
 }) {
   const kubeconfig = useAtomValue(kubeconfigAtom).trim();
   const namespace = useAtomValue(namespaceAtom);
-  const { states } = useProjectsExplorerReadModel({
+  const { devMockActive, states } = useProjectsExplorerReadModel({
     kubeconfig,
     ns: namespace,
   });
@@ -595,6 +603,7 @@ function AppSidebarChrome({
               currentProjectId={currentProjectId}
               groups={groups}
               projectIconKeys={states.projectIconKeys}
+              rowsInert={devMockActive}
             />
           </nav>
         </SidebarContent>


### PR DESCRIPTION
## Summary

Adds a **Projects mock** Dev Mock to the dev-tweaks panel so the `/project` index and the App Sidebar can be designed against any list size without a workspace behind them.

- **Enabled toggle + Mock Scenario select** (`plain` / `edge`): `plain` is ordinary healthy rows; `edge` is long names, CJK/emoji/special characters, and every Project Aggregate Status tone (plus the no-status dot).
- **Companion count slider** (`Project · list mock`, 0–200, sessionStorage) appears while the mock is enabled; 0 renders the shipped empty state.
- Fixtures are deterministic; every third row omits its Project Icon to exercise the sidebar fallback glyph.

## Safety while enabled

- Rows keep every affordance (hover, pin, row menu, edit/delete dialogs) so the list can be designed whole, but handlers are stand-ins: no navigation, and mutations only toast — nothing reaches a real endpoint with a fixture ID.
- The pinned-project prune is skipped (fixture IDs would otherwise wipe real Pinned Projects).
- Sidebar project rows render linkless via the existing `href`-less nav-row path.
- New Project stays live; it never takes a fixture ID.

## Implementation

Follows the Notifications mock precedent (client-side store fill): a tiny dev-tweaks-free store bridges the gated mock module and `useProjectsExplorerModel`, so production builds carry only a forever-null stub and the mock module itself is tree-shaken behind the usual inlined `NODE_ENV`/`NEXT_PUBLIC_DEV_TWEAKS` gate.

## Testing

- `bun check` clean; `bun typecheck` fails only on the pre-existing `preview-canvas-perf/page.tsx` error (verified present on clean `main` via stash).
- `bun test src/features/projects/explorer` (17 pass, incl. new generator tests) and sidebar tests (26 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)