### PR TITLE
feat(billing): surface gift credit in the Plan Account Balance block

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -592,9 +592,15 @@ _Avoid_: first region, default region, regions[0].
 
 ### Account Balance
 
-The user's account-level prepaid funds held by account-service, presented as the net of balance minus accumulated deductions. Account Balance is real money that can offset subscription charges; it is account-scoped, not per-workspace, and read-only in Brain — recharging it is not a Brain capability. It is not a Free Chat Turns count, a quota, or an entitlement counter.
+The user's account-level prepaid funds held by account-service, presented as the available amount: balance minus accumulated deductions, plus any usable Gift Credit — the same formula the platform's own debt pipeline judges an account by, so the number a user sees and the number that suspends them never disagree. Account Balance is real money that can offset subscription charges; it is account-scoped, not per-workspace, and read-only in Brain — recharging it is not a Brain capability. It is not a Free Chat Turns count, a quota, or an entitlement counter.
 
 _Avoid_: credits, wallet, free balance, top-up balance.
+
+### Gift Credit
+
+Promotional money the platform grants to an account — the new-user gift is the canonical case — consumed by metered usage before paid funds and expiring on a platform-set date. Gift Credit is account-scoped and counts toward the available Account Balance; while any remains, the Balance display names it so its silent burn-down is visible. It is not AI Credits (a workspace allowance for AI usage) and not cash: it cannot be topped up, transferred, or refunded.
+
+_Avoid_: bonus, voucher, trial balance, free balance.
 
 ### Subscription Plan
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -592,7 +592,7 @@ _Avoid_: first region, default region, regions[0].
 
 ### Account Balance
 
-The user's account-level prepaid funds held by account-service, presented as the available amount: balance minus accumulated deductions, plus any usable Gift Credit — the same formula the platform's own debt pipeline judges an account by, so the number a user sees and the number that suspends them never disagree. Account Balance is real money that can offset subscription charges; it is account-scoped, not per-workspace, and read-only in Brain — recharging it is not a Brain capability. It is not a Free Chat Turns count, a quota, or an entitlement counter.
+The user's account-level funds held by account-service, presented as the available amount: balance minus accumulated deductions, plus every usable credit — Gift Credit and any plan-granted credit alike — the same formula the platform's own debt pipeline judges an account by, so the number a user sees and the number that suspends them never disagree. Account Balance is a composite: prepaid cash (the rechargeable part, able to offset subscription charges) plus promotional credit that is not cash. It is account-scoped, not per-workspace, and read-only in Brain — recharging it is not a Brain capability. It is not a Free Chat Turns count, a quota, or an entitlement counter.
 
 _Avoid_: credits, wallet, free balance, top-up balance.
 
@@ -670,7 +670,7 @@ _Avoid_: PAYG plan, pay-as-you-go plan, free mode, plan named "PAYG".
 
 ### Account Debt
 
