### PR TITLE
fix(chat): correct Devbox Skill discovery shell loop

### DIFF
--- a/apps/ui/src/features/chat/tool/devbox-skills.test.ts
+++ b/apps/ui/src/features/chat/tool/devbox-skills.test.ts
@@ -1,5 +1,6 @@
 import { test } from "bun:test";
 import assert from "node:assert/strict";
+import { spawn } from "bun";
 import type { ChatDevboxSandbox } from "@/features/chat/devbox/chat-runtime";
 import {
   discoverChatDevboxSkills,
@@ -28,6 +29,34 @@ function createSandbox(files: Record<string, string>): ChatDevboxSandbox {
     writeFiles: () => Promise.resolve(),
   };
 }
+
+function createLocalBashSandbox(): ChatDevboxSandbox {
+  return {
+    executeCommand: async (command) => {
+      const child = spawn(["bash", "-c", command], {
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [exitCode, stderr, stdout] = await Promise.all([
+        child.exited,
+        new Response(child.stderr).text(),
+        new Response(child.stdout).text(),
+      ]);
+      return { exitCode, stderr, stdout };
+    },
+    getDevboxName: async () => "chat-runtime",
+    readFile: () => Promise.reject(new Error("unexpected Skill file read")),
+    runWithAbortSignal: async (_signal, operation) => await operation(),
+    stop: () => Promise.resolve(),
+    writeFiles: () => Promise.resolve(),
+  };
+}
+
+test("Skill discovery emits valid Bash", async () => {
+  await assert.doesNotReject(
+    discoverChatDevboxSkills(createLocalBashSandbox())
+  );
+});
 
 test("discovers user-facing Skills from both supported Devbox roots", async () => {
   const deployPath =

--- a/apps/ui/src/features/chat/tool/devbox-skills.ts
+++ b/apps/ui/src/features/chat/tool/devbox-skills.ts
@@ -78,9 +78,7 @@ function isInternalChatSkill(name: string): boolean {
 function skillDiscoveryCommand(): string {
   return [
     "set -euo pipefail",
-    "for skill_root in",
-    ...SKILL_ROOTS.map((root) => `  ${root}`),
-    "do",
+    `for skill_root in ${SKILL_ROOTS.map((root) => `"${root}"`).join(" ")}; do`,
     '  if [ -d "$skill_root" ]; then',
     '    find "$skill_root" -mindepth 2 -maxdepth 2 -type f -name SKILL.md -print',
     "  fi",


### PR DESCRIPTION
## Summary

- generate a valid Bash loop when discovering Skills in Chat Devboxes
- quote both supported Skill roots
- add a regression test that executes the generated command with Bash

## Root cause

The generated command placed a newline immediately after `for skill_root in`, so Bash ended the loop header before reading the root paths and reported an unexpected token.

## Verification

- `bun test src/features/chat/tool/devbox-skills.test.ts`
- `bun check`
- `bun typecheck`