### PR TITLE
fix(shell): align the account popover columns and anchor it to the rail button

### DIFF
--- a/apps/ui/src/features/shell/app-sidebar-account.tsx
+++ b/apps/ui/src/features/shell/app-sidebar-account.tsx
@@ -181,7 +181,7 @@ function AppSidebarUsageRow({
       <AppSidebarQuotaBar percent={row.percent} />
       <span
         className={cn(
-          "shrink-0 text-right text-xs tabular-nums",
+          "w-13 shrink-0 text-right text-xs tabular-nums",
           tone == null ? undefined : HINT_TEXT_CLASS[tone]
         )}
       >
@@ -235,7 +235,9 @@ function AppSidebarUsageRowSkeleton({
         </span>
       )}
       <span className="block h-1 min-w-0 flex-1 rounded-full bg-input/50" />
-      <Skeleton className="h-3 w-10 shrink-0 rounded-sm" />
+      <span className="flex w-13 shrink-0 justify-end">
+        <Skeleton className="h-3 w-10 rounded-sm" />
+      </span>
     </div>
   );
 }
@@ -385,7 +387,7 @@ function AppSidebarUsageSection({
       <AppSidebarUsageRow
         className={aiJustFilled ? USAGE_FILL_CLASS : undefined}
         label={aiRow.label}
-        labelClassName="whitespace-nowrap"
+        labelClassName="w-15 truncate"
         row={aiRow}
         slot="app-sidebar-ai-usage-row"
       />
@@ -394,7 +396,7 @@ function AppSidebarUsageSection({
     aiSlot = (
       <AppSidebarUsageRowSkeleton
         label={aiSkeletonLabel}
-        labelClassName="whitespace-nowrap"
+        labelClassName="w-15 truncate"
         slot="app-sidebar-ai-usage-skeleton"
       />
     );
@@ -406,7 +408,7 @@ function AppSidebarUsageSection({
         className={quotaJustFilled ? USAGE_FILL_CLASS : undefined}
         key={row.label}
         label={row.label === "Memory" ? "Mem" : row.label}
-        labelClassName="w-10"
+        labelClassName="w-15"
         row={row}
         slot="app-sidebar-quota-row"
       />
@@ -416,7 +418,7 @@ function AppSidebarUsageSection({
       <AppSidebarUsageRowSkeleton
         key={label}
         label={label}
-        labelClassName="w-10"
+        labelClassName="w-15"
         slot="app-sidebar-quota-skeleton"
       />
     ));
@@ -425,7 +427,7 @@ function AppSidebarUsageSection({
     return null;
   }
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="flex flex-col gap-2">
       {aiSlot}
       {quotaSlot}
     </div>
@@ -470,7 +472,7 @@ function AppSidebarAccountMenuRow({
       rel={rel}
       target={target}
     >
-      <span className="flex w-5 shrink-0 items-center justify-center text-neutral-50 transition-colors group-hover/menurow:text-blue-400">
+      <span className="flex w-6 shrink-0 items-center justify-center text-neutral-50 transition-colors group-hover/menurow:text-blue-400">
         {icon}
       </span>
       <span className="min-w-0 flex-1 truncate">{label}</span>
@@ -555,7 +557,7 @@ function AppSidebarUsageAccordion({
         >
           <span
             className={cn(
-              "flex w-5 shrink-0 items-center justify-center transition-colors group-hover/menurow:text-blue-400",
+              "flex w-6 shrink-0 items-center justify-center transition-colors group-hover/menurow:text-blue-400",
               open ? "text-blue-400" : "text-neutral-50"
             )}
           >
@@ -581,9 +583,7 @@ function AppSidebarUsageAccordion({
           )}
         >
           <div className="min-h-0 overflow-hidden">
-            <div className="px-2.5 pt-1.5 pb-2.5 [&>div]:gap-2">
-              {usageSection}
-            </div>
+            <div className="px-2.5 pt-1.5 pb-2.5">{usageSection}</div>
           </div>
         </div>
       </div>
@@ -892,7 +892,7 @@ export function AppSidebarAccount() {
           )}
         />
         <span
-          className="relative flex w-9 shrink-0 items-center justify-center"
+          className="relative flex w-9 shrink-0 items-center justify-center self-stretch"
           ref={iconSlotRef}
         >
           <AppSidebarAccountAvatar
@@ -939,9 +939,9 @@ export function AppSidebarAccount() {
           convention for popovers) — the default trigger anchor sits at the
           clipped full-width row's edge, far past the visible rail. */}
       <PopoverContent
-        align="start"
+        align={expanded ? "start" : "end"}
         anchor={expanded ? undefined : iconSlotRef}
-        className="w-56 gap-0 rounded-lg border border-border bg-input/30 p-3 text-brand-primary-foreground shadow-none ring-0 backdrop-blur-xl"
+        className="w-58 gap-0 rounded-lg border border-border bg-input/30 p-3 text-brand-primary-foreground shadow-none ring-0 backdrop-blur-xl"
         side={expanded ? "top" : "right"}
         sideOffset={6}
       >

--- a/apps/ui/src/features/shell/app-sidebar-ai-usage.test.ts
+++ b/apps/ui/src/features/shell/app-sidebar-ai-usage.test.ts
@@ -9,7 +9,7 @@ import {
 test("aiUsageRowFromFreeTurns renders the trial allowance as counted turns", () => {
   assert.deepEqual(
     aiUsageRowFromFreeTurns({ limit: 5, remaining: 3, used: 2 }),
-    { label: "Free trial messages", percent: 40, value: "2/5" }
+    { label: "Free msgs", percent: 40, value: "2/5" }
   );
 });
 

--- a/apps/ui/src/features/shell/app-sidebar-ai-usage.ts
+++ b/apps/ui/src/features/shell/app-sidebar-ai-usage.ts
@@ -6,8 +6,13 @@ import {
 import type { FreeChatTurnsUsage } from "@/features/chat/persistence/client";
 import type { AppSidebarQuotaRow } from "@/features/shell/app-sidebar-quota";
 
-/** The AI slot's user-visible labels — the popover skeleton reuses them. */
-export const FREE_TRIAL_MESSAGES_ROW_LABEL = "Free trial messages";
+/**
+ * The AI slot's user-visible labels — the popover skeleton reuses them.
+ * The free-turns label is the compact sidebar form of "Free trial messages"
+ * (the full label the Billing Plan view keeps): the popover's fixed label
+ * column would truncate the full phrase.
+ */
+export const FREE_TRIAL_MESSAGES_ROW_LABEL = "Free msgs";
 export const AI_CREDITS_ROW_LABEL = "AI Credits";
 
 /**

--- a/apps/ui/src/features/shell/app-sidebar.test.tsx
+++ b/apps/ui/src/features/shell/app-sidebar.test.tsx
@@ -73,7 +73,7 @@ const ACCOUNT_NAME_RE = /Ada Lovelace/;
 const ACCOUNT_ID_RE = new RegExp(`ID: ${ACCOUNT_USER.id}`);
 const AI_CREDITS_LABEL_RE = /AI Credits/;
 const AI_CREDITS_VALUE_RE = /240\/300/;
-const FREE_TURNS_LABEL_RE = /Free trial messages/;
+const FREE_TURNS_LABEL_RE = /Free msgs/;
 const FREE_TURNS_VALUE_RE = /5\/5/;
 
 function proSubscription(


### PR DESCRIPTION
## What

Fixes the App Sidebar account popover's alignment issues, both outside and inside the panel:

- **Collapsed rail anchoring**: the popover now bottom-aligns to the account button (`align="end"`), and the icon-slot anchor stretches to the button's full height — previously the anchor collapsed to the 24px avatar, leaving the popover's bottom edge 6px above the button and detached-looking under collision shifting.
- **Popover width**: `w-56 → w-58` (232px) to give the usage bars room.
- **One label column**: menu-row icon slot `w-5 → w-6`, so the identity-row name and the menu-row labels share a single vertical line.
- **Table-style usage rows**: unified `w-15` label column and `w-13` right-aligned value column — all six bars (AI Credits + 5 quota rows) now share both edges; skeletons keep identical geometry so data arriving never shifts the popover.
- **Spacing**: row gap unified to `gap-2`, set on `AppSidebarUsageSection` itself instead of the parent's implicit `[&>div]:gap-2` override.
- **Free-turns label**: the sidebar row uses the compact "Free msgs" (the Billing Plan view keeps the full "Free trial messages") — the unified label column would truncate the full phrase.

Design study and layout variants were prototyped first; the prototype is kept on branch `prototype/account-popover-v2`.

## Verification

- Measured in the browser: popover bottom edge flush with the button's bounds (same y), all six bar start/end positions and value right edges identical across rows.
- `bun test` — 26 tests across `app-sidebar.test.tsx` and `app-sidebar-ai-usage.test.ts` pass.
- `bun check` clean. `bun typecheck`'s only error (`preview-canvas-perf/page.tsx`) pre-exists on `main` and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)