-The state of an Account Balance that has fallen below zero: the platform suspends the account's PAYG workspaces and, if the debt persists, deletes their resources through its own escalating debt pipeline — separate from the Deletion Countdown, which belongs to Workspace Subscription expiry. The platform reports it on a PAYG workspace as a debt status with no subscription and no timestamps, so no suspension or deletion date can be stated for it. Recovery is restoring the Account Balance (a Desktop top-up), never a subscription action — an Account Debt warning must not speak of a subscription expiring or renewing.
+The state of an Account Balance that has fallen to or below zero — the platform's debt pipeline treats only a strictly positive available amount as in good standing: the platform suspends the account's PAYG workspaces and, if the debt persists, deletes their resources through its own escalating debt pipeline — separate from the Deletion Countdown, which belongs to Workspace Subscription expiry. The platform reports it on a PAYG workspace as a debt status with no subscription and no timestamps, so no suspension or deletion date can be stated for it. Recovery is restoring the Account Balance (a Desktop top-up), never a subscription action — an Account Debt warning must not speak of a subscription expiring or renewing.
 
 _Avoid_: subscription expired / plan expired (for a PAYG workspace), payment due (user-facing), negative balance (as the state's name), arrears.
 

--- a/apps/ui/src/app/api/billing/credits/route.ts
+++ b/apps/ui/src/app/api/billing/credits/route.ts
@@ -1,0 +1,7 @@
+import { BILLING_ROUTES } from "@/features/billing/server/billing-route-table";
+import { createBillingRoute } from "@/features/billing/server/create-billing-route";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export const GET = createBillingRoute(BILLING_ROUTES.credits);

--- a/apps/ui/src/features/billing/account-balance.test.ts
+++ b/apps/ui/src/features/billing/account-balance.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { formatAccountBalance, loadAccountBalance } from "./account-balance";
+import { loadAccountBalance } from "./account-balance";
 
-test("loads and formats the verified account's net Account Balance", async () => {
+test("loads the verified account's net Account Balance", async () => {
   let requestInput: RequestInfo | URL | undefined;
   let requestInit: RequestInit | undefined;
   const balance = await loadAccountBalance(
@@ -32,5 +32,4 @@ test("loads and formats the verified account's net Account Balance", async () =>
   assert.equal(headers.get("X-Sealos-App-Token"), "desktop-app-token");
   assert.equal(requestInit?.cache, "no-store");
   assert.deepEqual(balance, { currency: "usd", microUnits: 3_000_000 });
-  assert.equal(formatAccountBalance(balance), "$3.00");
 });

--- a/apps/ui/src/features/billing/account-balance.ts
+++ b/apps/ui/src/features/billing/account-balance.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-import { formatBillingAmount } from "@/features/billing/billing-amount";
 import {
   type BillingFetch,
   createBillingJsonRequester,
@@ -42,8 +41,4 @@ export async function loadAccountBalance(
     microUnits:
       parsed.data.account.Balance - parsed.data.account.DeductionBalance,
   };
-}
-
-export function formatAccountBalance(balance: AccountBalance): string {
-  return formatBillingAmount(balance.microUnits, balance.currency);
 }

--- a/apps/ui/src/features/billing/account-credits.test.ts
+++ b/apps/ui/src/features/billing/account-credits.test.ts
@@ -3,7 +3,7 @@ import { test } from "node:test";
 
 import { loadAccountCredits } from "./account-credits";
 
-test("loads the remaining usable gift credits", async () => {
+test("loads the remaining usable and gift credits", async () => {
   let requestInput: RequestInfo | URL | undefined;
   let requestInit: RequestInit | undefined;
   const credits = await loadAccountCredits(
@@ -21,6 +21,8 @@ test("loads the remaining usable gift credits", async () => {
             credits: 1_000_000,
             deductionBalance: 0,
             deductionCredits: 280_000,
+            kycDeductionCreditsBalance: 1_000_000,
+            kycDeductionCreditsDeductionBalance: 280_000,
           },
         })
       );
@@ -32,7 +34,36 @@ test("loads the remaining usable gift credits", async () => {
   assert.equal(headers.get("Authorization"), "Bearer apiVersion%3A%20v1");
   assert.equal(headers.get("X-Sealos-App-Token"), "desktop-app-token");
   assert.equal(requestInit?.cache, "no-store");
-  assert.deepEqual(credits, { usableMicroUnits: 720_000 });
+  assert.deepEqual(credits, {
+    giftMicroUnits: 720_000,
+    usableMicroUnits: 720_000,
+  });
+});
+
+test("a paid plan's grant feeds the usable total but not the gift", async () => {
+  // The aggregate covers every active Credits row; the KYC pair is the
+  // new-user gift alone. A paid plan with remaining plan credits must not
+  // surface them as a gift.
+  const credits = await loadAccountCredits(
+    { appToken: "token", kubeconfig: "kc" },
+    () =>
+      Promise.resolve(
+        Response.json({
+          credits: {
+            credits: 3_000_000,
+            currentPlanCreditsBalance: 3_000_000,
+            currentPlanCreditsDeductionBalance: 1_200_000,
+            deductionCredits: 1_200_000,
+            kycDeductionCreditsBalance: 0,
+            kycDeductionCreditsDeductionBalance: 0,
+          },
+        })
+      )
+  );
+  assert.deepEqual(credits, {
+    giftMicroUnits: 0,
+    usableMicroUnits: 1_800_000,
+  });
 });
 
 test("clamps over-consumed credits to zero", async () => {
@@ -41,9 +72,37 @@ test("clamps over-consumed credits to zero", async () => {
     () =>
       Promise.resolve(
         Response.json({
-          credits: { credits: 500_000, deductionCredits: 620_000 },
+          credits: {
+            credits: 500_000,
+            deductionCredits: 620_000,
+            kycDeductionCreditsBalance: 500_000,
+            kycDeductionCreditsDeductionBalance: 620_000,
+          },
         })
       )
   );
-  assert.deepEqual(credits, { usableMicroUnits: 0 });
+  assert.deepEqual(credits, { giftMicroUnits: 0, usableMicroUnits: 0 });
+});
+
+test("caps the gift at the aggregate usable total", async () => {
+  // An expired gift row drops out of the aggregate before the KYC pair
+  // reflects it; the chip must never claim more than the account can spend.
+  const credits = await loadAccountCredits(
+    { appToken: "token", kubeconfig: "kc" },
+    () =>
+      Promise.resolve(
+        Response.json({
+          credits: {
+            credits: 400_000,
+            deductionCredits: 100_000,
+            kycDeductionCreditsBalance: 1_000_000,
+            kycDeductionCreditsDeductionBalance: 0,
+          },
+        })
+      )
+  );
+  assert.deepEqual(credits, {
+    giftMicroUnits: 300_000,
+    usableMicroUnits: 300_000,
+  });
 });

--- a/apps/ui/src/features/billing/account-credits.test.ts
+++ b/apps/ui/src/features/billing/account-credits.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { loadAccountCredits } from "./account-credits";
+
+test("loads the remaining usable gift credits", async () => {
+  let requestInput: RequestInfo | URL | undefined;
+  let requestInit: RequestInit | undefined;
+  const credits = await loadAccountCredits(
+    {
+      appToken: "desktop-app-token",
+      kubeconfig: "apiVersion: v1",
+    },
+    (input, init) => {
+      requestInput = input;
+      requestInit = init;
+      return Promise.resolve(
+        Response.json({
+          credits: {
+            balance: 0,
+            credits: 1_000_000,
+            deductionBalance: 0,
+            deductionCredits: 280_000,
+          },
+        })
+      );
+    }
+  );
+
+  assert.equal(requestInput?.toString(), "/api/billing/credits");
+  const headers = new Headers(requestInit?.headers);
+  assert.equal(headers.get("Authorization"), "Bearer apiVersion%3A%20v1");
+  assert.equal(headers.get("X-Sealos-App-Token"), "desktop-app-token");
+  assert.equal(requestInit?.cache, "no-store");
+  assert.deepEqual(credits, { usableMicroUnits: 720_000 });
+});
+
+test("clamps over-consumed credits to zero", async () => {
+  const credits = await loadAccountCredits(
+    { appToken: "token", kubeconfig: "kc" },
+    () =>
+      Promise.resolve(
+        Response.json({
+          credits: { credits: 500_000, deductionCredits: 620_000 },
+        })
+      )
+  );
+  assert.deepEqual(credits, { usableMicroUnits: 0 });
+});

--- a/apps/ui/src/features/billing/account-credits.ts
+++ b/apps/ui/src/features/billing/account-credits.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+import {
+  type BillingFetch,
+  createBillingJsonRequester,
+} from "./billing-data-client";
+
+// account-service's credits/info reports aggregate totals over the active
+// Credits rows (GetAvailableCredits filters to unexpired ones upstream). It
+// carries no per-row expire_at, so the gift's expiry date is not readable
+// through any proxied endpoint today (AIM-315's gap list).
+const accountCreditsResponseSchema = z.object({
+  credits: z.object({
+    credits: z.number().default(0),
+    deductionCredits: z.number().default(0),
+  }),
+});
+
+export interface AccountCredits {
+  /** Remaining gift credit: active credits minus what deductions consumed. */
+  usableMicroUnits: number;
+}
+
+export async function loadAccountCredits(
+  credentials: {
+    appToken: string;
+    kubeconfig: string;
+  },
+  fetch: BillingFetch = globalThis.fetch
+): Promise<AccountCredits> {
+  const requestBillingJson = createBillingJsonRequester({
+    credentials,
+    fallbackErrorMessage: "Could not load gift credits.",
+    fetch,
+  });
+  const payload = await requestBillingJson("/api/billing/credits");
+  const parsed = accountCreditsResponseSchema.safeParse(payload);
+  if (!parsed.success) {
+    throw new Error("Gift credits response is invalid.");
+  }
+  return {
+    usableMicroUnits: Math.max(
+      0,
+      parsed.data.credits.credits - parsed.data.credits.deductionCredits
+    ),
+  };
+}

--- a/apps/ui/src/features/billing/account-credits.ts
+++ b/apps/ui/src/features/billing/account-credits.ts
@@ -6,18 +6,32 @@ import {
 } from "./billing-data-client";
 
 // account-service's credits/info reports aggregate totals over the active
-// Credits rows (GetAvailableCredits filters to unexpired ones upstream). It
-// carries no per-row expire_at, so the gift's expiry date is not readable
-// through any proxied endpoint today (AIM-315's gap list).
+// Credits rows (GetAvailableCredits filters to unexpired ones upstream)
+// alongside two labeled pairs: the KYC/free-plan row — the new-user gift —
+// and the current plan's own grant. On a Free trial upstream copies the KYC
+// pair from the current-plan pair, so the two agree there by construction.
+// No pair carries a per-row expire_at, so the gift's expiry date is not
+// readable through any proxied endpoint today (AIM-315's gap list).
 const accountCreditsResponseSchema = z.object({
   credits: z.object({
     credits: z.number().default(0),
     deductionCredits: z.number().default(0),
+    kycDeductionCreditsBalance: z.number().default(0),
+    kycDeductionCreditsDeductionBalance: z.number().default(0),
   }),
 });
 
 export interface AccountCredits {
-  /** Remaining gift credit: active credits minus what deductions consumed. */
+  /**
+   * Remaining new-user gift (the KYC/free-plan row): what the Gift chip may
+   * label. Never larger than usableMicroUnits.
+   */
+  giftMicroUnits: number;
+  /**
+   * Remaining usable credit across every active row — gift, plan grant, and
+   * anything else — the credits term of the platform's debt formula. Feeds
+   * the available Account Balance figure.
+   */
   usableMicroUnits: number;
 }
 
@@ -38,10 +52,20 @@ export async function loadAccountCredits(
   if (!parsed.success) {
     throw new Error("Gift credits response is invalid.");
   }
+  const { credits } = parsed.data;
+  const usableMicroUnits = Math.max(
+    0,
+    credits.credits - credits.deductionCredits
+  );
   return {
-    usableMicroUnits: Math.max(
-      0,
-      parsed.data.credits.credits - parsed.data.credits.deductionCredits
+    giftMicroUnits: Math.min(
+      usableMicroUnits,
+      Math.max(
+        0,
+        credits.kycDeductionCreditsBalance -
+          credits.kycDeductionCreditsDeductionBalance
+      )
     ),
+    usableMicroUnits,
   };
 }

--- a/apps/ui/src/features/billing/billing-plan-surface.states.test.tsx
+++ b/apps/ui/src/features/billing/billing-plan-surface.states.test.tsx
@@ -231,3 +231,68 @@ test("Free workspaces rows carry no Renewal Time", async () => {
     assert.equal(row?.renewalAt, null, `${scenario}: no Renewal Time`);
   }
 });
+
+async function renderBalanceValue(
+  props: { availableMicroUnits: number; giftMicroUnits: number },
+  run: (rendered: ReturnType<typeof render>) => void | Promise<void>
+) {
+  await withTestDom(async (act) => {
+    const { BillingBalanceValue } = await import("./billing-plan-surface");
+    let rendered: ReturnType<typeof render> | undefined;
+    try {
+      await act(() => {
+        rendered = render(<BillingBalanceValue currency="usd" {...props} />);
+      });
+      if (rendered != null) {
+        await run(rendered);
+      }
+    } finally {
+      await act(() => rendered?.unmount());
+    }
+  });
+}
+
+test("an active gift renders as a chip beside the available total", async () => {
+  // AIM-323: the newbie state — no cash, only the $1 gift partly consumed.
+  await renderBalanceValue(
+    { availableMicroUnits: 720_000, giftMicroUnits: 720_000 },
+    (rendered) => {
+      const text = rendered.container.textContent ?? "";
+      assert.ok(text.includes("$0.72"), "the available total renders");
+      assert.ok(text.includes("Gift $0.72"), "the gift chip renders");
+      assert.equal(
+        text.includes("Top up from the Sealos Desktop"),
+        false,
+        "a positive total carries no debt caption"
+      );
+    }
+  );
+});
+
+test("a spent gift leaves the bare number", async () => {
+  await renderBalanceValue(
+    { availableMicroUnits: 104_550_000, giftMicroUnits: 0 },
+    (rendered) => {
+      const text = rendered.container.textContent ?? "";
+      assert.ok(text.includes("$104.55"));
+      assert.equal(text.includes("Gift"), false);
+    }
+  );
+});
+
+test("a non-positive available total voices Account Debt", async () => {
+  // Recovery is a top-up, never a plan (CONTEXT.md's Account Debt voice).
+  await renderBalanceValue(
+    { availableMicroUnits: -6_320_000, giftMicroUnits: 0 },
+    (rendered) => {
+      const text = rendered.container.textContent ?? "";
+      assert.ok(text.includes("-$6.32"), "the negative total renders");
+      assert.ok(
+        text.includes(
+          "Top up from the Sealos Desktop to restore your services."
+        ),
+        "the debt caption renders"
+      );
+    }
+  );
+});

--- a/apps/ui/src/features/billing/billing-plan-surface.states.test.tsx
+++ b/apps/ui/src/features/billing/billing-plan-surface.states.test.tsx
@@ -233,7 +233,11 @@ test("Free workspaces rows carry no Renewal Time", async () => {
 });
 
 async function renderBalanceValue(
-  props: { availableMicroUnits: number; giftMicroUnits: number },
+  props: {
+    availableMicroUnits: number;
+    creditsResolved?: boolean;
+    giftMicroUnits: number;
+  },
   run: (rendered: ReturnType<typeof render>) => void | Promise<void>
 ) {
   await withTestDom(async (act) => {
@@ -241,7 +245,9 @@ async function renderBalanceValue(
     let rendered: ReturnType<typeof render> | undefined;
     try {
       await act(() => {
-        rendered = render(<BillingBalanceValue currency="usd" {...props} />);
+        rendered = render(
+          <BillingBalanceValue creditsResolved currency="usd" {...props} />
+        );
       });
       if (rendered != null) {
         await run(rendered);
@@ -292,6 +298,27 @@ test("a non-positive available total voices Account Debt", async () => {
           "Top up from the Sealos Desktop to restore your services."
         ),
         "the debt caption renders"
+      );
+    }
+  );
+});
+
+test("unresolved credits withhold the debt voice", async () => {
+  // A failed or pending credits fetch leaves the figure cash-only; unseen
+  // credits could still cover the account, so no red tint and no caption.
+  await renderBalanceValue(
+    {
+      availableMicroUnits: -6_320_000,
+      creditsResolved: false,
+      giftMicroUnits: 0,
+    },
+    (rendered) => {
+      const text = rendered.container.textContent ?? "";
+      assert.ok(text.includes("-$6.32"), "the cash figure still renders");
+      assert.equal(
+        text.includes("Top up from the Sealos Desktop"),
+        false,
+        "no debt caption without the full formula"
       );
     }
   );

--- a/apps/ui/src/features/billing/billing-plan-surface.tsx
+++ b/apps/ui/src/features/billing/billing-plan-surface.tsx
@@ -781,22 +781,31 @@ export function BillingAiCreditsSection({
 
 /**
  * The Account Balance figure (prototype D of AIM-313): the available total —
- * Balance − DeductionBalance + usable gift credits, the upstream debt
- * formula — with any gift pinned beside it as a borderless chip. Debt (≤ 0)
- * tints the amount and adds the Account Debt caption (recovery is a top-up,
- * never a plan). The $5 low-balance threshold deliberately does not tint
- * this persistent display — that voice belongs to notifications.
+ * Balance − DeductionBalance + usable credits across every active row, the
+ * upstream debt formula — with any remaining new-user gift (and only the
+ * gift: plan grants feed the total unlabeled) pinned beside it as a
+ * borderless chip. Debt (≤ 0) tints the amount and adds the Account Debt
+ * caption (recovery is a top-up, never a plan). The $5 low-balance threshold
+ * deliberately does not tint this persistent display — that voice belongs to
+ * notifications.
  */
 export function BillingBalanceValue({
   availableMicroUnits,
+  creditsResolved,
   currency,
   giftMicroUnits,
 }: {
   availableMicroUnits: number;
+  /**
+   * Whether the credits fetch has succeeded. While false the available
+   * figure is cash-only, so debt must not be voiced — unseen credits could
+   * still cover the account.
+   */
+  creditsResolved: boolean;
   currency: BillingCurrency;
   giftMicroUnits: number;
 }) {
-  const inDebt = availableMicroUnits <= 0;
+  const inDebt = creditsResolved && availableMicroUnits <= 0;
   return (
     <>
       <div className="flex flex-wrap items-baseline gap-2.5">

--- a/apps/ui/src/features/billing/billing-plan-surface.tsx
+++ b/apps/ui/src/features/billing/billing-plan-surface.tsx
@@ -779,6 +779,53 @@ export function BillingAiCreditsSection({
   );
 }
 
+/**
+ * The Account Balance figure (prototype D of AIM-313): the available total —
+ * Balance − DeductionBalance + usable gift credits, the upstream debt
+ * formula — with any gift pinned beside it as a borderless chip. Debt (≤ 0)
+ * tints the amount and adds the Account Debt caption (recovery is a top-up,
+ * never a plan). The $5 low-balance threshold deliberately does not tint
+ * this persistent display — that voice belongs to notifications.
+ */
+export function BillingBalanceValue({
+  availableMicroUnits,
+  currency,
+  giftMicroUnits,
+}: {
+  availableMicroUnits: number;
+  currency: BillingCurrency;
+  giftMicroUnits: number;
+}) {
+  const inDebt = availableMicroUnits <= 0;
+  return (
+    <>
+      <div className="flex flex-wrap items-baseline gap-2.5">
+        <p
+          className={cn(
+            "font-semibold text-2xl tabular-nums",
+            inDebt ? "text-red-400" : "text-foreground"
+          )}
+        >
+          {formatBillingAmount(availableMicroUnits, currency)}
+        </p>
+        {giftMicroUnits > 0 ? (
+          <Badge
+            className="self-center bg-blue-400/10 text-blue-400 tabular-nums"
+            variant="secondary"
+          >
+            Gift {formatBillingAmount(giftMicroUnits, currency)}
+          </Badge>
+        ) : null}
+      </div>
+      {inDebt ? (
+        <p className="text-red-400 text-xs">
+          Top up from the Sealos Desktop to restore your services.
+        </p>
+      ) : null}
+    </>
+  );
+}
+
 function BillingBalanceSection({
   balance,
   variant = "panel",

--- a/apps/ui/src/features/billing/billing-plan.interaction.test.tsx
+++ b/apps/ui/src/features/billing/billing-plan.interaction.test.tsx
@@ -445,6 +445,18 @@ const PLAN_PAGE_RESPONSES: Record<string, unknown> = {
   "/api/billing/account": {
     account: { Balance: 4_200_000, DeductionBalance: 1_200_000 },
   },
+  // A paid plan's own grant: the aggregate feeds the available total while
+  // the zero KYC pair keeps the Gift chip away.
+  "/api/billing/credits": {
+    credits: {
+      credits: 3_000_000,
+      currentPlanCreditsBalance: 3_000_000,
+      currentPlanCreditsDeductionBalance: 1_200_000,
+      deductionCredits: 1_200_000,
+      kycDeductionCreditsBalance: 0,
+      kycDeductionCreditsDeductionBalance: 0,
+    },
+  },
   "/api/billing/card": {
     payment_method: {
       card: { brand: "visa", exp_month: 12, exp_year: 2028, last4: "4242" },
@@ -760,6 +772,58 @@ test("Plan renders without waiting for the AI Credits request", async () => {
       assert.ok(text.includes("Account Balance"));
       assert.ok(rendered?.getByLabelText("Loading AI Credits"));
       assert.equal(text.includes("1,200 / 2,000"), false);
+    } finally {
+      await restore();
+    }
+  });
+});
+
+test("Account Balance composes cash and usable credits without a Gift chip", async () => {
+  // AIM-323 review: a paid plan's grant feeds the available total ($3.00
+  // cash + $1.80 plan credits) but must never be labeled Gift.
+  await withTestDom(async (act) => {
+    const { rendered, restore } = await renderPlanPage(act, (pathname) =>
+      jsonFixtureResponse(PLAN_PAGE_RESPONSES, pathname)
+    );
+
+    try {
+      const text = rendered?.container.textContent ?? "";
+      assert.ok(text.includes("Account Balance"));
+      assert.ok(text.includes("$4.80"), "cash + usable credits renders");
+      assert.equal(text.includes("Gift"), false, "plan credits are not Gift");
+    } finally {
+      await restore();
+    }
+  });
+});
+
+test("a failed credits request never voices Account Debt on cash alone", async () => {
+  // Cash-only ≤ 0 while credits are unknown: unseen credits could still
+  // cover the account, so the figure stays unvoiced instead of going red.
+  await withTestDom(async (act) => {
+    const responses = planPageResponses({
+      "/api/billing/account": {
+        account: { Balance: 0, DeductionBalance: 500_000 },
+      },
+    });
+    const { rendered, restore } = await renderPlanPage(act, (pathname) => {
+      if (pathname === "/api/billing/credits") {
+        return new Response(JSON.stringify({ error: "credits unavailable" }), {
+          headers: { "content-type": "application/json" },
+          status: 500,
+        });
+      }
+      return jsonFixtureResponse(responses, pathname);
+    });
+
+    try {
+      const text = rendered?.container.textContent ?? "";
+      assert.ok(text.includes("-$0.50"), "the cash figure still renders");
+      assert.equal(
+        text.includes("Top up from the Sealos Desktop"),
+        false,
+        "no debt caption without the credits term"
+      );
     } finally {
       await restore();
     }

--- a/apps/ui/src/features/billing/billing-plan.tsx
+++ b/apps/ui/src/features/billing/billing-plan.tsx
@@ -15,9 +15,12 @@ import { toast } from "sonner";
 import useSWR from "swr";
 import {
   type AccountBalance,
-  formatAccountBalance,
   loadAccountBalance,
 } from "@/features/billing/account-balance";
+import {
+  type AccountCredits,
+  loadAccountCredits,
+} from "@/features/billing/account-credits";
 import { loadAiCredits } from "@/features/billing/billing-ai-credits";
 import type { BillingCredentials } from "@/features/billing/billing-data-client";
 import { formatBillingDateTime } from "@/features/billing/billing-datetime";
@@ -42,10 +45,12 @@ import {
 } from "@/features/billing/billing-plan-data";
 import {
   BillingAiCreditsSection,
+  BillingBalanceValue,
   BillingPlanSurface,
 } from "@/features/billing/billing-plan-surface";
 import {
   accountBalanceSwrKey,
+  accountCreditsSwrKey,
   aiCreditsSwrKey,
   settleSubscriptionChange,
 } from "@/features/billing/billing-subscription-settlement";
@@ -268,9 +273,13 @@ function accountBalanceContent(input: {
   balance: AccountBalance | undefined;
   credentialsReady: boolean;
   error: unknown;
+  /** Undefined while loading or after a failed fetch — either renders as
+   *  no gift, so the figure quietly falls back to Balance − Deduction. */
+  giftCredits: AccountCredits | undefined;
+  giftCreditsLoading: boolean;
   isLoading: boolean;
 }): ReactNode {
-  if (!input.credentialsReady || input.isLoading) {
+  if (!input.credentialsReady || input.isLoading || input.giftCreditsLoading) {
     return (
       <Skeleton aria-label="Loading Account Balance" className="h-8 w-28" />
     );
@@ -285,10 +294,13 @@ function accountBalanceContent(input: {
   if (input.balance == null) {
     return null;
   }
+  const giftMicroUnits = input.giftCredits?.usableMicroUnits ?? 0;
   return (
-    <p className="font-semibold text-2xl text-foreground tabular-nums">
-      {formatAccountBalance(input.balance)}
-    </p>
+    <BillingBalanceValue
+      availableMicroUnits={input.balance.microUnits + giftMicroUnits}
+      currency={input.balance.currency}
+      giftMicroUnits={giftMicroUnits}
+    />
   );
 }
 
@@ -376,6 +388,11 @@ export function BillingPlan({
       ? accountBalanceSwrKey({ appToken, currency, kubeconfig })
       : null,
     () => loadAccountBalance({ appToken, currency, kubeconfig }),
+    { revalidateOnFocus: false, shouldRetryOnError: false }
+  );
+  const { data: giftCredits, isLoading: giftCreditsLoading } = useSWR(
+    credentialsReady ? accountCreditsSwrKey({ appToken, kubeconfig }) : null,
+    () => loadAccountCredits({ appToken, kubeconfig }),
     { revalidateOnFocus: false, shouldRetryOnError: false }
   );
   const {
@@ -616,6 +633,8 @@ export function BillingPlan({
             balance,
             credentialsReady,
             error: balanceError,
+            giftCredits,
+            giftCreditsLoading,
             isLoading: balanceLoading,
           })}
         </div>

--- a/apps/ui/src/features/billing/billing-plan.tsx
+++ b/apps/ui/src/features/billing/billing-plan.tsx
@@ -273,13 +273,13 @@ function accountBalanceContent(input: {
   balance: AccountBalance | undefined;
   credentialsReady: boolean;
   error: unknown;
-  /** Undefined while loading or after a failed fetch — either renders as
-   *  no gift, so the figure quietly falls back to Balance − Deduction. */
+  /** Undefined while loading or after a failed fetch — either renders the
+   *  cash figure alone (no chip) with the debt voice withheld, since unseen
+   *  credits could still cover the account. */
   giftCredits: AccountCredits | undefined;
-  giftCreditsLoading: boolean;
   isLoading: boolean;
 }): ReactNode {
-  if (!input.credentialsReady || input.isLoading || input.giftCreditsLoading) {
+  if (!input.credentialsReady || input.isLoading) {
     return (
       <Skeleton aria-label="Loading Account Balance" className="h-8 w-28" />
     );
@@ -294,12 +294,14 @@ function accountBalanceContent(input: {
   if (input.balance == null) {
     return null;
   }
-  const giftMicroUnits = input.giftCredits?.usableMicroUnits ?? 0;
   return (
     <BillingBalanceValue
-      availableMicroUnits={input.balance.microUnits + giftMicroUnits}
+      availableMicroUnits={
+        input.balance.microUnits + (input.giftCredits?.usableMicroUnits ?? 0)
+      }
+      creditsResolved={input.giftCredits != null}
       currency={input.balance.currency}
-      giftMicroUnits={giftMicroUnits}
+      giftMicroUnits={input.giftCredits?.giftMicroUnits ?? 0}
     />
   );
 }
@@ -390,7 +392,7 @@ export function BillingPlan({
     () => loadAccountBalance({ appToken, currency, kubeconfig }),
     { revalidateOnFocus: false, shouldRetryOnError: false }
   );
-  const { data: giftCredits, isLoading: giftCreditsLoading } = useSWR(
+  const { data: giftCredits } = useSWR(
     credentialsReady ? accountCreditsSwrKey({ appToken, kubeconfig }) : null,
     () => loadAccountCredits({ appToken, kubeconfig }),
     { revalidateOnFocus: false, shouldRetryOnError: false }
@@ -634,7 +636,6 @@ export function BillingPlan({
             credentialsReady,
             error: balanceError,
             giftCredits,
-            giftCreditsLoading,
             isLoading: balanceLoading,
           })}
         </div>

--- a/apps/ui/src/features/billing/billing-subscription-settlement.test.ts
+++ b/apps/ui/src/features/billing/billing-subscription-settlement.test.ts
@@ -19,6 +19,7 @@ async function until(condition: () => boolean, deadlineMs = 2000) {
 function settlementFetch(input: {
   quotaTotals: () => number | Error;
   onBalanceRequest?: () => void;
+  onCreditsRequest?: () => void;
   onQuotaRequest?: () => void;
 }): BillingFetch {
   return (requestInput) => {
@@ -27,6 +28,12 @@ function settlementFetch(input: {
       input.onBalanceRequest?.();
       return Promise.resolve(
         Response.json({ account: { Balance: 5_000_000, DeductionBalance: 0 } })
+      );
+    }
+    if (url === "/api/billing/credits") {
+      input.onCreditsRequest?.();
+      return Promise.resolve(
+        Response.json({ credits: { credits: 0, deductionCredits: 0 } })
       );
     }
     if (url === "/api/billing/workspace-quota") {
@@ -58,6 +65,7 @@ function credentials(workspace: string) {
 
 test("polls AI Credits until the total moves off the baseline, refreshing Account Balance once", async () => {
   let balanceRequests = 0;
+  let creditsRequests = 0;
   let quotaRequests = 0;
   const totals = [100, 100, 200];
   const cancel = settleSubscriptionChange({
@@ -66,6 +74,9 @@ test("polls AI Credits until the total moves off the baseline, refreshing Accoun
     fetch: settlementFetch({
       onBalanceRequest: () => {
         balanceRequests += 1;
+      },
+      onCreditsRequest: () => {
+        creditsRequests += 1;
       },
       onQuotaRequest: () => {
         quotaRequests += 1;
@@ -80,6 +91,7 @@ test("polls AI Credits until the total moves off the baseline, refreshing Accoun
   await sleep(60);
   assert.equal(quotaRequests, 3);
   assert.equal(balanceRequests, 1);
+  assert.equal(creditsRequests, 1);
   cancel();
 });
 

--- a/apps/ui/src/features/billing/billing-subscription-settlement.ts
+++ b/apps/ui/src/features/billing/billing-subscription-settlement.ts
@@ -5,6 +5,10 @@ import {
   loadAccountBalance,
 } from "@/features/billing/account-balance";
 import {
+  type AccountCredits,
+  loadAccountCredits,
+} from "@/features/billing/account-credits";
+import {
   type AiCredits,
   loadAiCredits,
 } from "@/features/billing/billing-ai-credits";
@@ -22,6 +26,17 @@ export function accountBalanceSwrKey(credentials: {
   return [
     "billing-account-balance",
     credentials.currency,
+    credentials.kubeconfig,
+    credentials.appToken,
+  ] as const;
+}
+
+export function accountCreditsSwrKey(credentials: {
+  appToken: string;
+  kubeconfig: string;
+}) {
+  return [
+    "billing-account-credits",
     credentials.kubeconfig,
     credentials.appToken,
   ] as const;
@@ -84,6 +99,14 @@ export function settleSubscriptionChange({
   mutate<AccountBalance>(
     accountBalanceSwrKey({ appToken, currency, kubeconfig }),
     loadAccountBalance({ appToken, currency, kubeconfig }, fetch),
+    { revalidate: false }
+  ).catch(() => undefined);
+
+  // Gift credits feed the same Account Balance figure (a plan purchase can
+  // grant plan credits upstream), so they refresh alongside it.
+  mutate<AccountCredits>(
+    accountCreditsSwrKey({ appToken, kubeconfig }),
+    loadAccountCredits({ appToken, kubeconfig }, fetch),
     { revalidate: false }
   ).catch(() => undefined);
 

--- a/apps/ui/src/features/billing/server/billing-route-table.ts
+++ b/apps/ui/src/features/billing/server/billing-route-table.ts
@@ -47,6 +47,12 @@ export const BILLING_ROUTES = {
     apiPath: "/api/billing/costs",
     upstreamPathname: "/account/v1alpha1/costs",
   },
+  // The one billing upstream outside the /account/v1alpha1 group: credits
+  // live in account-service's payment route group (AIM-315).
+  credits: {
+    apiPath: "/api/billing/credits",
+    upstreamPathname: "/payment/v1alpha1/credits/info",
+  },
   payments: {
     apiPath: "/api/billing/payments",
     upstreamPathname: "/account/v1alpha1/workspace-subscription/payment-list",

--- a/apps/ui/src/features/billing/server/dev-fixtures/dev-fixtures.test.ts
+++ b/apps/ui/src/features/billing/server/dev-fixtures/dev-fixtures.test.ts
@@ -135,9 +135,14 @@ test("every scenario passes every loader's schemas", async () => {
       `${scenario}: AI Credits load`
     );
     assert.equal(
-      giftCredits.usableMicroUnits,
+      giftCredits.giftMicroUnits,
       scenario === "free" ? 720_000 : 0,
       `${scenario}: only the Free trial carries an active gift credit`
+    );
+    assert.equal(
+      giftCredits.usableMicroUnits,
+      { active: 1_800_000, free: 720_000 }[scenario as string] ?? 0,
+      `${scenario}: the aggregate covers the gift or the plan grant alone`
     );
     if (CREDITLESS_SCENARIOS.has(scenario)) {
       assert.equal(

--- a/apps/ui/src/features/billing/server/dev-fixtures/dev-fixtures.test.ts
+++ b/apps/ui/src/features/billing/server/dev-fixtures/dev-fixtures.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { loadAccountBalance } from "../../account-balance";
+import { loadAccountCredits } from "../../account-credits";
 import { loadAiCredits } from "../../billing-ai-credits";
 import { loadBillingCosts } from "../../billing-costs-data";
 import type { BillingFetch } from "../../billing-data-client";
@@ -86,31 +87,39 @@ function loadPlanForScenario(scenario: string) {
 test("every scenario passes every loader's schemas", async () => {
   for (const scenario of BILLING_DEV_SCENARIOS) {
     const mockFetch = mockFetchFor(scenario);
-    const [plan, usage, pricing, costs, balance, credits] = await Promise.all([
-      loadBillingPlanSnapshot(CREDENTIALS, { fetch: mockFetch }),
-      loadBillingUsage(CREDENTIALS, { fetch: mockFetch }),
-      loadBillingPricing(CREDENTIALS, { fetch: mockFetch }),
-      loadBillingCosts(
-        {
-          appToken: CREDENTIALS.appToken,
-          dateRange: DATE_RANGE,
-          kubeconfig: CREDENTIALS.kubeconfig,
-          page: 1,
-          pageSize: 10,
-          workspace: null,
-        },
-        mockFetch
-      ),
-      loadAccountBalance(
-        {
-          appToken: CREDENTIALS.appToken,
-          currency: "usd",
-          kubeconfig: CREDENTIALS.kubeconfig,
-        },
-        mockFetch
-      ),
-      loadAiCredits(CREDENTIALS, mockFetch),
-    ]);
+    const [plan, usage, pricing, costs, balance, credits, giftCredits] =
+      await Promise.all([
+        loadBillingPlanSnapshot(CREDENTIALS, { fetch: mockFetch }),
+        loadBillingUsage(CREDENTIALS, { fetch: mockFetch }),
+        loadBillingPricing(CREDENTIALS, { fetch: mockFetch }),
+        loadBillingCosts(
+          {
+            appToken: CREDENTIALS.appToken,
+            dateRange: DATE_RANGE,
+            kubeconfig: CREDENTIALS.kubeconfig,
+            page: 1,
+            pageSize: 10,
+            workspace: null,
+          },
+          mockFetch
+        ),
+        loadAccountBalance(
+          {
+            appToken: CREDENTIALS.appToken,
+            currency: "usd",
+            kubeconfig: CREDENTIALS.kubeconfig,
+          },
+          mockFetch
+        ),
+        loadAiCredits(CREDENTIALS, mockFetch),
+        loadAccountCredits(
+          {
+            appToken: CREDENTIALS.appToken,
+            kubeconfig: CREDENTIALS.kubeconfig,
+          },
+          mockFetch
+        ),
+      ]);
     assert.equal(plan.plans.length, 9, `${scenario}: plan catalog loads`);
     assert.ok(usage.rows.length >= 5, `${scenario}: usage rows load`);
     assert.ok(pricing.prices.length >= 6, `${scenario}: metered prices load`);
@@ -124,6 +133,11 @@ test("every scenario passes every loader's schemas", async () => {
       Number.isFinite(credits.usedMicroUnits) &&
         Number.isFinite(credits.totalMicroUnits),
       `${scenario}: AI Credits load`
+    );
+    assert.equal(
+      giftCredits.usableMicroUnits,
+      scenario === "free" ? 720_000 : 0,
+      `${scenario}: only the Free trial carries an active gift credit`
     );
     if (CREDITLESS_SCENARIOS.has(scenario)) {
       assert.equal(

--- a/apps/ui/src/features/billing/server/dev-fixtures/index.ts
+++ b/apps/ui/src/features/billing/server/dev-fixtures/index.ts
@@ -735,6 +735,26 @@ const FIXTURES: Record<string, (context: FixtureContext) => unknown> = {
       },
     };
   },
+  // account-service serializes its CreditsInfoReq struct under "credits";
+  // the balance fields mirror the account fixture. Only `free` carries an
+  // active gift (the $1 newbie grant, partly consumed) — every other
+  // scenario reports none, so the Plan view shows the bare number.
+  "/payment/v1alpha1/credits/info": ({ scenario }) => {
+    const inDebt = DEBT_SCENARIOS.has(scenario);
+    const gift = scenario === "free";
+    return {
+      credits: {
+        balance: inDebt ? 5_000_000 : 128_000_000,
+        credits: gift ? 1_000_000 : 0,
+        currentPlanCreditsBalance: gift ? 1_000_000 : 0,
+        currentPlanCreditsDeductionBalance: gift ? 280_000 : 0,
+        deductionBalance: inDebt ? 11_320_000 : 23_450_000,
+        deductionCredits: gift ? 280_000 : 0,
+        kycDeductionCreditsBalance: gift ? 1_000_000 : 0,
+        kycDeductionCreditsDeductionBalance: gift ? 280_000 : 0,
+      },
+    };
+  },
 };
 
 interface WriteFixtureResult {

--- a/apps/ui/src/features/billing/server/dev-fixtures/index.ts
+++ b/apps/ui/src/features/billing/server/dev-fixtures/index.ts
@@ -737,21 +737,31 @@ const FIXTURES: Record<string, (context: FixtureContext) => unknown> = {
   },
   // account-service serializes its CreditsInfoReq struct under "credits";
   // the balance fields mirror the account fixture. Only `free` carries an
-  // active gift (the $1 newbie grant, partly consumed) — every other
-  // scenario reports none, so the Plan view shows the bare number.
+  // active gift (the $1 newbie grant, partly consumed; upstream copies the
+  // KYC pair from the current-plan pair on a Free trial, so they match).
+  // `active` instead carries a current-plan grant with no gift — the
+  // aggregate exceeds the KYC pair, so the Plan view must show the higher
+  // available total without a Gift chip. Every other scenario reports no
+  // credits, so debt scenarios stay red on cash alone.
   "/payment/v1alpha1/credits/info": ({ scenario }) => {
     const inDebt = DEBT_SCENARIOS.has(scenario);
     const gift = scenario === "free";
+    let grant = { balance: 0, used: 0 };
+    if (gift) {
+      grant = { balance: 1_000_000, used: 280_000 };
+    } else if (scenario === "active") {
+      grant = { balance: 3_000_000, used: 1_200_000 };
+    }
     return {
       credits: {
         balance: inDebt ? 5_000_000 : 128_000_000,
-        credits: gift ? 1_000_000 : 0,
-        currentPlanCreditsBalance: gift ? 1_000_000 : 0,
-        currentPlanCreditsDeductionBalance: gift ? 280_000 : 0,
+        credits: grant.balance,
+        currentPlanCreditsBalance: grant.balance,
+        currentPlanCreditsDeductionBalance: grant.used,
         deductionBalance: inDebt ? 11_320_000 : 23_450_000,
-        deductionCredits: gift ? 280_000 : 0,
-        kycDeductionCreditsBalance: gift ? 1_000_000 : 0,
-        kycDeductionCreditsDeductionBalance: gift ? 280_000 : 0,
+        deductionCredits: grant.used,
+        kycDeductionCreditsBalance: gift ? grant.balance : 0,
+        kycDeductionCreditsDeductionBalance: gift ? grant.used : 0,
       },
     };
   },


### PR DESCRIPTION
## Summary

New users get a $1 gift credit, but nothing in the UI showed it — deployments quietly ate the grant. The Plan view's **Account Balance** block now presents the available amount and names the gift while it lasts:

- **Main figure = available amount**: `Balance − DeductionBalance + usable gift credit` — the same formula the platform's debt pipeline judges an account by, so the number a user sees and the number that suspends them never disagree.
- **Gift chip**: while usable gift credit remains, a borderless `Badge` (`bg-blue-400/10 text-blue-400`) sits beside the figure: `Gift $0.72`. Spent or absent → bare number.
- **Account Debt state**: available ≤ 0 tints the amount `text-red-400` and adds one caption line — "Top up from the Sealos Desktop to restore your services." (top-up voice, never a subscription).
- **Deliberately not done**: the $5 low-balance threshold does not tint or caption here (that belongs to notifications); no burn rate, no breakdown, no links.

## Implementation

- **New proxy route** `/api/billing/credits` → account-service `credits/info`, the one billing upstream outside the `/account/v1alpha1` group. Standard `createBillingRoute` (authorized proxy + dev-mock interception); the route table guard and dev-mock contract tests pick it up automatically.
- **`account-credits.ts` loader**: usable = `credits − deductionCredits`, clamped at zero. On fetch failure the block degrades quietly to the bare cash figure — no chip, no error state.
- **`BillingBalanceValue`** lives beside `BillingBalanceSection`; both card and panel branches render the same balance node, so one component covers both.
- **Settlement**: `settleSubscriptionChange` refreshes the gift-credit cache alongside the balance (a plan purchase can grant plan credits upstream).
- **Dev mock**: the `free` scenario now carries a partly consumed gift ($0.72 usable); debt scenarios keep zero credits so the red state shows.
- **CONTEXT.md**: Account Balance redefined as the available amount; new **Gift Credit** term.

The chip carries no expiry date yet — no user-facing account-service endpoint serves the Credits rows' `expire_at` (`credits/list` is declared upstream but never registered). Tracked in labring/sealos-private#117; once an expiry field lands, the chip only needs the date appended.

## Testing

- `bun check` clean; `bun typecheck` fails only on the pre-existing `preview-canvas-perf/page.tsx` error (verified present on clean `main` via stash).
- New tests: `account-credits.test.ts`, dev-fixtures contract pass for all scenarios (only `free` carries a gift), three `BillingBalanceValue` state renders (chip / bare / debt), settlement asserts one credits refresh. Billing suite green per file; the two `billing-plan-surface.interaction` failures pre-date this branch (verified on clean `main`).
- Verified in the running app via the billing dev mock: `free` shows **$105.27 + Gift $0.72 chip**; `payment-due` shows red **-$6.32** with the top-up caption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)