### PR TITLE
feat(shell): App Sidebar defaults to Collapsed with a one-time reset

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,7 +22,7 @@ _Avoid_: Favorite Project, starred Project, recent Project.
 
 ### App Sidebar
 
-The persistent left-edge product navigation surface containing product-level navigation, Project navigation (Pinned Projects and all other Projects), and app-level actions. It is outside the Project Canvas and is not a Side Pane or a Project list. It has exactly two user-controlled states, and these are their canonical names: **Expanded** (icons with text labels) and **Collapsed** (an icon rail with tooltips). State changes only by explicit user action and is independent of viewport width.
+The persistent left-edge product navigation surface containing product-level navigation, Project navigation (Pinned Projects and all other Projects), and app-level actions. It is outside the Project Canvas and is not a Side Pane or a Project list. It has exactly two user-controlled states, and these are their canonical names: **Expanded** (icons with text labels) and **Collapsed** (an icon rail with tooltips). Before the user has ever changed it, the App Sidebar is Collapsed; thereafter the user's last chosen state is remembered per browser. State changes only by explicit user action and is independent of viewport width.
 
 _Avoid_: Project list, left Side Pane, Project Shortcut (retired term), open/closed sidebar, full/mini sidebar, rail mode.
 

--- a/apps/ui/src/features/shell/app-sidebar-cookie-bridge.tsx
+++ b/apps/ui/src/features/shell/app-sidebar-cookie-bridge.tsx
@@ -9,7 +9,7 @@ export async function AppSidebarCookieBridge({
   children: ReactNode;
 }) {
   const cookieStore = await cookies();
-  const defaultOpen = cookieStore.get(SIDEBAR_COOKIE_NAME)?.value !== "false";
+  const defaultOpen = cookieStore.get(SIDEBAR_COOKIE_NAME)?.value === "true";
 
   return (
     <AppSidebarShell defaultOpen={defaultOpen}>{children}</AppSidebarShell>

--- a/apps/ui/src/features/shell/app-sidebar.test.tsx
+++ b/apps/ui/src/features/shell/app-sidebar.test.tsx
@@ -186,7 +186,8 @@ await moduleDom.restore();
 
 async function withSidebar(
   run: () => void | Promise<void>,
-  defaultOpen = true,
+  // "unset" omits the prop so the scenario exercises the shell's own default.
+  defaultOpen: boolean | "unset" = true,
   beforeRender?: () => void
 ): Promise<void> {
   const dom = installTestDom();
@@ -198,7 +199,9 @@ async function withSidebar(
     await actAndDrain(() => {
       rendered = render(
         <JotaiProvider>
-          <AppSidebarShell defaultOpen={defaultOpen}>
+          <AppSidebarShell
+            {...(defaultOpen === "unset" ? {} : { defaultOpen })}
+          >
             <AppSidebar />
           </AppSidebarShell>
         </JotaiProvider>
@@ -247,7 +250,13 @@ function cookieValue(name: string): string | undefined {
     ?.slice(prefix.length);
 }
 
-test("app sidebar defaults to Expanded and collapses from the header button", async () => {
+test("the shell renders Collapsed when no remembered state is provided", async () => {
+  await withSidebar(() => {
+    assert.equal(sidebarState(), "collapsed");
+  }, "unset");
+});
+
+test("a remembered Expanded state renders Expanded and collapses from the header button", async () => {
   await withSidebar(async () => {
     assert.equal(sidebarState(), "expanded");
     const collapse = document.querySelector<HTMLButtonElement>(

--- a/apps/ui/src/features/shell/app-sidebar.tsx
+++ b/apps/ui/src/features/shell/app-sidebar.tsx
@@ -636,7 +636,7 @@ function AppSidebarChrome({
 
 export function AppSidebarShell({
   children,
-  defaultOpen = true,
+  defaultOpen = false,
 }: {
   children: ReactNode;
   defaultOpen?: boolean;

--- a/packages/ui/src/lib/sidebar-cookie.ts
+++ b/packages/ui/src/lib/sidebar-cookie.ts
@@ -1,2 +1,4 @@
-export const SIDEBAR_COOKIE_NAME = "sidebar_state";
+// v2: renamed from "sidebar_state" to reset every remembered state once when
+// the default flipped to Collapsed; old cookies are simply ignored.
+export const SIDEBAR_COOKIE_NAME = "sidebar_state_v2";
 export const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;


### PR DESCRIPTION
## What

- First visit (no remembered state): the App Sidebar renders **Collapsed** instead of Expanded.
- A user's explicit expand/collapse is still remembered per browser and always wins over the default.
- The state cookie is renamed `sidebar_state` → `sidebar_state_v2`, so everyone's remembered state resets once at the flip; old cookies are ignored and expire on their own.

## Changes

- `apps/ui/.../app-sidebar-cookie-bridge.tsx` — no remembered state now falls to Collapsed (`=== "true"` instead of `!== "false"`).
- `apps/ui/.../app-sidebar.tsx` — `AppSidebarShell` prop default flipped to `defaultOpen = false`.
- `packages/ui/src/lib/sidebar-cookie.ts` — cookie renamed for the one-time reset; single source for both the server-side reader and the client-side writer.
- `apps/ui/.../app-sidebar.test.tsx` — new case: omitting the prop renders Collapsed; the old "defaults to Expanded" test renamed to what it actually exercises (a remembered Expanded state).
- `CONTEXT.md` — App Sidebar entry now states the pre-choice state is Collapsed and the last choice is remembered per browser.

The shared `SidebarProvider` in `packages/ui` keeps its upstream `defaultOpen = true`; the app layer decides the default.

## Verification

- `bun test src/features/shell/app-sidebar.test.tsx` — 22 pass.
- Root `bun check` — clean.
- `bun typecheck` — only the pre-existing `preview-canvas-perf/page.tsx` error, present on clean `main` (verified via stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VqPE4JzFsZ3X2u8BXtzqH