### PR TITLE
feat(chat): wall zero-allowance plans with a truthful cause (ADR-0073)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -528,7 +528,7 @@ _Avoid_: wallet, credits (for a PAYG workspace), balance (for a subscribed works
 
 ### Paid Chat Wall
 
-The pre-send refusal of a `user` turn that has nothing to spend: a billing callout in the card slot naming the fix, and a locked composer stating why. Its cause is an exhausted Paid Source (AI Credits, or the Account Balance in Account Debt) or a plan that grants no AI allowance at all — the platform Free plan carries none, so an Active Free Trial that spends its last Free Chat Turn meets the allowance cause, not a spendable source. Paid Source causes lock at once; an allowance cause stages — an advisory notice with an open composer until a send is actually refused, the locked wall from then on. Still the only Chat Billing state that locks the composer — a Billing Interruption behind an error card locks nothing, because the next send re-gates.
+The pre-send refusal of a `user` turn that has nothing to spend: a billing callout in the card slot naming the fix, and a locked composer stating why. Its cause is an exhausted Paid Source (AI Credits, or the Account Balance in Account Debt) or a plan that grants no AI allowance at all — the platform Free plan carries none, so an Active Free Trial that spends its last Free Chat Turn meets the allowance cause, not a spendable source. Every cause locks at once. Still the only Chat Billing state that locks the composer — a Billing Interruption behind an error card locks nothing, because the next send re-gates.
 
 _Avoid_: paywall, quota exceeded (for chat), chat disabled.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -528,13 +528,13 @@ _Avoid_: wallet, credits (for a PAYG workspace), balance (for a subscribed works
 
 ### Paid Chat Wall
 
-The pre-send refusal of a `user` turn whose Paid Source is exhausted: a billing callout in the card slot naming the fix, and a locked composer stating why. The only Chat Billing state that locks the composer — a Billing Interruption behind an error card locks nothing, because the next send re-gates.
+The pre-send refusal of a `user` turn that has nothing to spend: a billing callout in the card slot naming the fix, and a locked composer stating why. Its cause is an exhausted Paid Source (AI Credits, or the Account Balance in Account Debt) or a plan that grants no AI allowance at all — the platform Free plan carries none, so an Active Free Trial that spends its last Free Chat Turn meets the allowance cause, not a spendable source. Paid Source causes lock at once; an allowance cause stages — an advisory notice with an open composer until a send is actually refused, the locked wall from then on. Still the only Chat Billing state that locks the composer — a Billing Interruption behind an error card locks nothing, because the next send re-gates.
 
 _Avoid_: paywall, quota exceeded (for chat), chat disabled.
 
 ### Free Chat Turns
 
-A platform-funded allowance of Chat Agent turns per namespace (user-visible label: Free trial messages), spendable only during the workspace's Active Free Trial through `SYSTEM_OPENAI_API_KEY` and `SYSTEM_OPENAI_API_BASE_URL`; a turn is reserved when it starts and returned if it fails, so only successfully completed turns stay spent. A lifetime entitlement counter — namespace-shared, never per-user, never reset — not a rate limit; exhausting it hands subsequent turns to `user` billing through the caller's AI Proxy.
+A platform-funded allowance of Chat Agent turns per namespace (user-visible label: Free trial messages), spendable only during the workspace's Active Free Trial through `SYSTEM_OPENAI_API_KEY` and `SYSTEM_OPENAI_API_BASE_URL`; a turn is reserved when it starts and returned if it fails, so only successfully completed turns stay spent. A lifetime entitlement counter — namespace-shared, never per-user, never reset — not a rate limit; exhausting it hands subsequent turns to `user` billing through the caller's AI Proxy, where a plan without an AI allowance is refused by the Paid Chat Wall's allowance cause (ADR-0073).
 
 _Avoid_: free tier, trial credits, free assistant messages, free messages.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -528,7 +528,7 @@ _Avoid_: wallet, credits (for a PAYG workspace), balance (for a subscribed works
 
 ### Paid Chat Wall
 
-The pre-send refusal of a `user` turn that has nothing to spend: a billing callout in the card slot naming the fix, and a locked composer stating why. Its cause is an exhausted Paid Source (AI Credits, or the Account Balance in Account Debt) or a plan that grants no AI allowance at all — the platform Free plan carries none, so an Active Free Trial that spends its last Free Chat Turn meets the allowance cause, not a spendable source. Every cause locks at once. Still the only Chat Billing state that locks the composer — a Billing Interruption behind an error card locks nothing, because the next send re-gates.
+The pre-send refusal of a `user` turn that has nothing to spend: a billing callout in the card slot naming the fix, and a locked composer stating why. Its cause is an exhausted Paid Source (AI Credits, or the Account Balance in Account Debt) or a plan that grants no AI allowance at all — the platform Free plan carries none, so an Active Free Trial that spends its last Free Chat Turn meets the allowance cause, not a spendable source. Every cause locks at once. The allowance cause is the one chat surface that says "plan" ("AI usage not included", `allowance-plan`): the Subscription Plan itself is the cause, so naming it is the truthful fix, and Chat Billing Mode's avoidance of the word stands everywhere else. Still the only Chat Billing state that locks the composer — a Billing Interruption behind an error card locks nothing, because the next send re-gates.
 
 _Avoid_: paywall, quota exceeded (for chat), chat disabled.
 

--- a/apps/ui/src/app/api/chat/free-turns/route.test.ts
+++ b/apps/ui/src/app/api/chat/free-turns/route.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, expect, mock, test } from "bun:test";
+
+import { BILLING_DEV_MOCK_COOKIE } from "@/features/billing/dev-mock-cookie";
+
+/**
+ * Pins the billing Dev Mock's answer on Brain's own free-turns route
+ * (ADR-0073): a named scenario shapes the sidebar's usage row and the Plan
+ * view's allowance card from the fixture, an absent cookie reaches the real
+ * handler, and a typo fails loud instead of falling through.
+ */
+
+let realHandlerCalls = 0;
+
+mock.module("@/features/chat/runtime/conversation-route-handlers", () => ({
+  assistantConversationRouteHandlers: {
+    freeTurns: () => {
+      realHandlerCalls += 1;
+      return Promise.resolve(Response.json({ real: true }));
+    },
+  },
+}));
+
+const { GET } = await import("./route");
+
+function freeTurnsRequest(scenario?: string): Request {
+  const request = new Request(
+    "http://localhost/api/chat/free-turns?namespace=ns-test"
+  );
+  if (scenario !== undefined) {
+    request.headers.set("cookie", `${BILLING_DEV_MOCK_COOKIE}=${scenario}`);
+  }
+  return request;
+}
+
+beforeEach(() => {
+  realHandlerCalls = 0;
+});
+
+test.each([
+  { scenario: "free", turns: { limit: 5, remaining: 3, used: 2 } },
+  { scenario: "free-expiring", turns: { limit: 5, remaining: 0, used: 5 } },
+  { scenario: "free-expired", turns: { limit: 5, remaining: 0, used: 5 } },
+])("$scenario answers the free-turns fixture without reaching the real handler", async ({
+  scenario,
+  turns,
+}) => {
+  const response = await GET(freeTurnsRequest(scenario));
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual(turns);
+  expect(realHandlerCalls).toBe(0);
+});
+
+test("an absent cookie falls through to the real handler", async () => {
+  const response = await GET(freeTurnsRequest());
+
+  expect(await response.json()).toEqual({ real: true });
+  expect(realHandlerCalls).toBe(1);
+});
+
+test("an unknown scenario fails loud instead of falling through", async () => {
+  const response = await GET(freeTurnsRequest("no-such-scenario"));
+
+  expect(response.status).toBe(500);
+  const body = (await response.json()) as { error: string };
+  expect(body.error).toContain("no-such-scenario");
+  expect(body.error).toContain("free-expiring");
+  expect(realHandlerCalls).toBe(0);
+});

--- a/apps/ui/src/app/api/chat/free-turns/route.ts
+++ b/apps/ui/src/app/api/chat/free-turns/route.ts
@@ -3,4 +3,36 @@ import { assistantConversationRouteHandlers } from "@/features/chat/runtime/conv
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export const GET = assistantConversationRouteHandlers.freeTurns;
+/**
+ * The billing Dev Mock answers this Brain-owned route too (dev/demo builds
+ * only): the sidebar's AI-usage row and the Plan view's allowance card read
+ * their Free Chat Turns here, so a Mock Scenario must shape them alongside
+ * the `/api/billing/*` proxies. The dynamic-import gate stays inlined so
+ * fixtures never enter production bundles (dev-mock/server/resolve.ts).
+ */
+async function freeTurnsDevMockResponse(
+  request: Request
+): Promise<Response | null> {
+  if (
+    process.env.NODE_ENV === "production" &&
+    process.env.NEXT_PUBLIC_DEV_TWEAKS !== "1"
+  ) {
+    return null;
+  }
+  const { freeChatTurnsFixture, resolveBillingDevMock } = await import(
+    "@/features/billing/server/dev-fixtures"
+  );
+  const resolution = resolveBillingDevMock(request);
+  if (resolution.kind === "off") {
+    return null;
+  }
+  if (resolution.kind === "invalid") {
+    return resolution.response;
+  }
+  return Response.json(freeChatTurnsFixture(resolution.scenario));
+}
+
+export const GET = async (request: Request): Promise<Response> => {
+  const mocked = await freeTurnsDevMockResponse(request);
+  return mocked ?? assistantConversationRouteHandlers.freeTurns(request);
+};

--- a/apps/ui/src/app/api/chat/route.test.ts
+++ b/apps/ui/src/app/api/chat/route.test.ts
@@ -1635,9 +1635,26 @@ test.each([
   expect(reserveCalls).toBe(0);
 });
 
-test("walls an exhausted trial on a zero-allowance plan with the trial voice (ADR-0073)", async () => {
-  freeTierSnapshot = { limit: 5, remaining: 0, used: 5 };
-  trialJudgment = "trial";
+test.each([
+  {
+    freeTier: { limit: 5, remaining: 0, used: 5 },
+    trial: "trial" as const,
+    wall: "allowance-trial",
+  },
+  {
+    freeTier: { limit: 5, remaining: 5, used: 0 },
+    trial: "not-trial" as const,
+    wall: "allowance-plan",
+  },
+])("walls a zero-allowance plan before any state mutates, voiced as $wall (ADR-0073)", async ({
+  freeTier,
+  trial,
+  wall,
+}) => {
+  // The production Free plan grants no AI Credits (total 0): an exhausted
+  // Active Free Trial meets the trial voice, every other plan the plan voice.
+  freeTierSnapshot = freeTier;
+  trialJudgment = trial;
   billingStanding = {
     ...billingStanding,
     accountDebt: false,
@@ -1646,13 +1663,17 @@ test("walls an exhausted trial on a zero-allowance plan with the trial voice (AD
   };
 
   const response = await POST(
-    chatRequest(userMessage("user-no-allowance", "one more message"))
+    chatRequest(userMessage(`user-no-allowance-${trial}`, "one more message"))
   );
 
   expect(response.status).toBe(402);
   const body = (await response.json()) as { code: string };
   expect(body.code).toBe("ai_allowance_missing");
-  expect(response.headers.get("X-Chat-Wall")).toBe("allowance-trial");
+  expect(response.headers.get("X-Chat-Billing")).toBe("user");
+  expect(response.headers.get("X-Chat-Paid-Source")).toBe("ai-credits");
+  expect(response.headers.get("X-Chat-Wall")).toBe(wall);
+  expect(history).toEqual([]);
+  expect(leaseAcquireCalls).toBe(0);
   expect(modelCalls).toBe(0);
   expect(reserveCalls).toBe(0);
 });

--- a/apps/ui/src/app/api/chat/route.test.ts
+++ b/apps/ui/src/app/api/chat/route.test.ts
@@ -1650,12 +1650,8 @@ test("walls an exhausted trial on a zero-allowance plan with the trial voice (AD
   );
 
   expect(response.status).toBe(402);
-  const body = (await response.json()) as {
-    code: string;
-    detail?: { allowance?: string };
-  };
+  const body = (await response.json()) as { code: string };
   expect(body.code).toBe("ai_allowance_missing");
-  expect(body.detail?.allowance).toBe("trial");
   expect(response.headers.get("X-Chat-Wall")).toBe("allowance-trial");
   expect(modelCalls).toBe(0);
   expect(reserveCalls).toBe(0);

--- a/apps/ui/src/app/api/chat/route.test.ts
+++ b/apps/ui/src/app/api/chat/route.test.ts
@@ -1635,6 +1635,32 @@ test.each([
   expect(reserveCalls).toBe(0);
 });
 
+test("walls an exhausted trial on a zero-allowance plan with the trial voice (ADR-0073)", async () => {
+  freeTierSnapshot = { limit: 5, remaining: 0, used: 5 };
+  trialJudgment = "trial";
+  billingStanding = {
+    ...billingStanding,
+    accountDebt: false,
+    aiCredits: { totalMicroUnits: 0, usedMicroUnits: 0 },
+    paidSource: "ai-credits",
+  };
+
+  const response = await POST(
+    chatRequest(userMessage("user-no-allowance", "one more message"))
+  );
+
+  expect(response.status).toBe(402);
+  const body = (await response.json()) as {
+    code: string;
+    detail?: { allowance?: string };
+  };
+  expect(body.code).toBe("ai_allowance_missing");
+  expect(body.detail?.allowance).toBe("trial");
+  expect(response.headers.get("X-Chat-Wall")).toBe("allowance-trial");
+  expect(modelCalls).toBe(0);
+  expect(reserveCalls).toBe(0);
+});
+
 test("judges the trial per turn with the verified workspace identity", async () => {
   const response = await POST(
     chatRequest(userMessage("user-judged", "inspect the cluster"))

--- a/apps/ui/src/app/api/chat/route.ts
+++ b/apps/ui/src/app/api/chat/route.ts
@@ -105,9 +105,6 @@ function paidWallResponse(state: FreeTierState): Response {
   if (state.wall === "allowance-trial" || state.wall === "allowance-plan") {
     body = {
       code: "ai_allowance_missing",
-      detail: {
-        allowance: state.wall === "allowance-trial" ? "trial" : "plan",
-      },
       error:
         "This workspace's plan doesn't include AI usage. Upgrade the plan to keep chatting with the assistant.",
     };

--- a/apps/ui/src/app/api/chat/route.ts
+++ b/apps/ui/src/app/api/chat/route.ts
@@ -99,20 +99,31 @@ function chatBillingHeaders(state: FreeTierState): Record<string, string> {
   };
 }
 
-/** The paid wall's refusal (design spec row E3). */
+/** The paid wall's refusal (design spec row E3; allowance causes ADR-0073). */
 function paidWallResponse(state: FreeTierState): Response {
-  const body: ChatApiErrorBody =
-    state.wall === "ai-credits"
-      ? {
-          code: "ai_credits_exhausted",
-          error:
-            "This workspace's AI Credits are used up. Upgrade the plan to keep chatting with the assistant.",
-        }
-      : {
-          code: "account_balance_exhausted",
-          error:
-            "Your account balance can't cover AI usage. Top up in Sealos Desktop to keep chatting with the assistant.",
-        };
+  let body: ChatApiErrorBody;
+  if (state.wall === "allowance-trial" || state.wall === "allowance-plan") {
+    body = {
+      code: "ai_allowance_missing",
+      detail: {
+        allowance: state.wall === "allowance-trial" ? "trial" : "plan",
+      },
+      error:
+        "This workspace's plan doesn't include AI usage. Upgrade the plan to keep chatting with the assistant.",
+    };
+  } else if (state.wall === "ai-credits") {
+    body = {
+      code: "ai_credits_exhausted",
+      error:
+        "This workspace's AI Credits are used up. Upgrade the plan to keep chatting with the assistant.",
+    };
+  } else {
+    body = {
+      code: "account_balance_exhausted",
+      error:
+        "Your account balance can't cover AI usage. Top up in Sealos Desktop to keep chatting with the assistant.",
+    };
+  }
   return Response.json(body, {
     headers: chatBillingHeaders(state),
     status: 402,

--- a/apps/ui/src/features/billing/dev-mock-swr-keys.ts
+++ b/apps/ui/src/features/billing/dev-mock-swr-keys.ts
@@ -2,8 +2,9 @@
  * Which SWR keys the billing Dev Mock owns. Switching a Mock Scenario
  * revalidates exactly these — every surface whose answers the fixtures
  * shape (Billing Area, the sidebar subscription badge, the Notification
- * Center's Brain feed and account facts, the Status Hint, the chat
- * free-turn count) — and nothing else. A blanket `mutate(() => true)` used
+ * Center's Brain feed and account facts, the Status Hint, and the chat
+ * free-turn count via the `/api/chat/free-turns` fixture) — and nothing
+ * else. A blanket `mutate(() => true)` used
  * to refire every key on the page; with the cluster unreachable those
  * requests hang, saturate the browser's per-host connection pool, and
  * queue the mock's own refetches behind them.

--- a/apps/ui/src/features/billing/server/dev-fixtures/dev-fixtures.test.ts
+++ b/apps/ui/src/features/billing/server/dev-fixtures/dev-fixtures.test.ts
@@ -18,7 +18,7 @@ import {
   BILLING_DEV_SCENARIOS,
   formatBillingDevMockCookie,
 } from "../../dev-mock-cookie";
-import { billingDevMockResponse } from "./index";
+import { billingDevMockResponse, freeChatTurnsFixture } from "./index";
 import { scenarioTestFetch } from "./scenario-test-fetch";
 
 /**
@@ -88,6 +88,30 @@ function loadPlanForScenario(scenario: string) {
     fetch: mockFetchFor(scenario),
   });
 }
+
+test("the free-turns fixture spends the trial's allowance with the scenario (ADR-0073)", () => {
+  // Only `free` is mid-spend; every other scenario reads as a trial long
+  // since used up, because the lifetime counter never resets.
+  for (const scenario of BILLING_DEV_SCENARIOS) {
+    const turns = freeChatTurnsFixture(scenario);
+    assert.equal(turns.limit, 5, `${scenario} keeps the platform's 5 turns`);
+    assert.equal(
+      turns.used + turns.remaining,
+      turns.limit,
+      `${scenario} accounts for every turn`
+    );
+    assert.equal(
+      turns.remaining,
+      scenario === "free" ? 3 : 0,
+      `${scenario} spends the expected number of turns`
+    );
+  }
+  assert.deepEqual(freeChatTurnsFixture("free-expiring"), {
+    limit: 5,
+    remaining: 0,
+    used: 5,
+  });
+});
 
 test("every scenario passes every loader's schemas", async () => {
   for (const scenario of BILLING_DEV_SCENARIOS) {

--- a/apps/ui/src/features/billing/server/dev-fixtures/index.ts
+++ b/apps/ui/src/features/billing/server/dev-fixtures/index.ts
@@ -106,6 +106,25 @@ function aiCreditsUsed(
   return scenario === "ai-credits-exhausted" ? 3_000_000 : 1_200_000;
 }
 
+/**
+ * The `/api/chat/free-turns` fixture (Brain's own route, not an upstream
+ * proxy): what the sidebar's AI-usage row and the Plan view's allowance
+ * card read. The Plan view only shows the card during an Active Free
+ * Trial, so the two trial scenarios stage its two looks — `free`
+ * mid-spend, `free-expiring` fully spent ("All 5 used") — and every other
+ * scenario reads as a trial long since used up, because the lifetime
+ * counter never resets (CONTEXT.md, Free Chat Turns).
+ */
+export function freeChatTurnsFixture(scenario: BillingDevScenario): {
+  limit: number;
+  remaining: number;
+  used: number;
+} {
+  const limit = 5;
+  const remaining = scenario === "free" ? 3 : 0;
+  return { limit, remaining, used: limit - remaining };
+}
+
 function daysFromNow(days: number): string {
   return new Date(Date.now() + days * DAY_IN_MILLISECONDS).toISOString();
 }

--- a/apps/ui/src/features/chat/chat-billing-card-tweaks.ts
+++ b/apps/ui/src/features/chat/chat-billing-card-tweaks.ts
@@ -2,7 +2,6 @@
 
 import { type DevTweaksConfig, useDevTweaks } from "@workspace/dev-tweaks";
 
-import type { ChatBillingInterruption } from "./chat-billing-interruption";
 import type { FreeTierState } from "./persistence/types";
 
 // Mirrors DEFAULT_FREE_CHAT_TURNS (persistence/free-tier.ts): the counter
@@ -16,14 +15,9 @@ const CHAT_BILLING_CARD_TWEAKS = {
     options: [
       { label: "Counter (free turns)", value: "counter" },
       { label: "0 turns — handoff (renders nothing)", value: "handoff" },
-      { label: "Allowance notice — after trial", value: "notice-trial" },
-      { label: "Allowance notice — plan without AI", value: "notice-plan" },
+      { label: "Allowance wall — after trial", value: "allowance-wall-trial" },
       {
-        label: "Allowance wall — after trial (refused)",
-        value: "allowance-wall-trial",
-      },
-      {
-        label: "Allowance wall — plan without AI (refused)",
+        label: "Allowance wall — plan without AI",
         value: "allowance-wall-plan",
       },
       { label: "Paid wall — AI Credits", value: "wall-ai-credits" },
@@ -40,104 +34,61 @@ const TWEAKABLE_BUILD =
   process.env.NODE_ENV === "development" ||
   process.env.NEXT_PUBLIC_DEV_TWEAKS === "1";
 
-/** What the tweak forces on the pane: the posture, plus — for the refused
- * allowance-wall stages — the fabricated refusal that arms the lock. */
-export interface ChatBillingCardOverride {
-  freeTier: FreeTierState;
-  interruption: ChatBillingInterruption | null;
-}
-
 /**
  * Styling override for the pane's billing card slot: while the panel toggle
  * is on, the posture select fabricates the rendered Chat Billing Posture —
  * the counter card at 1–5 pips (the slider), the true 0-free-turns handoff
  * (which deliberately renders NOTHING: an open composer on `user` billing,
- * ADR-0069 — pick an allowance or wall posture to see a card), the staged
- * allowance notice/wall pair (ADR-0073: the notice leaves the composer
- * open; the "refused" wall stages the post-refusal lock by fabricating the
- * interruption too), or the Paid Chat Wall in either Paid Source voice.
- * The wall is its own option rather than the slider's zero because real
- * remaining=0 shows no wall by itself. A tweak, not a Dev Mock, and
- * deliberately chat-pane-only: the server, the sidebar's free-turns row,
- * and the Plan view keep their real state (the billing Dev Mock's
- * `/api/chat/free-turns` fixture covers those), so ADR-0065's
- * server-computed posture is only ever overridden where the dev tweaks
- * panel exists.
+ * ADR-0069 — pick a wall posture to see a card), or the Paid Chat Wall in
+ * any of its causes: the allowance causes (ADR-0073: a plan without an AI
+ * allowance, voiced for after the trial or for the plan itself) and the
+ * two Paid Source voices. Every wall locks the composer. The wall is its
+ * own option rather than the slider's zero because real remaining=0 shows
+ * no wall by itself. A tweak, not a Dev Mock, and deliberately
+ * chat-pane-only: the server, the sidebar's free-turns row, and the Plan
+ * view keep their real state (the billing Dev Mock's `/api/chat/free-turns`
+ * fixture covers those), so ADR-0065's server-computed posture is only ever
+ * overridden where the dev tweaks panel exists.
  */
-const FIXED_POSTURES: Record<string, ChatBillingCardOverride> = {
+const FIXED_POSTURES: Record<string, FreeTierState> = {
   "allowance-wall-plan": {
-    freeTier: {
-      billing: "user",
-      limit: FREE_CHAT_TURNS_LIMIT,
-      paidSource: "ai-credits",
-      remaining: FREE_CHAT_TURNS_LIMIT,
-      wall: "allowance-plan",
-    },
-    interruption: { allowance: "plan", paidSource: null },
+    billing: "user",
+    limit: FREE_CHAT_TURNS_LIMIT,
+    paidSource: "ai-credits",
+    remaining: FREE_CHAT_TURNS_LIMIT,
+    wall: "allowance-plan",
   },
   "allowance-wall-trial": {
-    freeTier: {
-      billing: "user",
-      limit: FREE_CHAT_TURNS_LIMIT,
-      paidSource: "ai-credits",
-      remaining: 0,
-      wall: "allowance-trial",
-    },
-    interruption: { allowance: "trial", paidSource: null },
+    billing: "user",
+    limit: FREE_CHAT_TURNS_LIMIT,
+    paidSource: "ai-credits",
+    remaining: 0,
+    wall: "allowance-trial",
   },
   handoff: {
-    freeTier: {
-      billing: "user",
-      limit: FREE_CHAT_TURNS_LIMIT,
-      paidSource: null,
-      remaining: 0,
-      wall: null,
-    },
-    interruption: null,
-  },
-  "notice-plan": {
-    freeTier: {
-      billing: "user",
-      limit: FREE_CHAT_TURNS_LIMIT,
-      paidSource: "ai-credits",
-      remaining: FREE_CHAT_TURNS_LIMIT,
-      wall: "allowance-plan",
-    },
-    interruption: null,
-  },
-  "notice-trial": {
-    freeTier: {
-      billing: "user",
-      limit: FREE_CHAT_TURNS_LIMIT,
-      paidSource: "ai-credits",
-      remaining: 0,
-      wall: "allowance-trial",
-    },
-    interruption: null,
+    billing: "user",
+    limit: FREE_CHAT_TURNS_LIMIT,
+    paidSource: null,
+    remaining: 0,
+    wall: null,
   },
   "wall-ai-credits": {
-    freeTier: {
-      billing: "user",
-      limit: FREE_CHAT_TURNS_LIMIT,
-      paidSource: "ai-credits",
-      remaining: 0,
-      wall: "ai-credits",
-    },
-    interruption: null,
+    billing: "user",
+    limit: FREE_CHAT_TURNS_LIMIT,
+    paidSource: "ai-credits",
+    remaining: 0,
+    wall: "ai-credits",
   },
   "wall-balance": {
-    freeTier: {
-      billing: "user",
-      limit: FREE_CHAT_TURNS_LIMIT,
-      paidSource: "balance",
-      remaining: 0,
-      wall: "balance",
-    },
-    interruption: null,
+    billing: "user",
+    limit: FREE_CHAT_TURNS_LIMIT,
+    paidSource: "balance",
+    remaining: 0,
+    wall: "balance",
   },
 };
 
-export function useChatBillingCardFreeTierOverride(): ChatBillingCardOverride | null {
+export function useChatBillingCardFreeTierOverride(): FreeTierState | null {
   const values = useDevTweaks("Chat · billing card", CHAT_BILLING_CARD_TWEAKS, {
     id: "chat-billing-card",
     persist: { storage: "sessionStorage" },
@@ -154,13 +105,10 @@ export function useChatBillingCardFreeTierOverride(): ChatBillingCardOverride | 
     Math.max(1, Math.round(values.remaining))
   );
   return {
-    freeTier: {
-      billing: "free",
-      limit: FREE_CHAT_TURNS_LIMIT,
-      paidSource: null,
-      remaining,
-      wall: null,
-    },
-    interruption: null,
+    billing: "free",
+    limit: FREE_CHAT_TURNS_LIMIT,
+    paidSource: null,
+    remaining,
+    wall: null,
   };
 }

--- a/apps/ui/src/features/chat/chat-billing-card-tweaks.ts
+++ b/apps/ui/src/features/chat/chat-billing-card-tweaks.ts
@@ -2,6 +2,7 @@
 
 import { type DevTweaksConfig, useDevTweaks } from "@workspace/dev-tweaks";
 
+import type { ChatBillingInterruption } from "./chat-billing-interruption";
 import type { FreeTierState } from "./persistence/types";
 
 // Mirrors DEFAULT_FREE_CHAT_TURNS (persistence/free-tier.ts): the counter
@@ -14,7 +15,17 @@ const CHAT_BILLING_CARD_TWEAKS = {
     default: "counter",
     options: [
       { label: "Counter (free turns)", value: "counter" },
-      { label: "0 turns — user handoff", value: "handoff" },
+      { label: "0 turns — handoff (renders nothing)", value: "handoff" },
+      { label: "Allowance notice — after trial", value: "notice-trial" },
+      { label: "Allowance notice — plan without AI", value: "notice-plan" },
+      {
+        label: "Allowance wall — after trial (refused)",
+        value: "allowance-wall-trial",
+      },
+      {
+        label: "Allowance wall — plan without AI (refused)",
+        value: "allowance-wall-plan",
+      },
       { label: "Paid wall — AI Credits", value: "wall-ai-credits" },
       { label: "Paid wall — balance", value: "wall-balance" },
     ],
@@ -29,21 +40,104 @@ const TWEAKABLE_BUILD =
   process.env.NODE_ENV === "development" ||
   process.env.NEXT_PUBLIC_DEV_TWEAKS === "1";
 
+/** What the tweak forces on the pane: the posture, plus — for the refused
+ * allowance-wall stages — the fabricated refusal that arms the lock. */
+export interface ChatBillingCardOverride {
+  freeTier: FreeTierState;
+  interruption: ChatBillingInterruption | null;
+}
+
 /**
  * Styling override for the pane's billing card slot: while the panel toggle
  * is on, the posture select fabricates the rendered Chat Billing Posture —
- * the counter card at 1–5 pips (the slider), the real 0-free-turns state
- * (a `user` handoff with no wall and an open composer, ADR-0069), or the
- * Paid Chat Wall in either Paid Source voice (AI Credits vs balance), which
- * locks the composer. The wall is its own option rather than the slider's
- * zero because real remaining=0 shows no wall — the wall belongs to an
- * exhausted Paid Source, and its copy forks on which one. A tweak, not a
- * Dev Mock, and deliberately chat-pane-only: the server, the sidebar's
- * free-turns row, and the Plan view keep their real state, so ADR-0065's
+ * the counter card at 1–5 pips (the slider), the true 0-free-turns handoff
+ * (which deliberately renders NOTHING: an open composer on `user` billing,
+ * ADR-0069 — pick an allowance or wall posture to see a card), the staged
+ * allowance notice/wall pair (ADR-0073: the notice leaves the composer
+ * open; the "refused" wall stages the post-refusal lock by fabricating the
+ * interruption too), or the Paid Chat Wall in either Paid Source voice.
+ * The wall is its own option rather than the slider's zero because real
+ * remaining=0 shows no wall by itself. A tweak, not a Dev Mock, and
+ * deliberately chat-pane-only: the server, the sidebar's free-turns row,
+ * and the Plan view keep their real state (the billing Dev Mock's
+ * `/api/chat/free-turns` fixture covers those), so ADR-0065's
  * server-computed posture is only ever overridden where the dev tweaks
  * panel exists.
  */
-export function useChatBillingCardFreeTierOverride(): FreeTierState | null {
+const FIXED_POSTURES: Record<string, ChatBillingCardOverride> = {
+  "allowance-wall-plan": {
+    freeTier: {
+      billing: "user",
+      limit: FREE_CHAT_TURNS_LIMIT,
+      paidSource: "ai-credits",
+      remaining: FREE_CHAT_TURNS_LIMIT,
+      wall: "allowance-plan",
+    },
+    interruption: { allowance: "plan", paidSource: null },
+  },
+  "allowance-wall-trial": {
+    freeTier: {
+      billing: "user",
+      limit: FREE_CHAT_TURNS_LIMIT,
+      paidSource: "ai-credits",
+      remaining: 0,
+      wall: "allowance-trial",
+    },
+    interruption: { allowance: "trial", paidSource: null },
+  },
+  handoff: {
+    freeTier: {
+      billing: "user",
+      limit: FREE_CHAT_TURNS_LIMIT,
+      paidSource: null,
+      remaining: 0,
+      wall: null,
+    },
+    interruption: null,
+  },
+  "notice-plan": {
+    freeTier: {
+      billing: "user",
+      limit: FREE_CHAT_TURNS_LIMIT,
+      paidSource: "ai-credits",
+      remaining: FREE_CHAT_TURNS_LIMIT,
+      wall: "allowance-plan",
+    },
+    interruption: null,
+  },
+  "notice-trial": {
+    freeTier: {
+      billing: "user",
+      limit: FREE_CHAT_TURNS_LIMIT,
+      paidSource: "ai-credits",
+      remaining: 0,
+      wall: "allowance-trial",
+    },
+    interruption: null,
+  },
+  "wall-ai-credits": {
+    freeTier: {
+      billing: "user",
+      limit: FREE_CHAT_TURNS_LIMIT,
+      paidSource: "ai-credits",
+      remaining: 0,
+      wall: "ai-credits",
+    },
+    interruption: null,
+  },
+  "wall-balance": {
+    freeTier: {
+      billing: "user",
+      limit: FREE_CHAT_TURNS_LIMIT,
+      paidSource: "balance",
+      remaining: 0,
+      wall: "balance",
+    },
+    interruption: null,
+  },
+};
+
+export function useChatBillingCardFreeTierOverride(): ChatBillingCardOverride | null {
   const values = useDevTweaks("Chat · billing card", CHAT_BILLING_CARD_TWEAKS, {
     id: "chat-billing-card",
     persist: { storage: "sessionStorage" },
@@ -51,38 +145,22 @@ export function useChatBillingCardFreeTierOverride(): FreeTierState | null {
   if (!(TWEAKABLE_BUILD && values.override)) {
     return null;
   }
-  if (
-    values.posture === "wall-ai-credits" ||
-    values.posture === "wall-balance"
-  ) {
-    const source =
-      values.posture === "wall-ai-credits" ? "ai-credits" : "balance";
-    return {
-      billing: "user",
-      limit: FREE_CHAT_TURNS_LIMIT,
-      paidSource: source,
-      remaining: 0,
-      wall: source,
-    };
-  }
-  if (values.posture === "handoff") {
-    return {
-      billing: "user",
-      limit: FREE_CHAT_TURNS_LIMIT,
-      paidSource: null,
-      remaining: 0,
-      wall: null,
-    };
+  const fixed = FIXED_POSTURES[values.posture];
+  if (fixed != null) {
+    return fixed;
   }
   const remaining = Math.min(
     FREE_CHAT_TURNS_LIMIT,
     Math.max(1, Math.round(values.remaining))
   );
   return {
-    billing: "free",
-    limit: FREE_CHAT_TURNS_LIMIT,
-    paidSource: null,
-    remaining,
-    wall: null,
+    freeTier: {
+      billing: "free",
+      limit: FREE_CHAT_TURNS_LIMIT,
+      paidSource: null,
+      remaining,
+      wall: null,
+    },
+    interruption: null,
   };
 }

--- a/apps/ui/src/features/chat/chat-billing-card-tweaks.ts
+++ b/apps/ui/src/features/chat/chat-billing-card-tweaks.ts
@@ -8,20 +8,30 @@ import type { FreeTierState } from "./persistence/types";
 // card draws `limit` pips, so the slider range tracks the real allowance.
 const FREE_CHAT_TURNS_LIMIT = 5;
 
+/**
+ * Every posture but the counter fabricates one fixed state; the counter
+ * follows the slider. Declared apart so `FIXED_POSTURES` is keyed by these
+ * values and a typo in either place is a type error, not a silent fall
+ * through to the counter.
+ */
+const FIXED_POSTURE_OPTIONS = [
+  { label: "0 turns — handoff (renders nothing)", value: "handoff" },
+  { label: "Allowance wall — after trial", value: "allowance-wall-trial" },
+  { label: "Allowance wall — plan without AI", value: "allowance-wall-plan" },
+  { label: "Paid wall — AI Credits", value: "wall-ai-credits" },
+  { label: "Paid wall — balance", value: "wall-balance" },
+] as const satisfies readonly { label: string; value: string }[];
+
+type FixedChatBillingCardPosture =
+  (typeof FIXED_POSTURE_OPTIONS)[number]["value"];
+
 const CHAT_BILLING_CARD_TWEAKS = {
   override: false,
   posture: {
     default: "counter",
     options: [
       { label: "Counter (free turns)", value: "counter" },
-      { label: "0 turns — handoff (renders nothing)", value: "handoff" },
-      { label: "Allowance wall — after trial", value: "allowance-wall-trial" },
-      {
-        label: "Allowance wall — plan without AI",
-        value: "allowance-wall-plan",
-      },
-      { label: "Paid wall — AI Credits", value: "wall-ai-credits" },
-      { label: "Paid wall — balance", value: "wall-balance" },
+      ...FIXED_POSTURE_OPTIONS,
     ],
     type: "select",
   },
@@ -50,7 +60,7 @@ const TWEAKABLE_BUILD =
  * fixture covers those), so ADR-0065's server-computed posture is only ever
  * overridden where the dev tweaks panel exists.
  */
-const FIXED_POSTURES: Record<string, FreeTierState> = {
+const FIXED_POSTURES: Record<FixedChatBillingCardPosture, FreeTierState> = {
   "allowance-wall-plan": {
     billing: "user",
     limit: FREE_CHAT_TURNS_LIMIT,
@@ -88,6 +98,15 @@ const FIXED_POSTURES: Record<string, FreeTierState> = {
   },
 };
 
+/**
+ * The select's value is a plain string, and a session may still carry a
+ * posture an earlier build offered; anything not in the table is the
+ * counter.
+ */
+function isFixedPosture(value: string): value is FixedChatBillingCardPosture {
+  return Object.hasOwn(FIXED_POSTURES, value);
+}
+
 export function useChatBillingCardFreeTierOverride(): FreeTierState | null {
   const values = useDevTweaks("Chat · billing card", CHAT_BILLING_CARD_TWEAKS, {
     id: "chat-billing-card",
@@ -96,9 +115,8 @@ export function useChatBillingCardFreeTierOverride(): FreeTierState | null {
   if (!(TWEAKABLE_BUILD && values.override)) {
     return null;
   }
-  const fixed = FIXED_POSTURES[values.posture];
-  if (fixed != null) {
-    return fixed;
+  if (isFixedPosture(values.posture)) {
+    return FIXED_POSTURES[values.posture];
   }
   const remaining = Math.min(
     FREE_CHAT_TURNS_LIMIT,

--- a/apps/ui/src/features/chat/chat-billing-cards.interaction.test.tsx
+++ b/apps/ui/src/features/chat/chat-billing-cards.interaction.test.tsx
@@ -233,6 +233,66 @@ test("paid wall card speaks the exhausted source loudly and links to its fix", a
   });
 });
 
+test("allowance wall card names the missing allowance, not a Paid Source, and links to upgrade (ADR-0073)", async () => {
+  await withTestDom(async (act) => {
+    const { ChatBillingCardSlot } = await cardModules();
+    const navigations: string[] = [];
+    let rendered: ReturnType<typeof render> | undefined;
+    try {
+      await act(() => {
+        rendered = render(
+          <ChatBillingCardSlot
+            errored={false}
+            freeTier={{
+              ...USER,
+              paidSource: "ai-credits",
+              wall: "allowance-trial",
+            }}
+            onNavigateToBilling={(destination) => navigations.push(destination)}
+          />
+        );
+      });
+      const wall = rendered?.container.querySelector(
+        '[data-slot="chat-paid-wall-card"]'
+      );
+      assert.ok(wall, "the wall card renders for the trial voice");
+      const trialText = wall?.textContent ?? "";
+      assert.ok(trialText.includes("Free trial messages used up"));
+      assert.ok(
+        !trialText.includes("AI Credits"),
+        "a workspace that never held AI Credits is not told they ran out"
+      );
+      fireEvent.click(
+        rendered?.getByRole("button", { name: "Upgrade plan" }) as HTMLElement
+      );
+      assert.deepEqual(navigations, ["upgrade"]);
+
+      await act(() => {
+        rendered?.rerender(
+          <ChatBillingCardSlot
+            errored={false}
+            freeTier={{
+              ...USER,
+              paidSource: "ai-credits",
+              wall: "allowance-plan",
+            }}
+            onNavigateToBilling={(destination) => navigations.push(destination)}
+          />
+        );
+      });
+      const planText = rendered?.container.textContent ?? "";
+      assert.ok(planText.includes("AI usage not included"));
+      assert.ok(!planText.includes("Free trial"));
+      fireEvent.click(
+        rendered?.getByRole("button", { name: "Upgrade plan" }) as HTMLElement
+      );
+      assert.deepEqual(navigations, ["upgrade", "upgrade"]);
+    } finally {
+      await act(() => rendered?.unmount());
+    }
+  });
+});
+
 test("a billing interruption turns the error card truthful without locking anything", async () => {
   await withTestDom(async (act) => {
     const { ChatBillingCardSlot } = await cardModules();

--- a/apps/ui/src/features/chat/chat-billing-cards.tsx
+++ b/apps/ui/src/features/chat/chat-billing-cards.tsx
@@ -9,12 +9,19 @@ import { BillingCalloutCard } from "@/features/billing/billing-callout-card";
 import {
   type ChatBillingCopy,
   type ChatBillingInterruption,
+  chatAllowanceWall,
   chatBillingInterruptionCopy,
+  chatBillingNoticeCopy,
   chatBillingWallCopy,
 } from "./chat-billing-interruption";
-import type { ChatPaidSource, FreeTierState } from "./persistence/types";
+import type { ChatWallCause, FreeTierState } from "./persistence/types";
 
-export type ChatBillingCard = "billing-error" | "counter" | "error" | "wall";
+export type ChatBillingCard =
+  | "billing-error"
+  | "counter"
+  | "error"
+  | "notice"
+  | "wall";
 
 /**
  * Where a chat billing CTA lands: `upgrade` deep-links the Plan Picker open
@@ -31,14 +38,19 @@ export type ChatBillingDestination = "plans" | "top-up" | "upgrade";
  * error > counter. The paid wall outranks every error card because "try
  * again" is a lie once the server refuses chat; a billing interruption
  * outranks the generic error because it knows why. On open `user` billing
- * only an error card can ever show.
+ * only an error card can ever show. An `allowance-*` wall stages
+ * (ADR-0073): the advisory notice until a send was actually refused, the
+ * locked wall from then on.
  */
 export function resolveChatBillingCard(input: {
   billing: FreeTierState["billing"] | null;
   errored: boolean;
   interruption?: ChatBillingInterruption | null;
-  wall?: ChatPaidSource | null;
+  wall?: ChatWallCause | null;
 }): ChatBillingCard | null {
+  if (chatAllowanceWall(input.wall) != null) {
+    return input.interruption?.allowance == null ? "notice" : "wall";
+  }
   if (input.wall != null) {
     return "wall";
   }
@@ -156,6 +168,40 @@ function PaidWallCard({
 }
 
 /**
+ * The advisory sibling of the wall (ADR-0073): the same allowance cause in
+ * the warning voice, shown while the composer is still open — the user
+ * learns what the next send runs into before the pre-send gate refuses it.
+ */
+function AllowanceNoticeCard({
+  copy,
+  onNavigateToBilling,
+}: {
+  copy: ChatBillingCopy;
+  onNavigateToBilling: (destination: ChatBillingDestination) => void;
+}) {
+  return (
+    <BillingCalloutCard
+      action={
+        <AppButton
+          onClick={() => onNavigateToBilling(copy.cta.destination)}
+          size="sm"
+          variant="chip"
+        >
+          {copy.cta.label}
+        </AppButton>
+      }
+      body={copy.body}
+      className="rounded-xl p-3"
+      data-slot="chat-allowance-notice-card"
+      icon={TriangleAlert}
+      layout="inline"
+      title={copy.title}
+      tone="warning"
+    />
+  );
+}
+
+/**
  * The error card once the failed turn is known to be a billing refusal: the
  * error frame stays, the copy tells the truth and offers the fix. It locks
  * nothing — the next send re-gates, and the lock lives in exactly one place.
@@ -241,6 +287,7 @@ export function ChatBillingCardSlot({
   if (card == null) {
     return null;
   }
+  const allowance = chatAllowanceWall(wall);
   return (
     <div className="shrink-0 px-2.5 pt-1">
       {card === "wall" && wall != null ? (
@@ -249,9 +296,15 @@ export function ChatBillingCardSlot({
           onNavigateToBilling={onNavigateToBilling}
         />
       ) : null}
+      {card === "notice" && allowance != null ? (
+        <AllowanceNoticeCard
+          copy={chatBillingNoticeCopy(allowance, freeTier?.limit ?? 0)}
+          onNavigateToBilling={onNavigateToBilling}
+        />
+      ) : null}
       {card === "billing-error" ? (
         <BillingErrorCard
-          copy={chatBillingInterruptionCopy(interruption?.paidSource ?? null)}
+          copy={chatBillingInterruptionCopy(interruption)}
           onNavigateToBilling={onNavigateToBilling}
         />
       ) : null}

--- a/apps/ui/src/features/chat/chat-billing-cards.tsx
+++ b/apps/ui/src/features/chat/chat-billing-cards.tsx
@@ -9,19 +9,12 @@ import { BillingCalloutCard } from "@/features/billing/billing-callout-card";
 import {
   type ChatBillingCopy,
   type ChatBillingInterruption,
-  chatAllowanceWall,
   chatBillingInterruptionCopy,
-  chatBillingNoticeCopy,
   chatBillingWallCopy,
 } from "./chat-billing-interruption";
 import type { ChatWallCause, FreeTierState } from "./persistence/types";
 
-export type ChatBillingCard =
-  | "billing-error"
-  | "counter"
-  | "error"
-  | "notice"
-  | "wall";
+export type ChatBillingCard = "billing-error" | "counter" | "error" | "wall";
 
 /**
  * Where a chat billing CTA lands: `upgrade` deep-links the Plan Picker open
@@ -38,9 +31,8 @@ export type ChatBillingDestination = "plans" | "top-up" | "upgrade";
  * error > counter. The paid wall outranks every error card because "try
  * again" is a lie once the server refuses chat; a billing interruption
  * outranks the generic error because it knows why. On open `user` billing
- * only an error card can ever show. An `allowance-*` wall stages
- * (ADR-0073): the advisory notice until a send was actually refused, the
- * locked wall from then on.
+ * only an error card can ever show. Every wall cause locks alike — an
+ * allowance cause (ADR-0073) as immediately as an exhausted Paid Source.
  */
 export function resolveChatBillingCard(input: {
   billing: FreeTierState["billing"] | null;
@@ -48,9 +40,6 @@ export function resolveChatBillingCard(input: {
   interruption?: ChatBillingInterruption | null;
   wall?: ChatWallCause | null;
 }): ChatBillingCard | null {
-  if (chatAllowanceWall(input.wall) != null) {
-    return input.interruption?.allowance == null ? "notice" : "wall";
-  }
   if (input.wall != null) {
     return "wall";
   }
@@ -168,40 +157,6 @@ function PaidWallCard({
 }
 
 /**
- * The advisory sibling of the wall (ADR-0073): the same allowance cause in
- * the warning voice, shown while the composer is still open — the user
- * learns what the next send runs into before the pre-send gate refuses it.
- */
-function AllowanceNoticeCard({
-  copy,
-  onNavigateToBilling,
-}: {
-  copy: ChatBillingCopy;
-  onNavigateToBilling: (destination: ChatBillingDestination) => void;
-}) {
-  return (
-    <BillingCalloutCard
-      action={
-        <AppButton
-          onClick={() => onNavigateToBilling(copy.cta.destination)}
-          size="sm"
-          variant="chip"
-        >
-          {copy.cta.label}
-        </AppButton>
-      }
-      body={copy.body}
-      className="rounded-xl p-3"
-      data-slot="chat-allowance-notice-card"
-      icon={TriangleAlert}
-      layout="inline"
-      title={copy.title}
-      tone="warning"
-    />
-  );
-}
-
-/**
  * The error card once the failed turn is known to be a billing refusal: the
  * error frame stays, the copy tells the truth and offers the fix. It locks
  * nothing — the next send re-gates, and the lock lives in exactly one place.
@@ -287,7 +242,6 @@ export function ChatBillingCardSlot({
   if (card == null) {
     return null;
   }
-  const allowance = chatAllowanceWall(wall);
   return (
     <div className="shrink-0 px-2.5 pt-1">
       {card === "wall" && wall != null ? (
@@ -296,15 +250,9 @@ export function ChatBillingCardSlot({
           onNavigateToBilling={onNavigateToBilling}
         />
       ) : null}
-      {card === "notice" && allowance != null ? (
-        <AllowanceNoticeCard
-          copy={chatBillingNoticeCopy(allowance, freeTier?.limit ?? 0)}
-          onNavigateToBilling={onNavigateToBilling}
-        />
-      ) : null}
       {card === "billing-error" ? (
         <BillingErrorCard
-          copy={chatBillingInterruptionCopy(interruption)}
+          copy={chatBillingInterruptionCopy(interruption?.paidSource ?? null)}
           onNavigateToBilling={onNavigateToBilling}
         />
       ) : null}

--- a/apps/ui/src/features/chat/chat-billing-interruption.test.ts
+++ b/apps/ui/src/features/chat/chat-billing-interruption.test.ts
@@ -49,25 +49,13 @@ describe("chatBillingInterruptionFromError", () => {
     ).toEqual({ paidSource: "ai-credits" });
   });
 
-  it("reads the allowance refusal with its variant (ADR-0073)", () => {
-    expect(
-      chatBillingInterruptionFromError(
-        new Error(
-          JSON.stringify({
-            code: "ai_allowance_missing",
-            detail: { allowance: "trial" },
-            error: "x",
-          })
-        ),
-        "ai-credits"
-      )
-    ).toEqual({ allowance: "trial", paidSource: null });
+  it("reads the allowance refusal as a billing refusal with no Paid Source (ADR-0073)", () => {
     expect(
       chatBillingInterruptionFromError(
         new Error(JSON.stringify({ code: "ai_allowance_missing", error: "x" })),
-        null
+        "ai-credits"
       )
-    ).toEqual({ allowance: "plan", paidSource: null });
+    ).toEqual({ paidSource: null });
   });
 
   it("is null for every non-billing error, including non-JSON messages", () => {
@@ -90,9 +78,9 @@ describe("copy forks by Chat Billing Mode", () => {
       cta: { destination: "upgrade", label: "Upgrade plan" },
       title: "AI Credits used up",
     });
-    expect(
-      chatBillingInterruptionCopy({ paidSource: "ai-credits" }).title
-    ).toBe("Message not sent — AI Credits used up");
+    expect(chatBillingInterruptionCopy("ai-credits").title).toBe(
+      "Message not sent — AI Credits used up"
+    );
   });
 
   it("speaks the balance and a top-up for PAYG", () => {
@@ -101,9 +89,9 @@ describe("copy forks by Chat Billing Mode", () => {
       cta: { destination: "top-up", label: "Top up balance" },
       title: "Account balance in debt",
     });
-    expect(
-      chatBillingInterruptionCopy({ paidSource: "balance" }).cta.label
-    ).toBe("Top up balance");
+    expect(chatBillingInterruptionCopy("balance").cta.label).toBe(
+      "Top up balance"
+    );
   });
 
   it("speaks the allowance causes truthfully (ADR-0073)", () => {
@@ -113,13 +101,6 @@ describe("copy forks by Chat Billing Mode", () => {
     expect(chatBillingWallCopy("allowance-plan").title).toBe(
       "AI usage not included"
     );
-    expect(
-      chatBillingInterruptionCopy({ allowance: "trial", paidSource: null })
-        .title
-    ).toBe("Message not sent — free trial messages used up");
-    expect(
-      chatBillingInterruptionCopy({ allowance: "plan", paidSource: null }).title
-    ).toBe("Message not sent — AI usage not included");
   });
 
   it("never claims a source it does not know", () => {

--- a/apps/ui/src/features/chat/chat-billing-interruption.test.ts
+++ b/apps/ui/src/features/chat/chat-billing-interruption.test.ts
@@ -4,6 +4,7 @@ import {
   chatBillingInterruptionCopy,
   chatBillingInterruptionFromError,
   chatBillingWallCopy,
+  chatWallPlaceholder,
 } from "./chat-billing-interruption";
 
 describe("chatBillingInterruptionFromError", () => {
@@ -94,18 +95,44 @@ describe("copy forks by Chat Billing Mode", () => {
     );
   });
 
-  it("speaks the allowance causes truthfully (ADR-0073)", () => {
-    expect(chatBillingWallCopy("allowance-trial").title).toBe(
-      "Free trial messages used up"
-    );
-    expect(chatBillingWallCopy("allowance-plan").title).toBe(
-      "AI usage not included"
-    );
+  it("speaks the allowance causes truthfully, both pointing at the plan (ADR-0073)", () => {
+    const body =
+      "This workspace's plan doesn't include AI usage. Upgrade the plan to keep chatting.";
+    const cta = { destination: "upgrade" as const, label: "Upgrade plan" };
+    expect(chatBillingWallCopy("allowance-trial")).toEqual({
+      body,
+      cta,
+      title: "Free trial messages used up",
+    });
+    expect(chatBillingWallCopy("allowance-plan")).toEqual({
+      body,
+      cta,
+      title: "AI usage not included",
+    });
   });
 
   it("never claims a source it does not know", () => {
     const copy = chatBillingInterruptionCopy(null);
     expect(copy.title).toBe("Message not sent — billing refused the request");
     expect(copy.cta).toEqual({ destination: "plans", label: "View billing" });
+  });
+});
+
+describe("chatWallPlaceholder", () => {
+  it("names the allowance cause in the locked composer (ADR-0073)", () => {
+    expect(chatWallPlaceholder("allowance-trial")).toBe(
+      "Free trial messages used up — upgrade to continue"
+    );
+    expect(chatWallPlaceholder("allowance-plan")).toBe(
+      "AI usage not included — upgrade to continue"
+    );
+  });
+
+  it("keeps the generic billing placeholder for the Paid Source walls and an unknown wall", () => {
+    const generic = "Chat is paused — resolve billing to continue";
+    expect(chatWallPlaceholder("ai-credits")).toBe(generic);
+    expect(chatWallPlaceholder("balance")).toBe(generic);
+    expect(chatWallPlaceholder(null)).toBe(generic);
+    expect(chatWallPlaceholder(undefined)).toBe(generic);
   });
 });

--- a/apps/ui/src/features/chat/chat-billing-interruption.test.ts
+++ b/apps/ui/src/features/chat/chat-billing-interruption.test.ts
@@ -49,6 +49,27 @@ describe("chatBillingInterruptionFromError", () => {
     ).toEqual({ paidSource: "ai-credits" });
   });
 
+  it("reads the allowance refusal with its variant (ADR-0073)", () => {
+    expect(
+      chatBillingInterruptionFromError(
+        new Error(
+          JSON.stringify({
+            code: "ai_allowance_missing",
+            detail: { allowance: "trial" },
+            error: "x",
+          })
+        ),
+        "ai-credits"
+      )
+    ).toEqual({ allowance: "trial", paidSource: null });
+    expect(
+      chatBillingInterruptionFromError(
+        new Error(JSON.stringify({ code: "ai_allowance_missing", error: "x" })),
+        null
+      )
+    ).toEqual({ allowance: "plan", paidSource: null });
+  });
+
   it("is null for every non-billing error, including non-JSON messages", () => {
     expect(
       chatBillingInterruptionFromError(new Error("An error occurred."), null)
@@ -69,9 +90,9 @@ describe("copy forks by Chat Billing Mode", () => {
       cta: { destination: "upgrade", label: "Upgrade plan" },
       title: "AI Credits used up",
     });
-    expect(chatBillingInterruptionCopy("ai-credits").title).toBe(
-      "Message not sent — AI Credits used up"
-    );
+    expect(
+      chatBillingInterruptionCopy({ paidSource: "ai-credits" }).title
+    ).toBe("Message not sent — AI Credits used up");
   });
 
   it("speaks the balance and a top-up for PAYG", () => {
@@ -80,9 +101,25 @@ describe("copy forks by Chat Billing Mode", () => {
       cta: { destination: "top-up", label: "Top up balance" },
       title: "Account balance in debt",
     });
-    expect(chatBillingInterruptionCopy("balance").cta.label).toBe(
-      "Top up balance"
+    expect(
+      chatBillingInterruptionCopy({ paidSource: "balance" }).cta.label
+    ).toBe("Top up balance");
+  });
+
+  it("speaks the allowance causes truthfully (ADR-0073)", () => {
+    expect(chatBillingWallCopy("allowance-trial").title).toBe(
+      "Free trial messages used up"
     );
+    expect(chatBillingWallCopy("allowance-plan").title).toBe(
+      "AI usage not included"
+    );
+    expect(
+      chatBillingInterruptionCopy({ allowance: "trial", paidSource: null })
+        .title
+    ).toBe("Message not sent — free trial messages used up");
+    expect(
+      chatBillingInterruptionCopy({ allowance: "plan", paidSource: null }).title
+    ).toBe("Message not sent — AI usage not included");
   });
 
   it("never claims a source it does not know", () => {

--- a/apps/ui/src/features/chat/chat-billing-interruption.ts
+++ b/apps/ui/src/features/chat/chat-billing-interruption.ts
@@ -8,12 +8,6 @@ import type { ChatPaidSource, ChatWallCause } from "./persistence/types";
  * the pane's `onError` and the card copy.
  */
 export interface ChatBillingInterruption {
-  /**
-   * Set when the refusal named a missing AI allowance (ADR-0073): the
-   * workspace's plan grants no AI usage at all, forked on whether the Free
-   * Chat Turns story explains the stop.
-   */
-  allowance?: "plan" | "trial" | null;
   /** The paid source the refusal named, else the pane's own; null when neither is known. */
   paidSource: ChatPaidSource | null;
 }
@@ -64,45 +58,17 @@ export function chatBillingInterruptionFromError(
   if (code === "ai_credits_exhausted") {
     return { paidSource: "ai-credits" };
   }
-  const detailRecord =
-    typeof detail === "object" && detail != null
-      ? (detail as { allowance?: unknown; paidSource?: unknown })
-      : null;
   if (code === "ai_allowance_missing") {
-    return {
-      allowance: detailRecord?.allowance === "trial" ? "trial" : "plan",
-      paidSource: null,
-    };
+    // A plan without an AI allowance names no Paid Source to spend
+    // (ADR-0073); the `X-Chat-Wall` header on the same response carries
+    // the cause and locks the composer.
+    return { paidSource: null };
   }
-  const named = paidSourceFrom(detailRecord?.paidSource);
+  const named =
+    typeof detail === "object" && detail != null
+      ? paidSourceFrom((detail as { paidSource?: unknown }).paidSource)
+      : null;
   return { paidSource: named ?? knownPaidSource };
-}
-
-/** The two allowance wall causes (ADR-0073), narrowed for staging. */
-export function chatAllowanceWall(
-  wall: ChatWallCause | null | undefined
-): "allowance-plan" | "allowance-trial" | null {
-  return wall === "allowance-plan" || wall === "allowance-trial" ? wall : null;
-}
-
-/**
- * Whether the composer's message path is locked (ADR-0068, revised by
- * ADR-0073): an exhausted Paid Source locks immediately, while an
- * `allowance-*` wall stages — the advisory notice leaves the composer open,
- * and the lock lands only once a send was actually refused (the
- * interruption carries the refusal).
- */
-export function chatMessagingLocked(
-  wall: ChatWallCause | null | undefined,
-  interruption: ChatBillingInterruption | null
-): boolean {
-  if (wall === "ai-credits" || wall === "balance") {
-    return true;
-  }
-  if (chatAllowanceWall(wall) != null) {
-    return interruption?.allowance != null;
-  }
-  return false;
 }
 
 /** The pre-send wall card's copy, forked by the refusing cause. */
@@ -135,44 +101,10 @@ export function chatBillingWallCopy(cause: ChatWallCause): ChatBillingCopy {
   };
 }
 
-/**
- * The advisory notice's copy (ADR-0073): the same cause the wall would
- * name, spoken before any send was refused — so the composer stays open and
- * the user learns what the next send runs into.
- */
-export function chatBillingNoticeCopy(
-  cause: "allowance-plan" | "allowance-trial",
-  limit: number
-): ChatBillingCopy {
-  if (cause === "allowance-trial") {
-    return {
-      body: `This workspace has used all ${limit} free trial messages. Upgrade the plan to keep chatting.`,
-      cta: { destination: "upgrade", label: "Upgrade plan" },
-      title: "Free trial messages used up",
-    };
-  }
-  return {
-    body: "This workspace's plan doesn't include AI usage. Upgrade the plan to use the assistant.",
-    cta: { destination: "upgrade", label: "Upgrade plan" },
-    title: "AI usage not included",
-  };
-}
-
 /** The billing-ized error card's copy; an unknown source never claims one. */
 export function chatBillingInterruptionCopy(
-  interruption: ChatBillingInterruption | null
+  paidSource: ChatPaidSource | null
 ): ChatBillingCopy {
-  if (interruption?.allowance != null) {
-    return {
-      body: "The turn was refused because this workspace's plan doesn't include AI usage. Upgrade the plan to continue.",
-      cta: { destination: "upgrade", label: "Upgrade plan" },
-      title:
-        interruption.allowance === "trial"
-          ? "Message not sent — free trial messages used up"
-          : "Message not sent — AI usage not included",
-    };
-  }
-  const paidSource = interruption?.paidSource ?? null;
   if (paidSource === "ai-credits") {
     return {
       body: "The reply stopped because this workspace's AI Credits ran out. Upgrade the plan to continue.",

--- a/apps/ui/src/features/chat/chat-billing-interruption.ts
+++ b/apps/ui/src/features/chat/chat-billing-interruption.ts
@@ -1,5 +1,5 @@
 import type { ChatBillingDestination } from "./chat-billing-cards";
-import type { ChatPaidSource } from "./persistence/types";
+import type { ChatPaidSource, ChatWallCause } from "./persistence/types";
 
 /**
  * A paid turn the AI proxy refused for billing reasons (design spec row
@@ -8,6 +8,12 @@ import type { ChatPaidSource } from "./persistence/types";
  * the pane's `onError` and the card copy.
  */
 export interface ChatBillingInterruption {
+  /**
+   * Set when the refusal named a missing AI allowance (ADR-0073): the
+   * workspace's plan grants no AI usage at all, forked on whether the Free
+   * Chat Turns story explains the stop.
+   */
+  allowance?: "plan" | "trial" | null;
   /** The paid source the refusal named, else the pane's own; null when neither is known. */
   paidSource: ChatPaidSource | null;
 }
@@ -20,6 +26,7 @@ export interface ChatBillingCopy {
 
 const BILLING_REFUSAL_CODES = new Set([
   "account_balance_exhausted",
+  "ai_allowance_missing",
   "ai_credits_exhausted",
   "ai_proxy_billing_refused",
 ]);
@@ -57,18 +64,64 @@ export function chatBillingInterruptionFromError(
   if (code === "ai_credits_exhausted") {
     return { paidSource: "ai-credits" };
   }
-  const named =
+  const detailRecord =
     typeof detail === "object" && detail != null
-      ? paidSourceFrom((detail as { paidSource?: unknown }).paidSource)
+      ? (detail as { allowance?: unknown; paidSource?: unknown })
       : null;
+  if (code === "ai_allowance_missing") {
+    return {
+      allowance: detailRecord?.allowance === "trial" ? "trial" : "plan",
+      paidSource: null,
+    };
+  }
+  const named = paidSourceFrom(detailRecord?.paidSource);
   return { paidSource: named ?? knownPaidSource };
 }
 
-/** The pre-send wall card's copy, forked by what the turn would spend. */
-export function chatBillingWallCopy(
-  paidSource: ChatPaidSource
-): ChatBillingCopy {
-  if (paidSource === "ai-credits") {
+/** The two allowance wall causes (ADR-0073), narrowed for staging. */
+export function chatAllowanceWall(
+  wall: ChatWallCause | null | undefined
+): "allowance-plan" | "allowance-trial" | null {
+  return wall === "allowance-plan" || wall === "allowance-trial" ? wall : null;
+}
+
+/**
+ * Whether the composer's message path is locked (ADR-0068, revised by
+ * ADR-0073): an exhausted Paid Source locks immediately, while an
+ * `allowance-*` wall stages — the advisory notice leaves the composer open,
+ * and the lock lands only once a send was actually refused (the
+ * interruption carries the refusal).
+ */
+export function chatMessagingLocked(
+  wall: ChatWallCause | null | undefined,
+  interruption: ChatBillingInterruption | null
+): boolean {
+  if (wall === "ai-credits" || wall === "balance") {
+    return true;
+  }
+  if (chatAllowanceWall(wall) != null) {
+    return interruption?.allowance != null;
+  }
+  return false;
+}
+
+/** The pre-send wall card's copy, forked by the refusing cause. */
+export function chatBillingWallCopy(cause: ChatWallCause): ChatBillingCopy {
+  if (cause === "allowance-trial") {
+    return {
+      body: "This workspace's plan doesn't include AI usage. Upgrade the plan to keep chatting.",
+      cta: { destination: "upgrade", label: "Upgrade plan" },
+      title: "Free trial messages used up",
+    };
+  }
+  if (cause === "allowance-plan") {
+    return {
+      body: "This workspace's plan doesn't include AI usage. Upgrade the plan to keep chatting.",
+      cta: { destination: "upgrade", label: "Upgrade plan" },
+      title: "AI usage not included",
+    };
+  }
+  if (cause === "ai-credits") {
     return {
       body: "This workspace's AI Credits are exhausted. Upgrade the plan to keep chatting.",
       cta: { destination: "upgrade", label: "Upgrade plan" },
@@ -82,10 +135,44 @@ export function chatBillingWallCopy(
   };
 }
 
+/**
+ * The advisory notice's copy (ADR-0073): the same cause the wall would
+ * name, spoken before any send was refused — so the composer stays open and
+ * the user learns what the next send runs into.
+ */
+export function chatBillingNoticeCopy(
+  cause: "allowance-plan" | "allowance-trial",
+  limit: number
+): ChatBillingCopy {
+  if (cause === "allowance-trial") {
+    return {
+      body: `This workspace has used all ${limit} free trial messages. Upgrade the plan to keep chatting.`,
+      cta: { destination: "upgrade", label: "Upgrade plan" },
+      title: "Free trial messages used up",
+    };
+  }
+  return {
+    body: "This workspace's plan doesn't include AI usage. Upgrade the plan to use the assistant.",
+    cta: { destination: "upgrade", label: "Upgrade plan" },
+    title: "AI usage not included",
+  };
+}
+
 /** The billing-ized error card's copy; an unknown source never claims one. */
 export function chatBillingInterruptionCopy(
-  paidSource: ChatPaidSource | null
+  interruption: ChatBillingInterruption | null
 ): ChatBillingCopy {
+  if (interruption?.allowance != null) {
+    return {
+      body: "The turn was refused because this workspace's plan doesn't include AI usage. Upgrade the plan to continue.",
+      cta: { destination: "upgrade", label: "Upgrade plan" },
+      title:
+        interruption.allowance === "trial"
+          ? "Message not sent — free trial messages used up"
+          : "Message not sent — AI usage not included",
+    };
+  }
+  const paidSource = interruption?.paidSource ?? null;
   if (paidSource === "ai-credits") {
     return {
       body: "The reply stopped because this workspace's AI Credits ran out. Upgrade the plan to continue.",
@@ -110,3 +197,16 @@ export function chatBillingInterruptionCopy(
 /** The locked composer's placeholder while the wall holds. */
 export const CHAT_WALL_PLACEHOLDER =
   "Chat is paused — resolve billing to continue";
+
+/** The locked placeholder, naming the allowance cause when it is the lock. */
+export function chatWallPlaceholder(
+  wall: ChatWallCause | null | undefined
+): string {
+  if (wall === "allowance-trial") {
+    return "Free trial messages used up — upgrade to continue";
+  }
+  if (wall === "allowance-plan") {
+    return "AI usage not included — upgrade to continue";
+  }
+  return CHAT_WALL_PLACEHOLDER;
+}

--- a/apps/ui/src/features/chat/chat-billing-interruption.ts
+++ b/apps/ui/src/features/chat/chat-billing-interruption.ts
@@ -71,21 +71,22 @@ export function chatBillingInterruptionFromError(
   return { paidSource: named ?? knownPaidSource };
 }
 
+/**
+ * Both allowance causes name the same fix — the plan grants no AI usage, so
+ * upgrade it (ADR-0073); only the title says why the stop arrived now.
+ */
+const ALLOWANCE_WALL_COPY: Omit<ChatBillingCopy, "title"> = {
+  body: "This workspace's plan doesn't include AI usage. Upgrade the plan to keep chatting.",
+  cta: { destination: "upgrade", label: "Upgrade plan" },
+};
+
 /** The pre-send wall card's copy, forked by the refusing cause. */
 export function chatBillingWallCopy(cause: ChatWallCause): ChatBillingCopy {
   if (cause === "allowance-trial") {
-    return {
-      body: "This workspace's plan doesn't include AI usage. Upgrade the plan to keep chatting.",
-      cta: { destination: "upgrade", label: "Upgrade plan" },
-      title: "Free trial messages used up",
-    };
+    return { ...ALLOWANCE_WALL_COPY, title: "Free trial messages used up" };
   }
   if (cause === "allowance-plan") {
-    return {
-      body: "This workspace's plan doesn't include AI usage. Upgrade the plan to keep chatting.",
-      cta: { destination: "upgrade", label: "Upgrade plan" },
-      title: "AI usage not included",
-    };
+    return { ...ALLOWANCE_WALL_COPY, title: "AI usage not included" };
   }
   if (cause === "ai-credits") {
     return {

--- a/apps/ui/src/features/chat/chat-billing-interruption.ts
+++ b/apps/ui/src/features/chat/chat-billing-interruption.ts
@@ -127,8 +127,7 @@ export function chatBillingInterruptionCopy(
 }
 
 /** The locked composer's placeholder while the wall holds. */
-export const CHAT_WALL_PLACEHOLDER =
-  "Chat is paused — resolve billing to continue";
+const CHAT_WALL_PLACEHOLDER = "Chat is paused — resolve billing to continue";
 
 /** The locked placeholder, naming the allowance cause when it is the lock. */
 export function chatWallPlaceholder(

--- a/apps/ui/src/features/chat/persistence/chat-billing-judgment.ts
+++ b/apps/ui/src/features/chat/persistence/chat-billing-judgment.ts
@@ -84,7 +84,7 @@ export async function judgeChatBilling(
       ? await judgeTrial(reads)
       : "not-trial";
   return {
-    paidWall: async () => paidChatWall(await standing),
+    paidWall: async () => paidChatWall(await standing, trial),
     snapshot,
     systemModelConfigured,
     trial,

--- a/apps/ui/src/features/chat/persistence/client.ts
+++ b/apps/ui/src/features/chat/persistence/client.ts
@@ -18,12 +18,15 @@ const uiMessageSchema = z
   .passthrough() as unknown as z.ZodType<UIMessage>;
 
 const paidSourceSchema = z.enum(["ai-credits", "balance"]).nullable();
+const wallCauseSchema = z
+  .enum(["ai-credits", "balance", "allowance-trial", "allowance-plan"])
+  .nullable();
 const freeTierSchema = z.object({
   billing: z.enum(["free", "user"]),
   remaining: z.number(),
   limit: z.number(),
   paidSource: paidSourceSchema.optional(),
-  wall: paidSourceSchema.optional(),
+  wall: wallCauseSchema.optional(),
 });
 
 const sessionResponseSchema = z.object({

--- a/apps/ui/src/features/chat/persistence/paid-chat-wall.test.ts
+++ b/apps/ui/src/features/chat/persistence/paid-chat-wall.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "bun:test";
 
 import type { WorkspaceBillingStanding } from "@/features/billing/server/billing-standing-core";
 
-import { paidChatWall } from "./paid-chat-wall";
+import {
+  AI_PROXY_MINIMUM_BALANCE_MICRO_UNITS,
+  paidChatWall,
+} from "./paid-chat-wall";
 
 function standing(
   overrides: Partial<WorkspaceBillingStanding>
@@ -57,6 +60,38 @@ describe("paidChatWall", () => {
       paidChatWall(
         standing({
           aiCredits: { totalMicroUnits: 3_000_000, usedMicroUnits: 2_800_000 },
+          paidSource: "ai-credits",
+        }),
+        "not-trial"
+      )
+    ).toEqual({ paidSource: "ai-credits", wall: "ai-credits" });
+  });
+
+  it("mirrors aiproxy's floor exactly: open at 0.3 remaining, walled one unit below (ADR-0073)", () => {
+    // aiproxy's CheckBalance passes at balance >= amount, so a remainder of
+    // exactly GroupMinimumBalance still dispatches; the mirror must agree at
+    // the edge, and the constant must stay the upstream 0.3 at 1e6 precision.
+    expect(AI_PROXY_MINIMUM_BALANCE_MICRO_UNITS).toBe(300_000);
+    const total = 3_000_000;
+    expect(
+      paidChatWall(
+        standing({
+          aiCredits: {
+            totalMicroUnits: total,
+            usedMicroUnits: total - AI_PROXY_MINIMUM_BALANCE_MICRO_UNITS,
+          },
+          paidSource: "ai-credits",
+        }),
+        "not-trial"
+      )
+    ).toEqual({ paidSource: "ai-credits", wall: null });
+    expect(
+      paidChatWall(
+        standing({
+          aiCredits: {
+            totalMicroUnits: total,
+            usedMicroUnits: total - AI_PROXY_MINIMUM_BALANCE_MICRO_UNITS + 1,
+          },
           paidSource: "ai-credits",
         }),
         "not-trial"

--- a/apps/ui/src/features/chat/persistence/paid-chat-wall.test.ts
+++ b/apps/ui/src/features/chat/persistence/paid-chat-wall.test.ts
@@ -23,7 +23,7 @@ function standing(
 
 describe("paidChatWall", () => {
   it("walls a PAYG workspace in Account Debt on its balance", () => {
-    expect(paidChatWall(standing({ accountDebt: true }))).toEqual({
+    expect(paidChatWall(standing({ accountDebt: true }), "not-trial")).toEqual({
       paidSource: "balance",
       wall: "balance",
     });
@@ -32,7 +32,8 @@ describe("paidChatWall", () => {
   it("leaves a low-but-positive PAYG balance open — the $5 tier belongs to notifications", () => {
     expect(
       paidChatWall(
-        standing({ accountDebt: false, availableBalanceMicroUnits: 400_000 })
+        standing({ accountDebt: false, availableBalanceMicroUnits: 400_000 }),
+        "not-trial"
       )
     ).toEqual({ paidSource: "balance", wall: null });
   });
@@ -43,7 +44,22 @@ describe("paidChatWall", () => {
         standing({
           aiCredits: { totalMicroUnits: 3_000_000, usedMicroUnits: 3_000_000 },
           paidSource: "ai-credits",
-        })
+        }),
+        "not-trial"
+      )
+    ).toEqual({ paidSource: "ai-credits", wall: "ai-credits" });
+  });
+
+  it("walls below aiproxy's minimum-balance floor, not only at zero (ADR-0073)", () => {
+    // aiproxy refuses at remain < 0.3 (GroupMinimumBalance); a remainder
+    // inside that dead zone would be refused upstream on every turn.
+    expect(
+      paidChatWall(
+        standing({
+          aiCredits: { totalMicroUnits: 3_000_000, usedMicroUnits: 2_800_000 },
+          paidSource: "ai-credits",
+        }),
+        "not-trial"
       )
     ).toEqual({ paidSource: "ai-credits", wall: "ai-credits" });
   });
@@ -57,18 +73,55 @@ describe("paidChatWall", () => {
           accountDebt: true,
           aiCredits: { totalMicroUnits: 3_000_000, usedMicroUnits: 1_200_000 },
           paidSource: "ai-credits",
-        })
+        }),
+        "not-trial"
       )
     ).toEqual({ paidSource: "ai-credits", wall: null });
   });
 
-  it("never walls on a plan with no AI Credits allowance at all", () => {
+  it("walls a zero-allowance plan with the trial voice on an Active Free Trial (ADR-0073)", () => {
+    // The production Free plan grants no AI Credits at all; upstream refuses
+    // every user-billed turn regardless of the account balance.
     expect(
       paidChatWall(
         standing({
           aiCredits: { totalMicroUnits: 0, usedMicroUnits: 0 },
           paidSource: "ai-credits",
-        })
+        }),
+        "trial"
+      )
+    ).toEqual({ paidSource: "ai-credits", wall: "allowance-trial" });
+  });
+
+  it("walls a zero-allowance plan with the plan voice off-trial (ADR-0073)", () => {
+    expect(
+      paidChatWall(
+        standing({
+          aiCredits: { totalMicroUnits: 0, usedMicroUnits: 0 },
+          paidSource: "ai-credits",
+        }),
+        "not-trial"
+      )
+    ).toEqual({ paidSource: "ai-credits", wall: "allowance-plan" });
+  });
+
+  it("speaks the plan voice when the trial judgment is unknown", () => {
+    expect(
+      paidChatWall(
+        standing({
+          aiCredits: { totalMicroUnits: 0, usedMicroUnits: 0 },
+          paidSource: "ai-credits",
+        }),
+        "unknown"
+      )
+    ).toEqual({ paidSource: "ai-credits", wall: "allowance-plan" });
+  });
+
+  it("fails open when the credits read is unknown", () => {
+    expect(
+      paidChatWall(
+        standing({ aiCredits: null, paidSource: "ai-credits" }),
+        "not-trial"
       )
     ).toEqual({ paidSource: "ai-credits", wall: null });
   });
@@ -76,7 +129,8 @@ describe("paidChatWall", () => {
   it("fails open when the standing is unknown", () => {
     expect(
       paidChatWall(
-        standing({ accountDebt: null, aiCredits: null, paidSource: null })
+        standing({ accountDebt: null, aiCredits: null, paidSource: null }),
+        "not-trial"
       )
     ).toEqual({ paidSource: null, wall: null });
   });

--- a/apps/ui/src/features/chat/persistence/paid-chat-wall.ts
+++ b/apps/ui/src/features/chat/persistence/paid-chat-wall.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceBillingStanding } from "@/features/billing/server/billing-standing-core";
+import type { FreeTrialJudgment } from "@/lib/account-service/free-trial-core";
 
 import type { ChatPaidSource, FreeTierState } from "./types";
 
@@ -9,10 +10,28 @@ import type { ChatPaidSource, FreeTierState } from "./types";
  * is walled when its allowance is spent; a PAYG workspace spends the Account
  * Balance and is walled in Account Debt. A low-but-positive balance never
  * walls — that voice belongs to notifications. Unknown standing fails open.
+ *
+ * A subscribed workspace whose plan grants no AI Credits at all
+ * (`total = 0` — the production Free plan, and any workspace upstream never
+ * granted a quota package) is refused by aiproxy on every turn, balance
+ * regardless, so it is walled with an `allowance-*` cause (ADR-0073): the
+ * trial judgment picks whether the Free Chat Turns story explains the stop.
  */
 export type PaidChatWall = Required<Pick<FreeTierState, "paidSource" | "wall">>;
 
-export function paidChatWall(standing: WorkspaceBillingStanding): PaidChatWall {
+/**
+ * aiproxy refuses a group below this remainder before dispatch — its
+ * `GroupMinimumBalance = 0.3` (core/middleware/distributor.go), here in the
+ * account service's 1e6-per-currency-unit precision. Judged with `<` the
+ * way aiproxy's `CheckBalance(amount) = balance >= amount` fails. If
+ * upstream moves the constant, this mirror must follow (ADR-0073).
+ */
+export const AI_PROXY_MINIMUM_BALANCE_MICRO_UNITS = 300_000;
+
+export function paidChatWall(
+  standing: WorkspaceBillingStanding,
+  trial: FreeTrialJudgment
+): PaidChatWall {
   const paidSource: ChatPaidSource | null = standing.paidSource;
   if (paidSource === "balance") {
     return {
@@ -22,11 +41,21 @@ export function paidChatWall(standing: WorkspaceBillingStanding): PaidChatWall {
   }
   if (paidSource === "ai-credits") {
     const credits = standing.aiCredits;
-    const spent =
-      credits != null &&
-      credits.totalMicroUnits > 0 &&
-      credits.usedMicroUnits >= credits.totalMicroUnits;
-    return { paidSource, wall: spent ? "ai-credits" : null };
+    if (credits == null) {
+      return { paidSource, wall: null };
+    }
+    if (credits.totalMicroUnits <= 0) {
+      return {
+        paidSource,
+        wall: trial === "trial" ? "allowance-trial" : "allowance-plan",
+      };
+    }
+    const remaining = credits.totalMicroUnits - credits.usedMicroUnits;
+    return {
+      paidSource,
+      wall:
+        remaining < AI_PROXY_MINIMUM_BALANCE_MICRO_UNITS ? "ai-credits" : null,
+    };
   }
   return { paidSource: null, wall: null };
 }

--- a/apps/ui/src/features/chat/persistence/types.ts
+++ b/apps/ui/src/features/chat/persistence/types.ts
@@ -94,9 +94,8 @@ export interface FreeTierState {
   remaining: number;
   /**
    * The billing cause that refuses the next `user` turn (design spec row
-   * E3, ADR-0073); absent/null while open. The `allowance-*` causes render
-   * staged: an advisory notice first, the locked wall only once a send was
-   * actually refused.
+   * E3, ADR-0073); absent/null while open. Every cause locks the composer
+   * at once.
    */
   wall?: ChatWallCause | null;
 }

--- a/apps/ui/src/features/chat/persistence/types.ts
+++ b/apps/ui/src/features/chat/persistence/types.ts
@@ -72,6 +72,20 @@ export const assistantThreadDTOSchema = z.object({
  */
 export type ChatPaidSource = "ai-credits" | "balance";
 
+/**
+ * Why the next `user` turn is refused (ADR-0073): an exhausted Paid Source
+ * (`ai-credits` | `balance`), or a subscription whose plan grants no AI
+ * allowance at all — upstream refuses those turns unconditionally, and the
+ * account balance is never consulted for a subscribed workspace. The
+ * allowance causes fork on whether the workspace's Free Chat Turns story
+ * explains the stop (`allowance-trial`: "free trial messages used up") or
+ * the plan itself does (`allowance-plan`: "AI usage not included").
+ */
+export type ChatWallCause =
+  | ChatPaidSource
+  | "allowance-trial"
+  | "allowance-plan";
+
 export interface FreeTierState {
   billing: "free" | "user";
   limit: number;
@@ -79,10 +93,12 @@ export interface FreeTierState {
   paidSource?: ChatPaidSource | null;
   remaining: number;
   /**
-   * The exhausted paid source that blocks the next `user` turn (design spec
-   * row E3); absent/null while open.
+   * The billing cause that refuses the next `user` turn (design spec row
+   * E3, ADR-0073); absent/null while open. The `allowance-*` causes render
+   * staged: an advisory notice first, the locked wall only once a send was
+   * actually refused.
    */
-  wall?: ChatPaidSource | null;
+  wall?: ChatWallCause | null;
 }
 
 /** Bootstrap payload returned by `GET /api/chat/session`. */

--- a/apps/ui/src/features/chat/runtime/errors.ts
+++ b/apps/ui/src/features/chat/runtime/errors.ts
@@ -10,6 +10,7 @@ import type { WorkspaceActorAuthFailureCode } from "@/lib/request-kubeconfig-aut
 export type ChatApiErrorCode =
   | WorkspaceActorAuthFailureCode
   | "account_balance_exhausted"
+  | "ai_allowance_missing"
   | "ai_connection_unavailable"
   | "ai_credits_exhausted"
   | "ai_proxy_billing_refused"

--- a/apps/ui/src/features/shell/project-workspace-layout.tsx
+++ b/apps/ui/src/features/shell/project-workspace-layout.tsx
@@ -53,7 +53,6 @@ import {
 import {
   type ChatBillingInterruption,
   chatBillingInterruptionFromError,
-  chatMessagingLocked,
   chatWallPlaceholder,
 } from "@/features/chat/chat-billing-interruption";
 import {
@@ -417,7 +416,6 @@ const ProjectAssistantComposerMemo = memo(ProjectAssistantComposer);
 function ProjectAssistantChatSession({
   bootstrap,
   freeTier,
-  interruptionOverride = null,
   threads,
   assistantNamespaceRaw,
   onAssistantStreamFinished,
@@ -431,8 +429,6 @@ function ProjectAssistantChatSession({
 }: {
   bootstrap: Pick<AssistantSessionPayload, "chatId" | "messages">;
   freeTier: FreeTierState | null;
-  /** Dev-tweak staging of a refused allowance send (ADR-0073); null in prod. */
-  interruptionOverride?: ChatBillingInterruption | null;
   threads: AssistantThreadDTO[];
   assistantNamespaceRaw: string;
   onAssistantStreamFinished?: () => Promise<void>;
@@ -478,7 +474,6 @@ function ProjectAssistantChatSession({
   // nothing, the pre-send gate owns the lock.
   const [billingInterruption, setBillingInterruption] =
     useState<ChatBillingInterruption | null>(null);
-  const shownInterruption = interruptionOverride ?? billingInterruption;
   const paidSourceRef = useRef<ChatPaidSource | null>(null);
   const knownPaidSource = freeTier?.paidSource ?? null;
   useEffect(() => {
@@ -807,16 +802,13 @@ function ProjectAssistantChatSession({
         <ChatBillingCardSlot
           errored={status === "error"}
           freeTier={freeTier}
-          interruption={shownInterruption}
+          interruption={billingInterruption}
           onNavigateToBilling={navigateToBilling}
         />
         <ProjectAssistantComposerMemo
           busy={busy}
           lockedPlaceholder={chatWallPlaceholder(freeTier?.wall)}
-          messagingLocked={chatMessagingLocked(
-            freeTier?.wall,
-            shownInterruption
-          )}
+          messagingLocked={freeTier?.wall != null}
           onDatabaseIntent={onDatabaseIntent}
           onDockerIntent={onDockerIntent}
           onGithubIntent={onGithubIntent}
@@ -1026,8 +1018,7 @@ function ProjectAssistantChatPane() {
     <ProjectAssistantChatSession
       assistantNamespaceRaw={namespaceRaw}
       bootstrap={session}
-      freeTier={freeTierOverride?.freeTier ?? freeTier}
-      interruptionOverride={freeTierOverride?.interruption ?? null}
+      freeTier={freeTierOverride ?? freeTier}
       key={session.chatId}
       onAssistantStreamFinished={refreshAssistantState}
       onBillingHeaders={handleBillingHeaders}

--- a/apps/ui/src/features/shell/project-workspace-layout.tsx
+++ b/apps/ui/src/features/shell/project-workspace-layout.tsx
@@ -51,9 +51,10 @@ import {
   type ChatBillingDestination,
 } from "@/features/chat/chat-billing-cards";
 import {
-  CHAT_WALL_PLACEHOLDER,
   type ChatBillingInterruption,
   chatBillingInterruptionFromError,
+  chatMessagingLocked,
+  chatWallPlaceholder,
 } from "@/features/chat/chat-billing-interruption";
 import {
   fetchAssistantSession,
@@ -64,6 +65,7 @@ import {
   type AssistantSessionPayload,
   type AssistantThreadDTO,
   type ChatPaidSource,
+  type ChatWallCause,
   type FreeTierState,
   SELECTED_RESOURCE_CONTEXT_PART_TYPE,
   type SelectedResourceContext,
@@ -415,6 +417,7 @@ const ProjectAssistantComposerMemo = memo(ProjectAssistantComposer);
 function ProjectAssistantChatSession({
   bootstrap,
   freeTier,
+  interruptionOverride = null,
   threads,
   assistantNamespaceRaw,
   onAssistantStreamFinished,
@@ -428,6 +431,8 @@ function ProjectAssistantChatSession({
 }: {
   bootstrap: Pick<AssistantSessionPayload, "chatId" | "messages">;
   freeTier: FreeTierState | null;
+  /** Dev-tweak staging of a refused allowance send (ADR-0073); null in prod. */
+  interruptionOverride?: ChatBillingInterruption | null;
   threads: AssistantThreadDTO[];
   assistantNamespaceRaw: string;
   onAssistantStreamFinished?: () => Promise<void>;
@@ -473,6 +478,7 @@ function ProjectAssistantChatSession({
   // nothing, the pre-send gate owns the lock.
   const [billingInterruption, setBillingInterruption] =
     useState<ChatBillingInterruption | null>(null);
+  const shownInterruption = interruptionOverride ?? billingInterruption;
   const paidSourceRef = useRef<ChatPaidSource | null>(null);
   const knownPaidSource = freeTier?.paidSource ?? null;
   useEffect(() => {
@@ -801,13 +807,16 @@ function ProjectAssistantChatSession({
         <ChatBillingCardSlot
           errored={status === "error"}
           freeTier={freeTier}
-          interruption={billingInterruption}
+          interruption={shownInterruption}
           onNavigateToBilling={navigateToBilling}
         />
         <ProjectAssistantComposerMemo
           busy={busy}
-          lockedPlaceholder={CHAT_WALL_PLACEHOLDER}
-          messagingLocked={freeTier?.wall != null}
+          lockedPlaceholder={chatWallPlaceholder(freeTier?.wall)}
+          messagingLocked={chatMessagingLocked(
+            freeTier?.wall,
+            shownInterruption
+          )}
           onDatabaseIntent={onDatabaseIntent}
           onDockerIntent={onDockerIntent}
           onGithubIntent={onGithubIntent}
@@ -823,6 +832,12 @@ function ProjectAssistantChatSession({
 
 function chatPaidSourceHeader(value: string | null): ChatPaidSource | null {
   return value === "ai-credits" || value === "balance" ? value : null;
+}
+
+function chatWallCauseHeader(value: string | null): ChatWallCause | null {
+  return value === "allowance-plan" || value === "allowance-trial"
+    ? value
+    : chatPaidSourceHeader(value);
 }
 
 function ProjectAssistantChatPane() {
@@ -894,7 +909,7 @@ function ProjectAssistantChatPane() {
     // The paid wall rides the same header set (row E3): a 402 that slipped
     // past the panel's pre-check locks the composer here.
     const paidSource = chatPaidSourceHeader(headers.get("X-Chat-Paid-Source"));
-    const wall = chatPaidSourceHeader(headers.get("X-Chat-Wall"));
+    const wall = chatWallCauseHeader(headers.get("X-Chat-Wall"));
     setFreeTier((prev) => {
       if (Number.isFinite(remaining) && Number.isFinite(limit)) {
         return { billing: billingHeader, limit, paidSource, remaining, wall };
@@ -1011,7 +1026,8 @@ function ProjectAssistantChatPane() {
     <ProjectAssistantChatSession
       assistantNamespaceRaw={namespaceRaw}
       bootstrap={session}
-      freeTier={freeTierOverride ?? freeTier}
+      freeTier={freeTierOverride?.freeTier ?? freeTier}
+      interruptionOverride={freeTierOverride?.interruption ?? null}
       key={session.chatId}
       onAssistantStreamFinished={refreshAssistantState}
       onBillingHeaders={handleBillingHeaders}

--- a/docs/adr/0068-judge-billing-interruptions-from-billing-standing.md
+++ b/docs/adr/0068-judge-billing-interruptions-from-billing-standing.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted; the pre-deploy seam's posture is revised by ADR-0070 — the Deploy Billing Wall's refusal is softened into the advisory Deploy Billing Notice. The judgment itself, the terminal failure reverse-check, and the Paid Chat Wall stand.
+Accepted; the pre-deploy seam's posture is revised by ADR-0070 — the Deploy Billing Wall's refusal is softened into the advisory Deploy Billing Notice. The judgment itself, the terminal failure reverse-check, and the Paid Chat Wall stand; ADR-0073 extends the Paid Chat Wall with a third cause (a plan that grants no AI allowance) and its `ai_allowance_missing` code.
 
 The platform stops a workspace's work when its money or quota runs out, but it tells Brain nothing: Sealos suspends an account in Account Debt by pinning the namespace under a zero `debt-limit0` ResourceQuota and scaling its workloads to zero, and a full deployable quota simply leaves a pod unschedulable. A Deployment Runner sees only a stall (a runtime or readiness timeout, or an `exceeded quota` apply error naming `debt-limit0`), and an AI Proxy turn sees a `403 group_balance_not_enough`. We decided to name these Billing Interruptions by **re-reading the workspace's billing standing** — one account-service read of account, credits, subscription and resource quota, judged into Account Debt / full quota / Paid Source — at three seams that must never disagree: the pre-deploy judgment before a run (then the Deploy Billing Wall, since ADR-0070 the advisory Deploy Billing Notice), the deployment's terminal failure write, and the Paid Chat Wall before a `user` turn.
 
@@ -12,7 +12,7 @@ The platform stops a workspace's work when its money or quota runs out, but it t
 
 **When the reverse-check names a cause the runner never saw, the curated reason replaces the raw error on every runner.** The stall text contradicts the headline ("balance exhausted" over a timeout stack, "quota full" over a readiness timeout), so ADR-0042's raw display is withheld for it — the scrub ⇔ raw-display rule stands, the raw text is dropped rather than shown. An apply-time quota error the provider itself reported keeps the raw text under the quota evidence.
 
-**Paid chat turns are walled server-side before any state mutates (extends ADR-0065 and ADR-0069).** A `user` turn whose Paid Source is exhausted is refused with HTTP 402 and a `code` of `ai_credits_exhausted` or `account_balance_exhausted`, carrying the Paid Source and wall in the `X-Chat-*` header set; the AI Proxy's own mid-stream billing refusal is classified as `ai_proxy_billing_refused`. Arbitration in the card slot is wall > billing-error > error > counter. A `user` turn costs the trial judgment plus the standing reads, run in parallel under the same 5 s budget — where ADR-0065 spoke of one call per turn, there are now several, still uncached and still fail-open.
+**Paid chat turns are walled server-side before any state mutates (extends ADR-0065 and ADR-0069).** A `user` turn whose Paid Source is exhausted is refused with HTTP 402 and a `code` of `ai_credits_exhausted` or `account_balance_exhausted` (a plan that grants no AI allowance at all is refused with `ai_allowance_missing` — ADR-0073), carrying the Paid Source and wall in the `X-Chat-*` header set; the AI Proxy's own mid-stream billing refusal is classified as `ai_proxy_billing_refused`. Arbitration in the card slot is wall > billing-error > error > counter. A `user` turn costs the trial judgment plus the standing reads, run in parallel under the same 5 s budget — where ADR-0065 spoke of one call per turn, there are now several, still uncached and still fail-open.
 
 **Every seam fails open.** A failed, timed-out or unparsable standing read walls nothing, rewrites nothing and refuses nothing; the pre-deploy wall never triggers on a low but positive balance.
 
@@ -28,7 +28,7 @@ The platform stops a workspace's work when its money or quota runs out, but it t
 
 - The terminal failure write is now also the billing chokepoint: a run launched without a verifiable Workspace Actor cannot reverse-check and keeps its stall classification.
 - Two Deployment Failure Reasons and their Billing Evidence are proven by a read of account-service, not by the runner; tests exercise the judgment as a pure function over a standing.
-- `/api/chat` exposes two paid-wall 402 codes; ADR-0065's per-turn cost line now reads "several reads under one budget". ADR-0069 later removes the free-turn exhaustion 402.
+- `/api/chat` exposes two paid-wall 402 codes (three since ADR-0073 added the allowance cause); ADR-0065's per-turn cost line now reads "several reads under one budget". ADR-0069 later removes the free-turn exhaustion 402.
 - A subscription under the Deletion Countdown (payment-due) is suspended too, but it is neither Account Debt nor a full quota: its deployment still fails as the stall the runner saw, and the payment-due status hint carries the Renew voice. Walling or naming it needs its own Deployment Failure Reason and a revision of the Deploy Billing Wall — a follow-up taken by ADR-0070, which folds payment-due into the Deploy Billing Notice and commissions its reason.
 - Dev fixtures can stage both walls and both interruptions (`failed-balance`, `failed-quota`, `ai-credits-exhausted`, `refused-*`), since the platform's steady-state mocks alone cannot.
 

--- a/docs/adr/0069-separate-platform-ai-credentials-and-hand-off-free-chat.md
+++ b/docs/adr/0069-separate-platform-ai-credentials-and-hand-off-free-chat.md
@@ -1,5 +1,12 @@
 # Separate platform AI credentials and hand off exhausted Free Chat Turns
 
+## Status
+
+Exhaustion consequence revised by ADR-0073: the handoff stands, but a plan
+that grants no AI allowance (the production Free plan's `ai_quota` is 0)
+meets the Paid Chat Wall's allowance cause instead of a spendable Paid
+Source, staged as an advisory notice before the locked wall.
+
 Chat Agent and GitHub Deployment Tasks are different workloads with different
 platform funding. Their environment variables must select only their own
 platform connection, then fall back directly to the caller's AI Proxy. This
@@ -59,10 +66,10 @@ variable and is not a Brain configuration input.
 
 ## Consequences
 
-- The sixth successful Chat Agent turn in an eligible Active Free Trial
-  workspace can consume the caller's AI Credits or Account Balance. The Paid
-  Chat Wall remains the server-authoritative refusal when that source is
-  exhausted.
+- The sixth Chat Agent turn in an eligible Active Free Trial workspace spends
+  the caller's AI Credits where the plan grants any (a subscribed workspace
+  never spends the Account Balance on AI — ADR-0073). The Paid Chat Wall
+  remains the server-authoritative refusal when nothing is spendable.
 - Operators can disable platform-funded GitHub Deployment Tasks by leaving the
   dedicated pair blank without affecting platform-funded Chat turns.
 - No database migration is required. Existing Deploy Devboxes retain the

--- a/docs/adr/0069-separate-platform-ai-credentials-and-hand-off-free-chat.md
+++ b/docs/adr/0069-separate-platform-ai-credentials-and-hand-off-free-chat.md
@@ -25,9 +25,11 @@ system connection use `user` billing from their first turn.
 **Exhaustion hands off to the caller's AI Proxy.** After an eligible workspace
 spends its last Free Chat Turn, Chat Billing Mode becomes `user`. The next turn
 uses the caller's AI Proxy and is gated by ADR-0068's Paid Chat Wall before any
-conversation state changes. The former `blocked` mode,
-`free_chat_turns_exhausted` response, locked composer, and upgrade card are
-removed. A platform-funded turn that fails does not retry against the user's
+conversation state changes. The former `blocked` mode and its
+`free_chat_turns_exhausted` response are removed; a locked composer and an
+upgrade card return only as the Paid Chat Wall's allowance cause, which is
+what a plan without an AI allowance meets on that next turn (ADR-0073). A
+platform-funded turn that fails does not retry against the user's
 AI Proxy in the same request; silent provider failover would unexpectedly bill
 the user.
 
@@ -57,7 +59,9 @@ variable and is not a Brain configuration input.
 
 - **Keep blocking an Active Free Trial after five turns.** Rejected: the
   product now intentionally continues through the caller's metered AI Proxy,
-  subject to the Paid Chat Wall.
+  subject to the Paid Chat Wall. (Where the plan grants no AI allowance, that
+  wall is what the trial meets — ADR-0073 — so the stop is a truthful wall,
+  not the former blanket block.)
 - **Let GitHub Deployment Tasks reuse Chat Agent or host Codex credentials.**
   Rejected: it hides which platform budget funds a task and makes an unrelated
   Chat configuration change deployment billing.

--- a/docs/adr/0069-separate-platform-ai-credentials-and-hand-off-free-chat.md
+++ b/docs/adr/0069-separate-platform-ai-credentials-and-hand-off-free-chat.md
@@ -5,7 +5,7 @@
 Exhaustion consequence revised by ADR-0073: the handoff stands, but a plan
 that grants no AI allowance (the production Free plan's `ai_quota` is 0)
 meets the Paid Chat Wall's allowance cause instead of a spendable Paid
-Source, staged as an advisory notice before the locked wall.
+Source.
 
 Chat Agent and GitHub Deployment Tasks are different workloads with different
 platform funding. Their environment variables must select only their own

--- a/docs/adr/0073-wall-zero-allowance-plans-and-stage-the-allowance-notice.md
+++ b/docs/adr/0073-wall-zero-allowance-plans-and-stage-the-allowance-notice.md
@@ -1,0 +1,83 @@
+# Wall zero-allowance plans and stage the allowance notice
+
+ADR-0069 hands exhausted Free Chat Turns to the caller's AI Proxy on the
+assumption that a spendable Paid Source is waiting there. Upstream facts
+(verified 2026-09-01 against the usw-1 production cluster, `labring/sealos`
+and `labring/aiproxy` sources) say otherwise for the plans that matter most.
+This decision revises ADR-0069's exhaustion consequence and extends
+ADR-0068's Paid Chat Wall with a truthful cause and a staged posture.
+
+## Upstream facts
+
+- **The production Free plan grants no AI Credits.** Its `ai_quota` is 0,
+  and account-service skips creating a quota package entirely when
+  `ai_quota <= 0` — so a Free-trial workspace's `user` turns are refused by
+  aiproxy unconditionally, on every turn.
+- **A subscribed workspace never spends the Account Balance on AI.** For a
+  namespace carrying the `subscription.sealos.io/status` annotation, the
+  aiproxy pre-check reads only `remainAIQuota`; account-service's response
+  has no balance field on that branch, and the charge endpoint branches
+  hard between quota and balance. There is no fallback.
+- **aiproxy refuses below a floor, not at zero.** Its
+  `GroupMinimumBalance = 0.3` (and a per-request estimated-cost check)
+  refuses while a small remainder still shows.
+- The former judgment here (`total > 0 && used >= total`) therefore never
+  walled the zero-allowance case: the composer stayed open and every send
+  died as a generic error instead of a billing refusal.
+
+## Decision
+
+**A zero AI allowance walls, with a truthful cause.** When the standing
+read shows AI Credits with `total <= 0`, the Paid Chat Wall's cause is
+`allowance-trial` (the Active Free Trial judgment explains the stop:
+"Free trial messages used up") or `allowance-plan` (everything else:
+"AI usage not included"). An unknown credits read still fails open.
+
+**The exhaustion floor mirrors aiproxy.** AI Credits are exhausted below
+`AI_PROXY_MINIMUM_BALANCE_MICRO_UNITS = 300_000` (0.3 currency units at the
+1e6 precision), not at zero, so the wall and the upstream refusal agree at
+the bottom of the allowance. If upstream moves `GroupMinimumBalance`, this
+mirror must follow.
+
+**Allowance walls stage; Paid Source walls still lock at once.** An
+`allowance-*` wall renders first as an advisory notice in the warning
+voice — same cause, same Upgrade CTA, composer open, so the user learns
+what the next send runs into without being locked out of a pane they may
+only want to read. The pre-send gate refuses the send anyway
+(`402 ai_allowance_missing`, the draft stays in the composer), and that
+refusal arms the locked wall card for the rest of the pane's life. The
+`ai-credits` and `balance` walls keep ADR-0068's immediate lock.
+
+**The Billing Interruption speaks the same causes.** A refusal that slips
+past the gate (cache races, mid-stream) renders the allowance copy, not
+"AI Credits ran out" — a workspace that never held credits is never told it
+spent them.
+
+**Dev tooling covers every posture.** The chat billing-card tweak stages
+the notice and the refused wall in both voices; the billing Dev Mock now
+answers `/api/chat/free-turns` from a fixture so the sidebar's usage row
+and the Plan view's allowance card follow the scenario.
+
+## Considered Options
+
+- **Keep the silent handoff as shipped.** Rejected: on the production Free
+  plan the sixth turn is a guaranteed refusal loop told as generic errors.
+- **Restore the pre-ADR-0069 blocked mode (lock on exhaustion).** Rejected:
+  locking before any send overstates — the wall's refusal is what earns the
+  lock — and its copy ("free trial used up") is untrue for workspaces that
+  never had a trial.
+- **Fall back to the Account Balance when credits run out.** Rejected:
+  upstream has no such path for a subscribed workspace; pretending
+  otherwise would mis-narrate every refusal.
+
+## Consequences
+
+- An Active Free Trial workspace sees the allowance notice the moment its
+  last Free Chat Turn is spent, and the locked wall only after insisting.
+- ADR-0069's "the sixth turn can consume the caller's AI Credits or Account
+  Balance" holds only where the plan actually grants AI Credits; on the
+  production Free plan the sixth turn meets the allowance wall instead.
+- The 0.3 floor is a deliberate copy of an upstream constant and can drift;
+  it lives in one exported constant beside the wall judgment.
+- CONTEXT.md's Paid Chat Wall and Free Chat Turns entries are updated for
+  the allowance causes and the staged notice.

--- a/docs/adr/0073-wall-zero-allowance-plans-with-a-truthful-cause.md
+++ b/docs/adr/0073-wall-zero-allowance-plans-with-a-truthful-cause.md
@@ -1,11 +1,11 @@
-# Wall zero-allowance plans and stage the allowance notice
+# Wall zero-allowance plans with a truthful cause
 
 ADR-0069 hands exhausted Free Chat Turns to the caller's AI Proxy on the
 assumption that a spendable Paid Source is waiting there. Upstream facts
 (verified 2026-09-01 against the usw-1 production cluster, `labring/sealos`
 and `labring/aiproxy` sources) say otherwise for the plans that matter most.
 This decision revises ADR-0069's exhaustion consequence and extends
-ADR-0068's Paid Chat Wall with a truthful cause and a staged posture.
+ADR-0068's Paid Chat Wall with a truthful cause.
 
 ## Upstream facts
 
@@ -31,7 +31,10 @@ ADR-0068's Paid Chat Wall with a truthful cause and a staged posture.
 read shows AI Credits with `total <= 0`, the Paid Chat Wall's cause is
 `allowance-trial` (the Active Free Trial judgment explains the stop:
 "Free trial messages used up") or `allowance-plan` (everything else:
-"AI usage not included"). An unknown credits read still fails open.
+"AI usage not included"). An unknown credits read still fails open. The
+wall behaves as every Paid Chat Wall does under ADR-0068: the pre-send gate
+refuses with `402 ai_allowance_missing`, the card names the cause and the
+Upgrade CTA, and the composer locks at once with a placeholder stating why.
 
 **The exhaustion floor mirrors aiproxy.** AI Credits are exhausted below
 `AI_PROXY_MINIMUM_BALANCE_MICRO_UNITS = 300_000` (0.3 currency units at the
@@ -39,45 +42,40 @@ read shows AI Credits with `total <= 0`, the Paid Chat Wall's cause is
 the bottom of the allowance. If upstream moves `GroupMinimumBalance`, this
 mirror must follow.
 
-**Allowance walls stage; Paid Source walls still lock at once.** An
-`allowance-*` wall renders first as an advisory notice in the warning
-voice — same cause, same Upgrade CTA, composer open, so the user learns
-what the next send runs into without being locked out of a pane they may
-only want to read. The pre-send gate refuses the send anyway
-(`402 ai_allowance_missing`, the draft stays in the composer), and that
-refusal arms the locked wall card for the rest of the pane's life. The
-`ai-credits` and `balance` walls keep ADR-0068's immediate lock.
-
-**The Billing Interruption speaks the same causes.** A refusal that slips
-past the gate (cache races, mid-stream) renders the allowance copy, not
-"AI Credits ran out" — a workspace that never held credits is never told it
-spent them.
-
-**Dev tooling covers every posture.** The chat billing-card tweak stages
-the notice and the refused wall in both voices; the billing Dev Mock now
-answers `/api/chat/free-turns` from a fixture so the sidebar's usage row
-and the Plan view's allowance card follow the scenario.
+**Dev tooling covers every posture.** The chat billing-card tweak fabricates
+the allowance wall in both voices; the billing Dev Mock answers
+`/api/chat/free-turns` from a fixture so the sidebar's usage row and the
+Plan view's allowance card follow the scenario.
 
 ## Considered Options
 
 - **Keep the silent handoff as shipped.** Rejected: on the production Free
   plan the sixth turn is a guaranteed refusal loop told as generic errors.
-- **Restore the pre-ADR-0069 blocked mode (lock on exhaustion).** Rejected:
-  locking before any send overstates — the wall's refusal is what earns the
-  lock — and its copy ("free trial used up") is untrue for workspaces that
-  never had a trial.
+- **Restore the pre-ADR-0069 blocked mode with its single copy.** Rejected:
+  "free trial used up" is untrue for workspaces that never had a trial. The
+  lock is kept; the cause is forked.
+- **Soften the wall into an advisory notice** (ADR-0070's deploy pattern:
+  composer open until a send is actually refused, the refusal arming the
+  lock). Rejected: a wall that already knows the next send is refused has
+  nothing to wait for, and a refusal-armed lock splits the locking state
+  between the pane and its per-thread session.
 - **Fall back to the Account Balance when credits run out.** Rejected:
   upstream has no such path for a subscribed workspace; pretending
   otherwise would mis-narrate every refusal.
 
 ## Consequences
 
-- An Active Free Trial workspace sees the allowance notice the moment its
-  last Free Chat Turn is spent, and the locked wall only after insisting.
+- An Active Free Trial workspace meets the locked allowance wall the moment
+  its last Free Chat Turn is spent, in the Free trial messages voice; a
+  subscription that never had a trial meets it in the plan voice.
 - ADR-0069's "the sixth turn can consume the caller's AI Credits or Account
   Balance" holds only where the plan actually grants AI Credits; on the
   production Free plan the sixth turn meets the allowance wall instead.
 - The 0.3 floor is a deliberate copy of an upstream constant and can drift;
   it lives in one exported constant beside the wall judgment.
+- A refusal that bypasses the gate (a credits read that failed open, then
+  aiproxy refusing the turn) is still voiced as a Billing Interruption from
+  the Paid Source the pane knows — AI Credits, for a zero-allowance
+  subscription. Narrowing that voice to the allowance cause is a follow-up.
 - CONTEXT.md's Paid Chat Wall and Free Chat Turns entries are updated for
-  the allowance causes and the staged notice.
+  the allowance causes.

--- a/docs/adr/0073-wall-zero-allowance-plans-with-a-truthful-cause.md
+++ b/docs/adr/0073-wall-zero-allowance-plans-with-a-truthful-cause.md
@@ -11,7 +11,7 @@ ADR-0068's Paid Chat Wall with a truthful cause.
 
 - **The production Free plan grants no AI Credits.** Its `ai_quota` is 0,
   and account-service skips creating a quota package entirely when
-  `ai_quota <= 0` — so a Free-trial workspace's `user` turns are refused by
+  `ai_quota <= 0` — so an Active Free Trial workspace's `user` turns are refused by
   aiproxy unconditionally, on every turn.
 - **A subscribed workspace never spends the Account Balance on AI.** For a
   namespace carrying the `subscription.sealos.io/status` annotation, the

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,7 +43,7 @@ One line per decision; the linked record is authoritative. When adding an ADR, t
 - [0069 — Separate platform AI credentials and hand off exhausted Free Chat Turns](0069-separate-platform-ai-credentials-and-hand-off-free-chat.md) *(revises ADR-0065 and extends ADR-0068; exhaustion consequence revised by ADR-0073)*
 - [0070 — Soften the Deploy Billing Wall into the Deploy Billing Notice](0070-soften-the-deploy-billing-wall-into-the-deploy-billing-notice.md) *(revises ADR-0068's pre-deploy seam)*
 - [0071 — Unify notification CTA styling into the CTA Chip](0071-unify-notification-cta-styling-into-the-cta-chip.md)
-- [0073 — Wall zero-allowance plans and stage the allowance notice](0073-wall-zero-allowance-plans-and-stage-the-allowance-notice.md) *(revises ADR-0069's exhaustion consequence; extends ADR-0068's Paid Chat Wall)*
+- [0073 — Wall zero-allowance plans with a truthful cause](0073-wall-zero-allowance-plans-with-a-truthful-cause.md) *(revises ADR-0069's exhaustion consequence; extends ADR-0068's Paid Chat Wall)*
 
 ## Conventions
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,9 +40,10 @@ One line per decision; the linked record is authoritative. When adding an ADR, t
 - [0066 — Give Canvas Resources Editable Display Names Stored on the Resource](0066-store-resource-display-names-in-annotations.md)
 - [0067 — Store Notifications Hybrid: Read Platform CRs Live, Keep Brain's Own in App Postgres](0067-store-notifications-hybrid-cr-read-proxy-and-brain-postgres.md)
 - [0068 — Judge Billing Interruptions from billing standing, after a deployment fails and before a paid chat turn starts](0068-judge-billing-interruptions-from-billing-standing.md) *(extends ADR-0042 and ADR-0065; paid handoff extended by ADR-0069; pre-deploy seam softened by ADR-0070)*
-- [0069 — Separate platform AI credentials and hand off exhausted Free Chat Turns](0069-separate-platform-ai-credentials-and-hand-off-free-chat.md) *(revises ADR-0065 and extends ADR-0068)*
+- [0069 — Separate platform AI credentials and hand off exhausted Free Chat Turns](0069-separate-platform-ai-credentials-and-hand-off-free-chat.md) *(revises ADR-0065 and extends ADR-0068; exhaustion consequence revised by ADR-0073)*
 - [0070 — Soften the Deploy Billing Wall into the Deploy Billing Notice](0070-soften-the-deploy-billing-wall-into-the-deploy-billing-notice.md) *(revises ADR-0068's pre-deploy seam)*
 - [0071 — Unify notification CTA styling into the CTA Chip](0071-unify-notification-cta-styling-into-the-cta-chip.md)
+- [0073 — Wall zero-allowance plans and stage the allowance notice](0073-wall-zero-allowance-plans-and-stage-the-allowance-notice.md) *(revises ADR-0069's exhaustion consequence; extends ADR-0068's Paid Chat Wall)*
 
 ## Conventions
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,7 +39,7 @@ One line per decision; the linked record is authoritative. When adding an ADR, t
 - [0065 — Gate Free Chat Turns on the Active Free Trial](0065-gate-free-chat-turns-on-the-active-free-trial-and-block-on-exhaustion.md) *(replaces the deleted ADR-0033; exhaustion behavior revised by ADR-0069)*
 - [0066 — Give Canvas Resources Editable Display Names Stored on the Resource](0066-store-resource-display-names-in-annotations.md)
 - [0067 — Store Notifications Hybrid: Read Platform CRs Live, Keep Brain's Own in App Postgres](0067-store-notifications-hybrid-cr-read-proxy-and-brain-postgres.md)
-- [0068 — Judge Billing Interruptions from billing standing, after a deployment fails and before a paid chat turn starts](0068-judge-billing-interruptions-from-billing-standing.md) *(extends ADR-0042 and ADR-0065; paid handoff extended by ADR-0069; pre-deploy seam softened by ADR-0070)*
+- [0068 — Judge Billing Interruptions from billing standing, after a deployment fails and before a paid chat turn starts](0068-judge-billing-interruptions-from-billing-standing.md) *(extends ADR-0042 and ADR-0065; paid handoff extended by ADR-0069; pre-deploy seam softened by ADR-0070; Paid Chat Wall cause extended by ADR-0073)*
 - [0069 — Separate platform AI credentials and hand off exhausted Free Chat Turns](0069-separate-platform-ai-credentials-and-hand-off-free-chat.md) *(revises ADR-0065 and extends ADR-0068; exhaustion consequence revised by ADR-0073)*
 - [0070 — Soften the Deploy Billing Wall into the Deploy Billing Notice](0070-soften-the-deploy-billing-wall-into-the-deploy-billing-notice.md) *(revises ADR-0068's pre-deploy seam)*
 - [0071 — Unify notification CTA styling into the CTA Chip](0071-unify-notification-cta-styling-into-the-cta-chip.md)


### PR DESCRIPTION
## Why

While chasing why the dev-tweaks panel could no longer stage the "free trial messages used up" state, I checked what the production platform actually does after the fifth Free Chat Turn — against the `usw-1` cluster and the `labring/sealos` / `labring/aiproxy` sources:

- **The production Free plan grants no AI Credits** (`ai_quota = 0` in `plan-list`), and account-service creates no quota package unless `plan.AIQuota > 0`.
- **A subscribed workspace never spends the Account Balance on AI.** aiproxy's pre-check reads only `remainAIQuota` for a namespace carrying the `subscription.sealos.io/status` annotation; account-service's response has no balance field on that branch ("for subscription, there is no balance field"), and the charge endpoint branches hard between quota and balance.
- **aiproxy refuses below `GroupMinimumBalance = 0.3`**, not at zero.

So ADR-0069's silent handoff put a Free-trial workspace's sixth turn onto an unconditional 403, and because our wall judgment required `total > 0`, nothing walled it — the user got generic error cards on every send.

## What

- **Judgment** (`paid-chat-wall.ts`): `total <= 0` walls with a truthful cause — `allowance-trial` on an Active Free Trial ("Free trial messages used up") or `allowance-plan` otherwise ("AI usage not included"). Unknown credits still fail open. AI Credits exhaustion mirrors aiproxy's 0.3 floor through one exported constant, `AI_PROXY_MINIMUM_BALANCE_MICRO_UNITS = 300_000`.
- **Wall behaviour**: the allowance causes behave like every other Paid Chat Wall cause. The pre-send gate refuses with `402 ai_allowance_missing` and the cause in `X-Chat-Wall`, before any conversation state is touched; the card names the cause with an `Upgrade plan` CTA; the composer locks at once with a placeholder stating why. A refusal that bypasses the gate is still voiced as a Billing Interruption from the Paid Source the pane knows — narrowing that to the allowance cause is a stated follow-up in ADR-0073.
- **Dev tooling**: two new allowance-wall postures on the chat billing-card tweak (trial / plan voice), the `handoff` posture labelled as rendering nothing, and a billing Dev Mock fixture for `/api/chat/free-turns` so the sidebar's usage row and the Plan view's "All 5 used" follow the scenario (`free` mid-spend, everything else spent).
- **Docs**: ADR-0073 with the evidence, including the considered-and-rejected advisory-notice staging. ADR-0068 gets the third 402 code and a Status line; ADR-0069 gets a Status and its "AI Credits or Account Balance" consequence trimmed; the README index and CONTEXT.md's Paid Chat Wall and Free Chat Turns entries are updated. The allowance cause is the one chat surface allowed to say "plan", recorded in CONTEXT.md.

## Verified

- `bun typecheck` (only the pre-existing `preview-canvas-perf` error remains), `bun check`.
- `bun test` on the wall judgment (including the exact 0.3 edge), the wall and placeholder copy, the chat route's 402 for both allowance voices, the allowance wall card, the free-turns Dev Mock route, and the billing fixtures.
- The micro-unit assumption behind the 0.3 floor is confirmed from source: account-service serves `ai_quota` from `GetAIQuota`'s int64 sums, and aiproxy divides the same quota by `balancePrecision = 1000000` before comparing with `GroupMinimumBalance = 0.3`.
- End to end in the browser with the billing Dev Mock on `free-expired`: the locked wall card renders with its reason in the composer placeholder, and the Plan view shows "All 5 used" under `free-expiring`.

## Notes for review

- This revises ADR-0069's exhaustion consequence, so @zjy365 please take a look at the ADR-0073 reasoning in particular.
- The 0.3 floor is a deliberate copy of an upstream constant and is documented as such.
- The ADR index goes 0071 → 0073 on purpose: PR #318 adds ADR-0072 and its README line belongs to that PR, so #318 should land first (or the numbering needs a second look if it does not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QusL551FaquK8wCUXm7x9g
