### PR TITLE
feat(theme): unlock light/dark with animated theme toggler

### DIFF
--- a/apps/ui/src/features/billing/billing-app-cost-drawer.tsx
+++ b/apps/ui/src/features/billing/billing-app-cost-drawer.tsx
@@ -349,7 +349,7 @@ export function BillingAppCostDrawer({
                           key={`day-${tableRow.day}`}
                         >
                           <TableCell
-                            className="bg-white/8 font-normal text-foreground"
+                            className="bg-muted font-normal text-foreground dark:bg-white/8"
                             colSpan={COLUMN_COUNT}
                           >
                             <span className="sticky left-4 inline-block">

--- a/apps/ui/src/features/billing/billing-cost-charts.tsx
+++ b/apps/ui/src/features/billing/billing-cost-charts.tsx
@@ -178,7 +178,7 @@ function LineLegendContent({
               <circle
                 cx="8"
                 cy="5"
-                fill="var(--color-canvas-surface)"
+                fill="var(--main-action-surface-bg)"
                 r="3"
                 stroke={item.color}
                 strokeWidth="2"
@@ -257,7 +257,7 @@ function ChartBody({
   isLoading: boolean;
 }) {
   if (isLoading) {
-    return <Skeleton className="h-72 w-full bg-white/8" />;
+    return <Skeleton className="h-72 w-full bg-muted dark:bg-white/8" />;
   }
   if (error != null) {
     return (
@@ -349,7 +349,7 @@ export function BillingCostCharts({
               {daily.series.map((series) => (
                 <Line
                   activeDot={{
-                    fill: "var(--color-canvas-surface)",
+                    fill: "var(--main-action-surface-bg)",
                     r: 3,
                     stroke: `var(--color-${series.dataKey})`,
                     strokeWidth: 2,

--- a/apps/ui/src/features/billing/billing-cost-tree.tsx
+++ b/apps/ui/src/features/billing/billing-cost-tree.tsx
@@ -203,7 +203,7 @@ function CostScopeCard({
         <span
           className={cn(
             "font-bold tabular-nums",
-            selected ? "text-blue-400" : "text-foreground"
+            selected ? "text-blue-600 dark:text-blue-400" : "text-foreground"
           )}
         >
           {formatBillingAmount(cost, currency)}

--- a/apps/ui/src/features/billing/billing-costs-surface.tsx
+++ b/apps/ui/src/features/billing/billing-costs-surface.tsx
@@ -624,7 +624,7 @@ export function BillingCostsSurface({
                   >
                     <div className="font-semibold">
                       <span>{bannerTitle}: </span>
-                      <span className="text-blue-400 tabular-nums">
+                      <span className="text-blue-600 tabular-nums dark:text-blue-400">
                         {isLoading
                           ? "…"
                           : formatBillingAmount(bannerCostMicroUnits, currency)}

--- a/apps/ui/src/features/billing/billing-plan-checkout-dialog.tsx
+++ b/apps/ui/src/features/billing/billing-plan-checkout-dialog.tsx
@@ -246,7 +246,7 @@ function paymentStatusCopy(status: PaymentWaitStatus): PaymentStatusCopy {
     icon: (
       <LoaderCircle
         aria-hidden
-        className="size-10 animate-spin text-blue-400 motion-reduce:[animation-duration:3s]"
+        className="size-10 animate-spin text-blue-600 dark:text-blue-400 motion-reduce:[animation-duration:3s]"
         strokeWidth={1.5}
       />
     ),
@@ -411,7 +411,7 @@ function DowngradeStage({
   return (
     <>
       <AppDialog.Header>
-        <AppDialog.Icon className="text-blue-400">
+        <AppDialog.Icon className="text-blue-600 dark:text-blue-400">
           <CircleCheckBig aria-hidden strokeWidth={1.75} />
         </AppDialog.Icon>
         <AppDialog.Title>Downgrade to {plan.name}</AppDialog.Title>
@@ -454,7 +454,7 @@ function DowngradeStage({
           <p className="text-muted-foreground text-sm">
             You are now in the process of changing your subscription, and the
             change will{" "}
-            <span className="font-medium text-blue-400">
+            <span className="font-medium text-blue-600 dark:text-blue-400">
               {"take effect on the following month's subscription date."}
             </span>
           </p>
@@ -569,7 +569,7 @@ function PromotionCodeField({
   if (!open) {
     return (
       <AppButton
-        className="h-auto self-start p-0 text-blue-400 hover:text-blue-400"
+        className="h-auto self-start p-0 text-blue-600 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-400"
         disabled={disabled}
         onClick={() => setOpen(true)}
         variant="link"
@@ -782,10 +782,7 @@ function QuoteStage({
                         strokeWidth={1.75}
                       />
                     </TooltipTrigger>
-                    <TooltipContent
-                      className="dark"
-                      positionerClassName="z-[52]"
-                    >
+                    <TooltipContent positionerClassName="z-[52]">
                       Prorated charge for the remainder of the current billing
                       cycle.
                     </TooltipContent>
@@ -814,7 +811,7 @@ function QuoteStage({
               )}
               {card != null && onManageCard != null ? (
                 <AppButton
-                  className="h-auto self-start p-0 text-blue-400 hover:text-blue-400"
+                  className="h-auto self-start p-0 text-blue-600 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-400"
                   onClick={onManageCard}
                   variant="link"
                 >

--- a/apps/ui/src/features/billing/billing-plan-surface.tsx
+++ b/apps/ui/src/features/billing/billing-plan-surface.tsx
@@ -841,7 +841,7 @@ export function BillingBalanceValue({
         </p>
         {giftMicroUnits > 0 ? (
           <Badge
-            className="self-center bg-blue-400/10 text-blue-400 tabular-nums"
+            className="self-center bg-blue-600/10 text-blue-600 tabular-nums dark:bg-blue-400/10 dark:text-blue-400"
             variant="secondary"
           >
             Gift {formatBillingAmount(giftMicroUnits, currency)}
@@ -1221,7 +1221,7 @@ export function BillingPlanSurface({
               <div className="flex items-center gap-2" key={resource.label}>
                 <CircleCheck
                   aria-hidden
-                  className="size-4 shrink-0 text-blue-400"
+                  className="size-4 shrink-0 text-blue-600 dark:text-blue-400"
                   strokeWidth={1.75}
                 />
                 <span className="text-muted-foreground text-sm">

--- a/apps/ui/src/features/billing/billing-pricing.tsx
+++ b/apps/ui/src/features/billing/billing-pricing.tsx
@@ -228,7 +228,7 @@ export function BillingPriceTable({
           ) : (
             sections.map((section) => (
               <Fragment key={section.title}>
-                <TableRow className="bg-white/5 hover:bg-white/5">
+                <TableRow className="bg-muted hover:bg-muted dark:bg-white/5 dark:hover:bg-white/5">
                   <TableCell className="h-12 font-medium" colSpan={3}>
                     {section.title}
                   </TableCell>
@@ -439,7 +439,7 @@ function CalculatorRow({
 
 function CalculatorSectionBar({ title }: { title: string }) {
   return (
-    <h3 className="border-border border-y bg-white/5 px-5 py-3.5 font-medium text-foreground text-sm">
+    <h3 className="border-border border-y bg-muted px-5 py-3.5 font-medium text-foreground text-sm dark:bg-white/5">
       {title}
     </h3>
   );

--- a/apps/ui/src/features/billing/billing-tab-shell.tsx
+++ b/apps/ui/src/features/billing/billing-tab-shell.tsx
@@ -83,7 +83,7 @@ export function BillingNavigationFrame({
         <div className="flex min-w-0 items-center gap-2">
           <ReceiptText
             aria-hidden
-            className="size-4 shrink-0 text-blue-400"
+            className="size-4 shrink-0 text-blue-600 dark:text-blue-400"
             strokeWidth={2}
           />
           <h1 className="truncate font-semibold text-foreground text-lg leading-none">
@@ -108,7 +108,7 @@ export function BillingNavigationFrame({
                   className={cn(
                     "flex h-9 shrink-0 items-center gap-2 whitespace-nowrap rounded-md p-2 font-medium text-primary text-sm leading-none transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring/70",
                     active
-                      ? "bg-input text-foreground [&_svg]:text-blue-400"
+                      ? "bg-input text-foreground [&_svg]:text-blue-600 dark:[&_svg]:text-blue-400"
                       : "hover:bg-input/30 hover:text-foreground"
                   )}
                   href={tab.href}

--- a/apps/ui/src/features/billing/billing-usage.tsx
+++ b/apps/ui/src/features/billing/billing-usage.tsx
@@ -67,7 +67,7 @@ function UsageProgress({ value }: { value: number }) {
       aria-valuemax={100}
       aria-valuemin={0}
       aria-valuenow={value}
-      className="h-1 w-full max-w-40 overflow-hidden rounded-full bg-white/8"
+      className="h-1 w-full max-w-40 overflow-hidden rounded-full bg-muted dark:bg-white/8"
       role="progressbar"
     >
       <div
@@ -129,7 +129,7 @@ export function BillingUsageSurface({
                         aria-label={
                           index === 0 ? "Loading workspace usage" : undefined
                         }
-                        className="h-4 w-full bg-white/8"
+                        className="h-4 w-full bg-muted dark:bg-white/8"
                       />
                     </TableCell>
                   </TableRow>

--- a/apps/ui/src/features/db-browser/DataBrowserPane.tsx
+++ b/apps/ui/src/features/db-browser/DataBrowserPane.tsx
@@ -42,7 +42,7 @@ export function DataBrowserPane({
       refreshProjectCanvas={refreshProjectCanvas}
       selectedDatabaseData={selectedDatabaseData}
     >
-      <div className="dark flex h-full min-h-0 w-full overflow-hidden text-foreground">
+      <div className="flex h-full min-h-0 w-full overflow-hidden text-foreground">
         <DataBrowserPaneBody />
       </div>
     </DataBrowserRuntimeProvider>

--- a/apps/ui/src/features/db-browser/backups/BackupServiceSurface.tsx
+++ b/apps/ui/src/features/db-browser/backups/BackupServiceSurface.tsx
@@ -295,7 +295,7 @@ function BackupRowsList({
               const canDelete = backup.deletable && !isDeleting;
               return (
                 <article
-                  className="flex min-h-[74px] flex-row items-center justify-between gap-3 rounded-md bg-white/[0.04] px-4 py-3 transition-colors hover:bg-white/[0.06]"
+                  className="flex min-h-[74px] flex-row items-center justify-between gap-3 rounded-md bg-muted px-4 py-3 transition-colors hover:bg-muted/80 dark:bg-white/[0.04] dark:hover:bg-white/[0.06]"
                   data-qa-module="database"
                   data-qa-object="backup-row"
                   data-qa-resource-id={backup.name}
@@ -748,9 +748,11 @@ function DeleteBackupModal({
             {"and any restored DB Services remain unchanged."}
           </AppDialog.Description>
           <AppDialog.Field>
-            <p className="select-text text-sm/5 text-zinc-400">
+            <p className="select-text text-muted-foreground text-sm/5 dark:text-zinc-400">
               {"Type "}
-              <span className="font-mono text-zinc-100">{backup.name}</span>
+              <span className="font-mono text-foreground dark:text-zinc-100">
+                {backup.name}
+              </span>
               {" to confirm."}
             </p>
             <AppDialog.Input

--- a/apps/ui/src/features/db-browser/components/database/shared/SingleObjectExportModal.tsx
+++ b/apps/ui/src/features/db-browser/components/database/shared/SingleObjectExportModal.tsx
@@ -71,8 +71,8 @@ export function SingleObjectExportModal({
                 className={cn(
                   "inline-flex h-9 items-center justify-start gap-2 rounded-lg border border-border px-3 font-medium text-sm/5 outline-none transition-colors",
                   format === option
-                    ? "bg-white/10 text-zinc-50"
-                    : "bg-white/[0.045] text-zinc-300 hover:bg-white/10 hover:text-zinc-50"
+                    ? "bg-input text-foreground dark:bg-white/10 dark:text-zinc-50"
+                    : "text-muted-foreground hover:bg-input/60 dark:bg-white/[0.045] dark:text-zinc-300 dark:hover:bg-white/10 dark:hover:text-zinc-50"
                 )}
                 disabled={isExporting}
                 key={option}

--- a/apps/ui/src/features/db-browser/components/database/sql/TableView/TableView.DataGrid.tsx
+++ b/apps/ui/src/features/db-browser/components/database/sql/TableView/TableView.DataGrid.tsx
@@ -201,7 +201,7 @@ export function TableViewDataGrid({
               key={row.rowKey}
             >
               <td
-                className="sticky left-0 z-30 border-border border-r border-b bg-[#0C1120] px-2 py-2 text-center font-normal text-sm"
+                className="sticky left-0 z-30 border-border border-r border-b bg-db-access-row-selector-surface px-2 py-2 text-center font-normal text-sm"
                 data-qa-module="sql"
                 data-qa-object="table-row"
                 data-qa-resource-id={row.rowKey}

--- a/apps/ui/src/features/project-canvas/actions/canvas-action-surface.test.tsx
+++ b/apps/ui/src/features/project-canvas/actions/canvas-action-surface.test.tsx
@@ -20,7 +20,8 @@ const CENTERED_NAME_RE =
   /<p class="[^"]*text-center[^"]*" title="orders-db">orders-db<\/p>/;
 const DB_ACCESS_TITLE_RE =
   /<h2 class="[^"]*" title="DB Access">DB Access<\/h2>/;
-const ACTION_SURFACE_BACKGROUND_RE = /bg-neutral-950/;
+// The surface background is theme-paired (light sheet / dark canvas navy)
+// via --main-action-surface-bg, so no literal bg-neutral-950 remains.
 const MAIN_ACTION_SURFACE_BACKGROUND_RE = /main-action-surface-background/;
 const MAIN_ACTION_BODY_BACKGROUND_RE = /main-action-surface-body-background/;
 const DB_ACCESS_RE = /text-foreground/;
@@ -76,7 +77,6 @@ test("main action surface renders shared chrome and empty body slot", () => {
   assert.match(html, DB_ACCESS_TITLE_RE);
   assert.doesNotMatch(html, ENGINE_SUBTITLE_RE);
   assert.match(html, CLOSE_LABEL_RE);
-  assert.match(html, ACTION_SURFACE_BACKGROUND_RE);
   assert.match(html, MAIN_ACTION_SURFACE_BACKGROUND_RE);
   assert.match(html, MAIN_ACTION_BODY_BACKGROUND_RE);
   assert.match(html, DB_ACCESS_RE);
@@ -101,7 +101,6 @@ test("main action surface frame renders custom surface content", () => {
   assert.match(html, CUSTOM_TITLE_RE);
   assert.match(html, CUSTOM_SUBTITLE_RE);
   assert.match(html, CUSTOM_BODY_RE);
-  assert.match(html, ACTION_SURFACE_BACKGROUND_RE);
   assert.match(html, MAIN_ACTION_SURFACE_BACKGROUND_RE);
   assert.match(html, MAIN_ACTION_BODY_BACKGROUND_RE);
 });

--- a/apps/ui/src/features/project-canvas/actions/canvas-action-surface.tsx
+++ b/apps/ui/src/features/project-canvas/actions/canvas-action-surface.tsx
@@ -62,7 +62,7 @@ export function MainActionSurfaceFrame({
   return (
     <section
       aria-label={label}
-      className="dark main-action-surface-background absolute inset-0 z-30 flex min-h-0 min-w-0 flex-col overflow-hidden bg-neutral-950 text-foreground"
+      className="main-action-surface-background absolute inset-0 z-30 flex min-h-0 min-w-0 flex-col overflow-hidden text-foreground"
       data-slot="main-action-surface"
     >
       <header
@@ -73,7 +73,7 @@ export function MainActionSurfaceFrame({
       >
         <div className="flex min-w-0 items-center gap-2">
           {icon == null ? null : (
-            <span className="flex size-4 shrink-0 items-center justify-center text-blue-400">
+            <span className="flex size-4 shrink-0 items-center justify-center text-blue-600 dark:text-blue-400">
               {icon}
             </span>
           )}

--- a/apps/ui/src/features/shell/app-sidebar-account.tsx
+++ b/apps/ui/src/features/shell/app-sidebar-account.tsx
@@ -141,7 +141,7 @@ function AppSidebarQuotaBar({ percent }: { percent: number | null }) {
       <span
         className={cn(
           "block h-full rounded-full",
-          tone == null ? "bg-blue-400" : USAGE_BAR_CLASS[tone]
+          tone == null ? "bg-blue-600 dark:bg-blue-400" : USAGE_BAR_CLASS[tone]
         )}
         style={{ width: `${percent ?? 0}%` }}
       />
@@ -469,7 +469,7 @@ function AppSidebarAccountMenuRow({
       rel={rel}
       target={target}
     >
-      <span className="flex w-6 shrink-0 items-center justify-center text-neutral-50 transition-colors group-hover/menurow:text-blue-400">
+      <span className="flex w-6 shrink-0 items-center justify-center text-foreground transition-colors group-hover/menurow:text-blue-600 dark:group-hover/menurow:text-blue-400">
         {icon}
       </span>
       <span className="min-w-0 flex-1 truncate">{label}</span>
@@ -554,8 +554,8 @@ function AppSidebarUsageAccordion({
         >
           <span
             className={cn(
-              "flex w-6 shrink-0 items-center justify-center transition-colors group-hover/menurow:text-blue-400",
-              open ? "text-blue-400" : "text-neutral-50"
+              "flex w-6 shrink-0 items-center justify-center transition-colors group-hover/menurow:text-blue-600 dark:group-hover/menurow:text-blue-400",
+              open ? "text-blue-600 dark:text-blue-400" : "text-foreground"
             )}
           >
             <Gauge aria-hidden className="size-4" strokeWidth={1.8} />
@@ -694,7 +694,7 @@ function AppSidebarAccountMenuView({
       {userId === "" ? null : (
         <button
           aria-label="Copy user ID"
-          className="flex cursor-pointer items-center gap-1 text-muted-foreground text-xs tabular-nums transition-colors hover:text-neutral-50"
+          className="flex cursor-pointer items-center gap-1 text-muted-foreground text-xs tabular-nums transition-colors hover:text-foreground"
           onClick={onCopyId}
           type="button"
         >
@@ -720,7 +720,7 @@ function AppSidebarAccountMenuView({
         usageSection={usageSection}
       />
       <Link
-        className="flex h-9 items-center justify-center gap-1.5 rounded-md bg-input/40 font-medium text-neutral-50 text-sm transition-colors hover:bg-input/60"
+        className="flex h-9 items-center justify-center gap-1.5 rounded-md bg-input/40 font-medium text-foreground text-sm transition-colors hover:bg-input/60"
         href="/billing?mode=upgrade"
         onClick={recordBillingReturnRoute}
       >
@@ -899,7 +899,7 @@ export function AppSidebarAccount() {
               : "opacity-0 duration-200 ease-out"
           )}
         >
-          <span className="block truncate font-medium text-neutral-50 text-sm/4">
+          <span className="block truncate font-medium text-foreground text-sm/4">
             {displayName}
           </span>
           {secondLine == null ? null : (
@@ -931,7 +931,7 @@ export function AppSidebarAccount() {
       <PopoverContent
         align={expanded ? "start" : "end"}
         anchor={expanded ? undefined : iconSlotRef}
-        className="w-58 gap-0 rounded-lg border border-border bg-input/30 p-3 text-brand-primary-foreground shadow-none ring-0 backdrop-blur-xl"
+        className="w-58 gap-0 rounded-lg border border-border bg-input/30 p-3 text-foreground shadow-none ring-0 backdrop-blur-xl dark:text-brand-primary-foreground"
         side={expanded ? "top" : "right"}
         sideOffset={6}
       >

--- a/apps/ui/src/features/shell/app-sidebar-notifications.tsx
+++ b/apps/ui/src/features/shell/app-sidebar-notifications.tsx
@@ -173,7 +173,9 @@ function NotificationCard({
             <span
               className={cn(
                 "min-w-0 truncate text-sm",
-                unread ? "font-medium text-neutral-50" : "text-neutral-300"
+                unread
+                  ? "font-medium text-foreground"
+                  : "text-muted-foreground dark:text-neutral-300"
               )}
             >
               {item.title}
@@ -200,7 +202,7 @@ function NotificationCard({
       <span
         aria-hidden
         className={cn(
-          "absolute top-2.5 right-2.5 size-1.5 rounded-full bg-blue-400 transition-opacity",
+          "absolute top-2.5 right-2.5 size-1.5 rounded-full bg-blue-600 transition-opacity dark:bg-blue-400",
           unread ? "opacity-100" : "opacity-0"
         )}
       />
@@ -219,7 +221,7 @@ function NotificationsEmptyState({ tab }: { tab: NotificationTab }) {
           strokeWidth={1.8}
         />
       </span>
-      <span className="font-medium text-neutral-50 text-sm">
+      <span className="font-medium text-foreground text-sm">
         {nothingYet ? "No notifications yet" : "You're all caught up"}
       </span>
       <span className="text-muted-foreground text-xs">
@@ -258,7 +260,7 @@ export function NotificationsPanel({ feed }: { feed: NotificationFeed }) {
       <div className="flex h-10 shrink-0 items-center justify-between pr-2 pl-3">
         <span className="font-medium text-sm">Notifications</span>
         <AppButton
-          className="text-muted-foreground hover:text-neutral-50"
+          className="text-muted-foreground hover:text-foreground"
           disabled={unreadCount === 0}
           onClick={markAllRead}
           size="sm"
@@ -280,7 +282,7 @@ export function NotificationsPanel({ feed }: { feed: NotificationFeed }) {
                   Unread
                   {unreadCount > 0 ? (
                     <span
-                      className="rounded-full bg-blue-400/15 px-1.5 text-[10px] text-blue-400 tabular-nums"
+                      className="rounded-full bg-blue-600/15 px-1.5 text-[10px] text-blue-600 tabular-nums dark:bg-blue-400/15 dark:text-blue-400"
                       data-slot="app-sidebar-notifications-unread-count"
                     >
                       {unreadCount}
@@ -346,7 +348,7 @@ export function AppSidebarNotifications() {
           ? `Notifications, ${unreadCount} unread`
           : "Notifications"
       }
-      className="group/nbell relative flex h-9 w-full shrink-0 cursor-pointer items-center overflow-hidden rounded-md text-left text-neutral-50 text-sm"
+      className="group/nbell relative flex h-9 w-full shrink-0 cursor-pointer items-center overflow-hidden rounded-md text-left text-foreground text-sm"
       data-slot="app-sidebar-notifications"
       type="button"
     />
@@ -365,14 +367,14 @@ export function AppSidebarNotifications() {
           )}
         />
         <span
-          className="relative flex w-9 shrink-0 items-center justify-center transition-colors group-hover/nbell:text-blue-400"
+          className="relative flex w-9 shrink-0 items-center justify-center transition-colors group-hover/nbell:text-blue-600 dark:group-hover/nbell:text-blue-400"
           ref={iconSlotRef}
         >
           <Bell aria-hidden className="size-4" strokeWidth={1.8} />
           <span
             aria-hidden
             className={cn(
-              "absolute top-2 right-2 size-1.5 rounded-full bg-blue-400 transition-opacity motion-reduce:transition-none",
+              "absolute top-2 right-2 size-1.5 rounded-full bg-blue-600 transition-opacity motion-reduce:transition-none dark:bg-blue-400",
               !expanded && unreadCount > 0
                 ? "opacity-100 duration-200 ease-out"
                 : "opacity-0 duration-300 ease-sidebar"
@@ -399,7 +401,7 @@ export function AppSidebarNotifications() {
         >
           {badgeLabel == null ? null : (
             <span
-              className="flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-400/15 px-1 font-medium text-[10px] text-blue-400 tabular-nums"
+              className="flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-600/15 px-1 font-medium text-[10px] text-blue-600 tabular-nums dark:bg-blue-400/15 dark:text-blue-400"
               data-slot="app-sidebar-notifications-badge"
             >
               {badgeLabel}
@@ -415,7 +417,7 @@ export function AppSidebarNotifications() {
       <PopoverContent
         align="start"
         anchor={expanded ? undefined : iconSlotRef}
-        className="flex min-h-80 w-96 flex-col gap-0 rounded-lg border border-border bg-input/30 p-0 text-brand-primary-foreground shadow-none ring-0 backdrop-blur-xl"
+        className="flex min-h-80 w-96 flex-col gap-0 rounded-lg border border-border bg-input/30 p-0 text-foreground shadow-none ring-0 backdrop-blur-xl dark:text-brand-primary-foreground"
         side="right"
         sideOffset={expanded ? 10 : 6}
       >

--- a/apps/ui/src/features/shell/app-sidebar.tsx
+++ b/apps/ui/src/features/shell/app-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   SidebarProvider,
   useSidebar,
 } from "@workspace/ui/components/sidebar";
+import { ThemeToggle } from "@workspace/ui/components/theme-toggle";
 import {
   Tooltip,
   TooltipContent,
@@ -66,7 +67,8 @@ function ProjectIcon({
         aria-hidden
         className={cn(
           "size-4 shrink-0 transition-colors",
-          !active && "text-neutral-400 group-hover/row:text-blue-400"
+          !active &&
+            "text-muted-foreground group-hover/row:text-blue-600 dark:group-hover/row:text-blue-400"
         )}
         strokeWidth={1.8}
       />
@@ -78,7 +80,8 @@ function ProjectIcon({
       brandKey={iconKey}
       className={cn(
         "transition-colors",
-        !active && "text-neutral-400 group-hover/row:text-blue-400"
+        !active &&
+          "text-muted-foreground group-hover/row:text-blue-600 dark:group-hover/row:text-blue-400"
       )}
     />
   );
@@ -127,7 +130,7 @@ function AppSidebarNavRow({
   const iconSlotRef = useRef<HTMLSpanElement>(null);
   const accessibleName = ariaLabel ?? label;
   const className =
-    "group/row relative flex h-9 w-full shrink-0 items-center overflow-hidden rounded-md text-left text-neutral-50 text-sm";
+    "group/row relative flex h-9 w-full shrink-0 items-center overflow-hidden rounded-md text-left text-foreground text-sm";
   const body = (
     <>
       <span
@@ -142,8 +145,8 @@ function AppSidebarNavRow({
       />
       <span
         className={cn(
-          "relative flex w-9 shrink-0 items-center justify-center transition-colors group-hover/row:text-blue-400",
-          active && "text-blue-400"
+          "relative flex w-9 shrink-0 items-center justify-center transition-colors group-hover/row:text-blue-600 dark:group-hover/row:text-blue-400",
+          active && "text-blue-600 dark:text-blue-400"
         )}
         ref={iconSlotRef}
       >
@@ -211,6 +214,67 @@ function AppSidebarNavRow({
   );
 }
 
+// Footer row for the theme switch, mirroring AppSidebarNavRow's geometry so
+// the icon column, hover sheet, and collapsed-rail tooltip anchor match the
+// Projects/Notifications rows above it. The row itself IS the toggle button
+// (AnimatedThemeToggler renders a button) — no nested interactive element.
+function AppSidebarThemeToggleRow() {
+  const { state } = useSidebar();
+  const expanded = state === "expanded";
+  const iconSlotRef = useRef<HTMLSpanElement>(null);
+
+  return (
+    <Tooltip disabled={expanded}>
+      <TooltipTrigger
+        render={
+          <ThemeToggle
+            aria-label="Toggle theme"
+            className={cn(
+              "group/row relative isolate flex h-9 w-full shrink-0 cursor-pointer items-center overflow-hidden rounded-md text-left text-sm",
+              // Semantic so the row follows the theme; in dark,
+              // --foreground is exactly the rows' near-white above it.
+              "text-foreground"
+            )}
+            data-slot="app-sidebar-theme-toggle"
+            iconClassName={cn(
+              // Match AppSidebarNavRow's icon column: a w-9 centered slot.
+              "relative size-9 w-9 shrink-0",
+              "transition-colors group-hover/row:text-blue-600 dark:group-hover/row:text-blue-400"
+            )}
+            iconRef={iconSlotRef}
+            title={expanded ? "Theme" : undefined}
+          >
+            {/* Same hover sheet as AppSidebarNavRow; -z-10 inside the row's
+                isolate keeps it under the icon/label without DOM reorder. */}
+            <span
+              aria-hidden
+              className={cn(
+                "app-sidebar-hover absolute inset-y-0 left-0 -z-10 rounded-md transition-[width,background-color] group-hover/row:bg-input/30 motion-reduce:transition-none",
+                expanded
+                  ? "w-full duration-300 ease-sidebar"
+                  : "w-9 duration-200 ease-out"
+              )}
+            />
+            <span
+              className={cn(
+                "app-sidebar-label relative min-w-0 flex-1 truncate whitespace-nowrap pr-2 transition-opacity motion-reduce:transition-none",
+                expanded
+                  ? "opacity-100 duration-300 ease-sidebar"
+                  : "opacity-0 duration-200 ease-out"
+              )}
+            >
+              Theme
+            </span>
+          </ThemeToggle>
+        }
+      />
+      <TooltipContent anchor={iconSlotRef} side="right">
+        Theme
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function AppSidebarGroupHeading({
   children,
   collapsed,
@@ -240,7 +304,7 @@ function AppSidebarGroupHeading({
         tabIndex={expanded ? undefined : -1}
         type="button"
       >
-        <span className="flex min-w-0 flex-1 items-center gap-1 pl-2 font-medium text-muted-foreground text-xs transition-colors group-hover/heading:text-neutral-300">
+        <span className="flex min-w-0 flex-1 items-center gap-1 pl-2 font-medium text-muted-foreground text-xs transition-colors group-hover/heading:text-foreground dark:group-hover/heading:text-neutral-300">
           <span className="truncate">{children}</span>
           <ChevronRight
             aria-hidden
@@ -282,7 +346,7 @@ function AppSidebarHeader() {
         aria-hidden={expanded || undefined}
         aria-label="Expand sidebar"
         className={cn(
-          "group/expand shrink-0 border-0 text-neutral-50",
+          "group/expand shrink-0 border-0 text-foreground",
           expanded && "pointer-events-none"
         )}
         data-slot="app-sidebar-expand"
@@ -304,7 +368,7 @@ function AppSidebarHeader() {
       </AppIconButton>
       <span
         className={cn(
-          "min-w-0 flex-1 truncate whitespace-nowrap font-semibold text-neutral-50 text-sm transition-opacity motion-reduce:transition-none",
+          "min-w-0 flex-1 truncate whitespace-nowrap font-semibold text-foreground text-sm transition-opacity motion-reduce:transition-none",
           expanded
             ? "opacity-100 duration-300 ease-sidebar"
             : "opacity-0 duration-200 ease-out"
@@ -318,7 +382,7 @@ function AppSidebarHeader() {
         aria-hidden={expanded ? undefined : true}
         aria-label="Collapse sidebar"
         className={cn(
-          "shrink-0 border-0 text-neutral-50 transition-opacity motion-reduce:transition-none",
+          "shrink-0 border-0 text-foreground transition-opacity motion-reduce:transition-none",
           expanded
             ? "opacity-100 duration-300 ease-sidebar"
             : "pointer-events-none opacity-0 duration-150 ease-out"
@@ -619,8 +683,9 @@ function AppSidebarChrome({
         </SidebarContent>
         <SidebarFooter className="p-0">
           <div className="flex shrink-0 flex-col gap-0.5 pt-3 transition-[gap,padding] duration-200 ease-out group-data-[collapsible=icon]:gap-1 group-data-[collapsible=icon]:pt-2 motion-reduce:transition-none">
+            <AppSidebarThemeToggleRow />
             {/* Billing and the Sealos Desktop Entry live inside the account
-                popover; the account row is the whole footer. */}
+                popover. */}
             {/* Account-row exception: the avatar disc is visually heavier
                   than the row glyphs, so in both states it takes this extra
                   margin on top of the footer gap. */}

--- a/bun.lock
+++ b/bun.lock
@@ -213,6 +213,7 @@
         "katex": "^0.16.45",
         "lucide-react": "^1.12.0",
         "mermaid": "^11.14.0",
+        "motion": "^13.1.1",
         "nanoid": "^5.1.11",
         "next-themes": "^0.4.6",
         "react": "^19.2.4",
@@ -2465,6 +2466,8 @@
 
     "@vercel/sandbox/zod": ["zod@3.24.4", "https://registry.npmmirror.com/zod/-/zod-3.24.4.tgz", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 
+    "@workspace/ui/motion": ["motion@13.1.1", "", { "dependencies": { "framer-motion": "^13.1.1", "tslib": "^2.4.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-WNZoK6xiF+kkTqkZ5K7FDDh6A8BG4i5Hc7KXtW8gtTxkpJFds+hIOrDaQGKjQj/AE/i4hJqAaUHEqp/Qo02y6Q=="],
+
     "@workspace/ui/recharts": ["recharts@3.8.0", "https://registry.npmmirror.com/recharts/-/recharts-3.8.0.tgz", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ=="],
 
     "accepts/mime-types": ["mime-types@3.0.2", "https://registry.npmmirror.com/mime-types/-/mime-types-3.0.2.tgz", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
@@ -2667,6 +2670,8 @@
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-5.0.5.tgz", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
+    "@workspace/ui/motion/framer-motion": ["framer-motion@13.1.1", "", { "dependencies": { "motion-dom": "^13.1.1", "motion-utils": "^13.0.0", "tslib": "^2.4.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-B/xn2TPS4f61cEBLFjiYlQFnBZUW1YVj/LM+C+N4OP8Rs95VLEI2ot/RlfBg111la/EiyECFaJJi/A3FWA8MUA=="],
+
     "@workspace/ui/recharts/eventemitter3": ["eventemitter3@5.0.4", "https://registry.npmmirror.com/eventemitter3/-/eventemitter3-5.0.4.tgz", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "@workspace/ui/recharts/victory-vendor": ["victory-vendor@37.3.6", "https://registry.npmmirror.com/victory-vendor/-/victory-vendor-37.3.6.tgz", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
@@ -2758,6 +2763,10 @@
     "@ts-morph/common/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "https://registry.npmmirror.com/balanced-match/-/balanced-match-4.0.4.tgz", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "https://registry.npmmirror.com/balanced-match/-/balanced-match-4.0.4.tgz", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "@workspace/ui/motion/framer-motion/motion-dom": ["motion-dom@13.1.1", "", { "dependencies": { "motion-utils": "^13.0.0" } }, "sha512-XSf8VYWSB6G/0IY3rWVbyLcxWXtAVHkN1PQE2agTaCv3u8RGvbwu56TyyR/MNzBqqNavEBTZzErcxI1TxBrjcA=="],
+
+    "@workspace/ui/motion/framer-motion/motion-utils": ["motion-utils@13.0.0", "", {}, "sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ=="],
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "https://registry.npmmirror.com/balanced-match/-/balanced-match-4.0.4.tgz", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,6 +26,7 @@
     "katex": "^0.16.45",
     "lucide-react": "^1.12.0",
     "mermaid": "^11.14.0",
+    "motion": "^13.1.1",
     "nanoid": "^5.1.11",
     "next-themes": "^0.4.6",
     "react": "^19.2.4",

--- a/packages/ui/src/components/animated-theme-toggler.test.tsx
+++ b/packages/ui/src/components/animated-theme-toggler.test.tsx
@@ -1,0 +1,266 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { render } from "@testing-library/react/pure";
+import { act, type ReactElement } from "react";
+
+import { AnimatedThemeToggler } from "./animated-theme-toggler";
+
+const ICON_SETTLE_MS = 320; // Sun/Moon motion transitions run 250ms.
+
+function installTestDom() {
+  if (GlobalRegistrator.isRegistered) {
+    throw new Error("a test DOM is already registered");
+  }
+  GlobalRegistrator.register({ url: "https://animated-theme-toggler.test" });
+  return () => GlobalRegistrator.unregister();
+}
+
+async function withMounted(
+  element: ReactElement,
+  run: (rendered: ReturnType<typeof render>) => Promise<void> | void
+) {
+  const restoreDom = installTestDom();
+  const reactTestGlobals = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  const previousActEnvironment = reactTestGlobals.IS_REACT_ACT_ENVIRONMENT;
+  reactTestGlobals.IS_REACT_ACT_ENVIRONMENT = true;
+  let rendered: ReturnType<typeof render> | undefined;
+  try {
+    await act(() => {
+      rendered = render(element);
+    });
+    assert.ok(rendered);
+    await run(rendered);
+  } finally {
+    if (rendered) {
+      await act(async () => {
+        // Let motion icon animations finish before teardown: their timers
+        // must not fire against the unregistered DOM in a later test file.
+        await new Promise((resolve) => {
+          setTimeout(resolve, ICON_SETTLE_MS);
+        });
+        rendered?.unmount();
+      });
+    }
+    reactTestGlobals.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    await restoreDom();
+  }
+}
+
+test("controlled dark mode flips the class synchronously and reports only the requested theme (no VT)", async () => {
+  const changes: string[] = [];
+  await withMounted(
+    <AnimatedThemeToggler
+      onThemeChange={(next) => {
+        changes.push(next);
+      }}
+      theme="dark"
+    />,
+    async ({ container }) => {
+      document.documentElement.classList.add("dark");
+      const button = container.querySelector("button");
+      assert.ok(button, "button should render");
+
+      // happy-dom has no startViewTransition -> fallback path: class flips
+      // immediately, the owner is told the new theme.
+      await act(() => {
+        button.click();
+      });
+
+      assert.deepEqual(changes, ["light"]);
+      assert.equal(
+        document.documentElement.classList.contains("dark"),
+        false,
+        "controlled toggler paints the dark class itself so a later VT can snapshot it"
+      );
+    }
+  );
+});
+
+test("controlled mode never writes localStorage and keeps the parent-owned theme", async () => {
+  await withMounted(
+    <AnimatedThemeToggler
+      onThemeChange={() => {
+        // parent persists; component must not touch storage
+      }}
+      theme="dark"
+    />,
+    async ({ container }) => {
+      document.documentElement.classList.add("dark");
+      localStorage.clear();
+      const button = container.querySelector("button");
+      assert.ok(button);
+      await act(() => {
+        button.click();
+      });
+      assert.equal(
+        localStorage.getItem("theme"),
+        null,
+        "controlled mode must not persist; the owner (next-themes) does"
+      );
+    }
+  );
+});
+
+test("uncontrolled mode toggles the class both ways and persists to localStorage", async () => {
+  await withMounted(<AnimatedThemeToggler />, async ({ container }) => {
+    const button = container.querySelector("button");
+    assert.ok(button);
+
+    // light -> dark (no dark class at mount, so the handler state is settled)
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+    assert.equal(document.documentElement.classList.contains("dark"), true);
+    assert.equal(localStorage.getItem("theme"), "dark");
+
+    // dark -> light (flush the MutationObserver mirror first so the handler
+    // closure observes the dark class)
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+    assert.equal(document.documentElement.classList.contains("dark"), false);
+    assert.equal(localStorage.getItem("theme"), "light");
+  });
+});
+
+test("an in-flight view transition suppresses repeat clicks until cleanup", async () => {
+  let vtCount = 0;
+  let resolveReady: () => void = () => undefined;
+  let resolveFinished: () => void = () => undefined;
+  const changes: string[] = [];
+  await withMounted(
+    <AnimatedThemeToggler
+      onThemeChange={(next) => {
+        changes.push(next);
+      }}
+      theme="dark"
+    />,
+    async ({ container }) => {
+      document.documentElement.classList.add("dark");
+      // Opaque slot for the stub: the lib.dom ViewTransition signature is
+      // narrower than what the component actually reads (.ready/.finished).
+      const doc = document as unknown as Record<string, unknown>;
+      doc.startViewTransition = (cb: () => void) => {
+        vtCount += 1;
+        cb();
+        return {
+          ready: new Promise<void>((resolve) => {
+            resolveReady = resolve;
+          }),
+          finished: new Promise<void>((resolve) => {
+            resolveFinished = resolve;
+          }),
+        };
+        // Partial VT object — the component only reads .ready/.finished.
+      };
+      (Element.prototype as unknown as { animate?: unknown }).animate ??=
+        () => ({
+          cancel: () => undefined,
+          finished: Promise.resolve(),
+        });
+
+      const button = container.querySelector("button");
+      assert.ok(button);
+
+      await act(() => {
+        button.click();
+      });
+      // Still in flight: a second click must be a no-op.
+      await act(() => {
+        button.click();
+      });
+      assert.equal(vtCount, 1, "re-entrant clicks must not start a second VT");
+      assert.deepEqual(changes, ["light"]);
+      assert.equal(
+        document.documentElement.dataset.sealaiThemeVt,
+        "active",
+        "the scoped VT attrs stay pinned while in flight"
+      );
+
+      // Settle: resolve the pending VT promises inside act so the cleanup
+      // state update flushes.
+      await act(async () => {
+        resolveReady();
+        resolveFinished();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      assert.equal(
+        document.documentElement.dataset.sealaiThemeVt,
+        undefined,
+        "cleanup removes the scoped VT attrs"
+      );
+      assert.equal(
+        document.documentElement.style.getPropertyValue(
+          "--sealai-theme-toggle-vt-duration"
+        ),
+        ""
+      );
+      // happy-dom ships no native startViewTransition; restoring the
+      // pre-test (undefined) value keeps the stub from leaking.
+      doc.startViewTransition = undefined;
+    }
+  );
+});
+
+test("the button carries an accessible name even before the icon mounts", async () => {
+  await withMounted(<AnimatedThemeToggler theme="dark" />, ({ container }) => {
+    const button = container.querySelector("button");
+    assert.ok(button);
+    assert.ok(
+      (button.textContent ?? "").includes("Toggle theme"),
+      "accessible sr-only name present"
+    );
+  });
+});
+
+// The icon is hidden during SSR/hydration and appears after mount; each theme
+// shows the opposite glyph (Sun invites "go light", Moon invites "go dark").
+// Sun is the only glyph containing a <circle> in lucide, which distinguishes
+// them without depending on generated class names.
+async function mountedIcon(container: HTMLElement) {
+  await act(async () => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  });
+  const slot = container.querySelector(
+    '[data-slot="animated-theme-toggler-icon"]'
+  );
+  assert.ok(slot, "icon slot should render");
+  return slot.querySelector("svg");
+}
+
+test("dark theme renders the Sun glyph once mounted", async () => {
+  await withMounted(
+    <AnimatedThemeToggler theme="dark" />,
+    async ({ container }) => {
+      const icon = await mountedIcon(container);
+      assert.ok(icon, "one icon should show after mount");
+      assert.ok(
+        icon.querySelector("circle"),
+        "dark theme should show the Sun (rays circle)"
+      );
+    }
+  );
+});
+
+test("light theme renders the Moon glyph once mounted", async () => {
+  await withMounted(
+    <AnimatedThemeToggler theme="light" />,
+    async ({ container }) => {
+      const icon = await mountedIcon(container);
+      assert.ok(icon, "one icon should show after mount");
+      assert.equal(
+        icon.querySelector("circle"),
+        null,
+        "light theme should show the Moon (path only)"
+      );
+    }
+  );
+});

--- a/packages/ui/src/components/animated-theme-toggler.tsx
+++ b/packages/ui/src/components/animated-theme-toggler.tsx
@@ -1,0 +1,460 @@
+"use client";
+
+import { cn } from "@workspace/ui/lib/utils";
+import { Moon, Sun } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import {
+  type ComponentPropsWithRef,
+  type MutableRefObject,
+  type Ref,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+export type TransitionVariant =
+  | "circle"
+  | "square"
+  | "triangle"
+  | "diamond"
+  | "hexagon"
+  | "rectangle"
+  | "star";
+
+export interface AnimatedThemeTogglerProps
+  extends ComponentPropsWithRef<"button"> {
+  /** Optional visible label rendered after the icon (accessible name stays
+   *  the built-in "Toggle theme" sr-only text). */
+  children?: React.ReactNode;
+  /** Diffusion duration in milliseconds (View Transitions only). */
+  duration?: number;
+  /** Expand from the viewport center instead of the button center. */
+  fromCenter?: boolean;
+  /** Classes for the icon slot (e.g. to align it with a list-row icon column). */
+  iconClassName?: string;
+  /** Ref to the icon slot span (e.g. as a Tooltip anchor in list rows). */
+  iconRef?: Ref<HTMLSpanElement>;
+  /** Called on toggle with the new theme. Pair with `theme` for controlled usage. */
+  onThemeChange?: (theme: "light" | "dark") => void;
+  /** React 19 ref-as-prop; merged with the internal button ref so callers
+   *  (e.g. Tooltip anchors) can observe the element without stealing it. */
+  ref?: Ref<HTMLButtonElement>;
+  /**
+   * Controlled theme value. When provided, the parent owns persistence
+   * (next-themes) and this component will not write to localStorage.
+   */
+  theme?: "light" | "dark";
+  /** Shape of the clip-path reveal. Defaults to a circle. */
+  variant?: TransitionVariant;
+}
+
+/**
+ * Animated light/dark theme toggle (ported from magicui's
+ * animated-theme-toggler, adapted for next-themes control).
+ *
+ * The page reveal is a native View Transition: `document.startViewTransition`
+ * snapshots the old page, the callback flips the `dark` class on <html>
+ * synchronously (so the new snapshot already carries the new theme), and a
+ * clip-path keyframe animation on `::view-transition-new(root)` grows the new
+ * page out from the button. Browsers without View Transitions apply the theme
+ * change directly — no animation, no error. The globals.css rules scoped to
+ * `html[data-sealai-theme-vt="active"]` (duration sync + collapsed clip pin
+ * for Firefox) activate only while a toggle is in flight, so other view
+ * transitions in the app are untouched.
+ *
+ * In controlled mode the class flip is done here for snapshot correctness;
+ * the owner's `setTheme` runs afterwards and re-applies the same class
+ * (idempotent) while persisting the choice.
+ *
+ * The Sun/Moon micro-animation (motion) deliberately runs after the view
+ * transition settles: while a VT is active the live DOM is frozen, so icons
+ * crossfade in place right after the circular reveal completes.
+ */
+function polygonCollapsed(point: string, vertexCount: number): string {
+  const pairs = Array.from({ length: vertexCount }, () => point).join(", ");
+  return `polygon(${pairs})`;
+}
+
+// All coordinates are percentages of the snapshot reference box: Chrome
+// renders absolute px clip-path coordinates unscaled on fractional display
+// scales for the first transition after load, so px values can land at the
+// wrong position.
+function getThemeTransitionClipPaths(
+  variant: TransitionVariant,
+  cx: number,
+  cy: number,
+  maxRadius: number,
+  viewportWidth: number,
+  viewportHeight: number
+): [string, string] {
+  const toX = (x: number) => `${(x / viewportWidth) * 100}%`;
+  const toY = (y: number) => `${(y / viewportHeight) * 100}%`;
+  const point = (x: number, y: number) => `${toX(x)} ${toY(y)}`;
+  // circle() percentage radii resolve against hypot(w, h) / sqrt(2) of the
+  // reference box.
+  const toRadius = (r: number) =>
+    `${(r / (Math.hypot(viewportWidth, viewportHeight) / Math.SQRT2)) * 100}%`;
+
+  switch (variant) {
+    case "circle":
+      return [
+        `circle(0% at ${point(cx, cy)})`,
+        `circle(${toRadius(maxRadius)} at ${point(cx, cy)})`,
+      ];
+    case "square": {
+      const halfW = Math.max(cx, viewportWidth - cx);
+      const halfH = Math.max(cy, viewportHeight - cy);
+      const halfSide = Math.max(halfW, halfH) * 1.05;
+      const end = [
+        point(cx - halfSide, cy - halfSide),
+        point(cx + halfSide, cy - halfSide),
+        point(cx + halfSide, cy + halfSide),
+        point(cx - halfSide, cy + halfSide),
+      ].join(", ");
+      return [polygonCollapsed(point(cx, cy), 4), `polygon(${end})`];
+    }
+    case "triangle": {
+      const scale = maxRadius * 2.2;
+      const dx = (Math.sqrt(3) / 2) * scale;
+      const verts = [
+        point(cx, cy - scale),
+        point(cx + dx, cy + 0.5 * scale),
+        point(cx - dx, cy + 0.5 * scale),
+      ].join(", ");
+      return [polygonCollapsed(point(cx, cy), 3), `polygon(${verts})`];
+    }
+    case "diamond": {
+      // Slightly larger than the view-transition circle radius so
+      // axis-aligned coverage matches the circle reveal.
+      const R = maxRadius * Math.SQRT2;
+      const end = [
+        point(cx, cy - R),
+        point(cx + R, cy),
+        point(cx, cy + R),
+        point(cx - R, cy),
+      ].join(", ");
+      return [polygonCollapsed(point(cx, cy), 4), `polygon(${end})`];
+    }
+    case "hexagon": {
+      const R = maxRadius * Math.SQRT2;
+      const verts: string[] = [];
+      for (let i = 0; i < 6; i++) {
+        const a = -Math.PI / 2 + (i * Math.PI) / 3;
+        verts.push(point(cx + R * Math.cos(a), cy + R * Math.sin(a)));
+      }
+      return [
+        polygonCollapsed(point(cx, cy), 6),
+        `polygon(${verts.join(", ")})`,
+      ];
+    }
+    case "rectangle": {
+      const halfW = Math.max(cx, viewportWidth - cx);
+      const halfH = Math.max(cy, viewportHeight - cy);
+      const end = [
+        point(cx - halfW, cy - halfH),
+        point(cx + halfW, cy - halfH),
+        point(cx + halfW, cy + halfH),
+        point(cx - halfW, cy + halfH),
+      ].join(", ");
+      return [polygonCollapsed(point(cx, cy), 4), `polygon(${end})`];
+    }
+    case "star": {
+      // Small overscan so the last frames never leave a 1px seam before the
+      // transition group ends.
+      const R = maxRadius * Math.SQRT2 * 1.03;
+      const innerRatio = 0.42;
+      const starPolygon = (radius: number) => {
+        const verts: string[] = [];
+        for (let i = 0; i < 5; i++) {
+          const outerA = -Math.PI / 2 + (i * 2 * Math.PI) / 5;
+          verts.push(
+            point(
+              cx + radius * Math.cos(outerA),
+              cy + radius * Math.sin(outerA)
+            )
+          );
+          const innerA = outerA + Math.PI / 5;
+          verts.push(
+            point(
+              cx + radius * innerRatio * Math.cos(innerA),
+              cy + radius * innerRatio * Math.sin(innerA)
+            )
+          );
+        }
+        return `polygon(${verts.join(", ")})`;
+      };
+      const startR = Math.max(2, R * 0.025);
+      return [starPolygon(startR), starPolygon(R)];
+    }
+    default:
+      return [
+        `circle(0% at ${point(cx, cy)})`,
+        `circle(${toRadius(maxRadius)} at ${point(cx, cy)})`,
+      ];
+  }
+}
+
+export const AnimatedThemeToggler = ({
+  className,
+  duration = 400,
+  variant,
+  fromCenter = false,
+  theme,
+  onThemeChange,
+  iconClassName,
+  iconRef,
+  children,
+  onClick,
+  ref,
+  ...props
+}: AnimatedThemeTogglerProps) => {
+  const shape = variant ?? "circle";
+  const isControlled = theme !== undefined;
+  const [internalIsDark, setInternalIsDark] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  // Ref gates re-entrant clicks synchronously; the paired state hides the
+  // icon while the transition is in flight (a render-time read of the ref
+  // would never re-show it — refs do not trigger renders).
+  const [isTransitioning, setIsTransitioning] = useState(false);
+  const isDark = isControlled ? theme === "dark" : internalIsDark;
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const isTransitioningRef = useRef(false);
+  const activeAnimRef = useRef<Animation | null>(null);
+
+  const cancelAnim = useCallback(() => {
+    activeAnimRef.current?.cancel();
+    activeAnimRef.current = null;
+  }, []);
+
+  const setButtonRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      buttonRef.current = node;
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        (ref as MutableRefObject<HTMLButtonElement | null>).current = node;
+      }
+    },
+    [ref]
+  );
+
+  // No SSR truth for the theme; the icon appears once mounted so the Sun/Moon
+  // crossfade never has to resolve a hydration mismatch.
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      cancelAnim();
+      const root = document.documentElement;
+      if (root.dataset.sealaiThemeVt !== "active") {
+        return;
+      }
+      delete root.dataset.sealaiThemeVt;
+      root.style.removeProperty("--sealai-theme-toggle-vt-duration");
+      root.style.removeProperty("--sealai-theme-vt-clip-from");
+    };
+  }, [cancelAnim]);
+
+  // Uncontrolled mode mirrors the <html> class so an external owner (e.g. a
+  // script that applies a stored theme) still drives the icon.
+  useEffect(() => {
+    if (isControlled) {
+      return;
+    }
+
+    const updateTheme = () => {
+      setInternalIsDark(document.documentElement.classList.contains("dark"));
+    };
+
+    updateTheme();
+
+    const observer = new MutationObserver(updateTheme);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    return () => observer.disconnect();
+  }, [isControlled]);
+
+  const toggleTheme = useCallback(() => {
+    const button = buttonRef.current;
+    if (
+      !button ||
+      isTransitioningRef.current ||
+      document.documentElement.dataset.sealaiThemeVt === "active"
+    ) {
+      return;
+    }
+
+    // innerWidth/innerHeight (not visualViewport): percentages must resolve
+    // against the snapshot reference box, which includes classic scrollbars.
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    let x: number;
+    let y: number;
+    if (fromCenter) {
+      x = viewportWidth / 2;
+      y = viewportHeight / 2;
+    } else {
+      const { top, left, width, height } = button.getBoundingClientRect();
+      x = left + width / 2;
+      y = top + height / 2;
+    }
+
+    const maxRadius = Math.hypot(
+      Math.max(x, viewportWidth - x),
+      Math.max(y, viewportHeight - y)
+    );
+
+    const applyTheme = () => {
+      const newTheme = !isDark;
+      // Flip the class synchronously so the View Transitions API snapshots
+      // the new theme inside the startViewTransition callback. In controlled
+      // mode this is the authoritative paint; the owner's setTheme re-applies
+      // the same class afterwards (idempotent) and persists the choice.
+      const root = document.documentElement;
+      root.classList.toggle("dark");
+      root.style.colorScheme = newTheme ? "dark" : "light";
+      if (isControlled) {
+        onThemeChange?.(newTheme ? "dark" : "light");
+      } else {
+        setInternalIsDark(newTheme);
+        localStorage.setItem("theme", newTheme ? "dark" : "light");
+      }
+    };
+
+    if (typeof document.startViewTransition !== "function") {
+      applyTheme();
+      return;
+    }
+
+    const clipPath = getThemeTransitionClipPaths(
+      shape,
+      x,
+      y,
+      maxRadius,
+      viewportWidth,
+      viewportHeight
+    );
+
+    const root = document.documentElement;
+    root.dataset.sealaiThemeVt = "active";
+    root.style.setProperty(
+      "--sealai-theme-toggle-vt-duration",
+      `${duration}ms`
+    );
+    // Pin the collapsed clip-path via CSS so Firefox does not paint the new
+    // theme unclipped between snapshot and the ready.then() JS animation.
+    root.style.setProperty("--sealai-theme-vt-clip-from", clipPath[0]);
+    const cleanup = () => {
+      isTransitioningRef.current = false;
+      setIsTransitioning(false);
+      delete root.dataset.sealaiThemeVt;
+      root.style.removeProperty("--sealai-theme-toggle-vt-duration");
+      root.style.removeProperty("--sealai-theme-vt-clip-from");
+      cancelAnim();
+    };
+
+    isTransitioningRef.current = true;
+    setIsTransitioning(true);
+    const transition = document.startViewTransition(applyTheme);
+    if (typeof transition?.finished?.finally === "function") {
+      transition.finished.finally(cleanup).catch(() => undefined);
+    } else {
+      cleanup();
+    }
+
+    const ready = transition?.ready;
+    if (ready && typeof ready.then === "function") {
+      ready
+        .then(() => {
+          const anim = document.documentElement.animate(
+            { clipPath },
+            {
+              duration,
+              // Star: linear avoids easing overshoot that fights polygon
+              // interpolation at t→1; the VT group duration is synced above.
+              easing: shape === "star" ? "linear" : "ease-in-out",
+              fill: "forwards",
+              pseudoElement: "::view-transition-new(root)",
+            }
+          );
+          activeAnimRef.current = anim;
+        })
+        .catch(() => undefined);
+    }
+  }, [
+    shape,
+    fromCenter,
+    duration,
+    isDark,
+    isControlled,
+    onThemeChange,
+    cancelAnim,
+  ]);
+
+  return (
+    <button
+      {...props}
+      className={cn(className)}
+      onClick={(event) => {
+        // Compose with a caller-provided handler: a TooltipTrigger render
+        // injects its own onClick, which must not silence the toggle.
+        onClick?.(event);
+        if (!event.defaultPrevented) {
+          toggleTheme();
+        }
+      }}
+      ref={setButtonRef}
+      type="button"
+    >
+      <span
+        className={cn(
+          "relative inline-flex size-4 shrink-0 items-center justify-center",
+          iconClassName
+        )}
+        data-slot="animated-theme-toggler-icon"
+        ref={iconRef}
+      >
+        {/* The live DOM is frozen while a view transition is in flight, so
+            defer the icon crossfade until the reveal has settled. */}
+        {mounted && !isTransitioning ? (
+          <AnimatePresence initial={false} mode="wait">
+            {isDark ? (
+              <motion.span
+                animate={{ opacity: 1, rotate: 0, scale: 1 }}
+                aria-hidden
+                className="absolute inset-0 flex items-center justify-center"
+                exit={{ opacity: 0, rotate: 90, scale: 0.5 }}
+                initial={{ opacity: 0, rotate: -90, scale: 0.5 }}
+                key="sun"
+                transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
+              >
+                <Sun className="size-4" strokeWidth={1.5} />
+              </motion.span>
+            ) : (
+              <motion.span
+                animate={{ opacity: 1, rotate: 0, scale: 1 }}
+                aria-hidden
+                className="absolute inset-0 flex items-center justify-center"
+                exit={{ opacity: 0, rotate: -90, scale: 0.5 }}
+                initial={{ opacity: 0, rotate: 90, scale: 0.5 }}
+                key="moon"
+                transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
+              >
+                <Moon className="size-4" strokeWidth={1.5} />
+              </motion.span>
+            )}
+          </AnimatePresence>
+        ) : null}
+      </span>
+      {children}
+      <span className="sr-only">Toggle theme</span>
+    </button>
+  );
+};

--- a/packages/ui/src/components/theme-provider.tsx
+++ b/packages/ui/src/components/theme-provider.tsx
@@ -13,8 +13,7 @@ function ThemeProvider({
       defaultTheme="dark"
       disableTransitionOnChange
       enableSystem={false}
-      forcedTheme="dark"
-      themes={["dark"]}
+      themes={["light", "dark"]}
       {...props}
     >
       {children}

--- a/packages/ui/src/components/theme-toggle.tsx
+++ b/packages/ui/src/components/theme-toggle.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import {
+  AnimatedThemeToggler,
+  type AnimatedThemeTogglerProps,
+} from "@workspace/ui/components/animated-theme-toggler";
+import { useTheme } from "next-themes";
+
+/**
+ * next-themes-backed {@link AnimatedThemeToggler}. The provider owns
+ * persistence; the toggler only reports the requested theme and paints the
+ * View Transition reveal. Kept in @workspace/ui because app packages do not
+ * resolve `next-themes` directly (same boundary as sonner.tsx).
+ */
+function ThemeToggle(
+  props: Omit<AnimatedThemeTogglerProps, "theme" | "onThemeChange">
+) {
+  const { resolvedTheme, setTheme } = useTheme();
+
+  return (
+    <AnimatedThemeToggler
+      onThemeChange={setTheme}
+      theme={resolvedTheme === "dark" ? "dark" : "light"}
+      {...props}
+    />
+  );
+}
+
+export { ThemeToggle };

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -163,8 +163,9 @@
   /** Shared glass-sheet blur radius; mirrors CANVAS_GLASS_BLUR_RADIUS in JS. */
   --canvas-glass-blur-radius: 40px;
 
-  /** Project chrome surface tokens. */
-  --project-chrome-surface-base: #080a11;
+  /** Project chrome surface tokens. The dark base (#080a11) moved into
+      `.dark` so light mode follows the theme; dark resolves identically. */
+  --project-chrome-surface-base: oklch(0.985 0 0);
   --project-chrome-surface: color-mix(
     in oklab,
     var(--input) 30%,
@@ -255,6 +256,10 @@
   );
   --sealai-brand-primary-hover: var(--color-blue-500);
   --sealai-brand-primary-foreground: oklch(0.922 0 0);
+
+  /** Project chrome surface base (was :root-only dark; paired here so dark
+      resolves exactly as before while light follows the theme). */
+  --project-chrome-surface-base: #080a11;
 }
 
 @layer base {
@@ -744,6 +749,26 @@
     > .slider {
     background-color: var(--scrollbar-thumb);
   }
+}
+
+/* AnimatedThemeToggler View Transitions (ported from magicui): disable the
+   browser's default crossfade so the JS clip-path animation owns the reveal.
+   Scoped via the data-attribute the toggler sets only while a toggle is in
+   flight, so other view transitions in the app (e.g. Next.js navigation)
+   keep default behavior. The clip-from pin keeps Firefox from painting the
+   new theme unclipped between snapshot and the JS animation. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  mix-blend-mode: normal;
+  animation: none;
+}
+
+html[data-sealai-theme-vt="active"]::view-transition-group(root) {
+  animation-duration: var(--sealai-theme-toggle-vt-duration);
+}
+
+html[data-sealai-theme-vt="active"]::view-transition-new(root) {
+  clip-path: var(--sealai-theme-vt-clip-from);
 }
 
 /* Registered via @utility (not a plain class in @layer utilities) so it can

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -842,11 +842,12 @@ html[data-sealai-theme-vt="active"]::view-transition-new(root) {
   }
 
   /* Canvas Glow material (see CONTEXT.md): same canvas base + glow as
-     .main-action-surface-background, but the glow renders above the surface's
-     content: content layers must stay below z-20. */
+     .main-action-surface-background, but the glow renders above the
+     surface's content: content layers must stay below z-20. Shares the
+     theme-paired surface/glow tokens (light sheet, dark canvas navy). */
   .canvas-glow-overlay {
     overflow: hidden;
-    background-color: var(--color-canvas-surface);
+    background-color: var(--main-action-surface-bg);
     isolation: isolate;
   }
 
@@ -861,7 +862,7 @@ html[data-sealai-theme-vt="active"]::view-transition-new(root) {
     content: "";
     background: radial-gradient(
       ellipse closest-side at center,
-      var(--color-canvas-glow) 0%,
+      var(--main-action-surface-glow-color) 0%,
       transparent 100%
     );
     mix-blend-mode: screen;

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -80,6 +80,7 @@
   --color-db-access-sticky-header-surface: var(
     --db-access-sticky-header-surface
   );
+  --color-db-access-row-selector-surface: var(--db-access-row-selector-surface);
 
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
@@ -153,7 +154,14 @@
   /** Canvas component tokens. */
   --color-canvas-surface: var(--color-neutral-950);
   --canvas-minimap-node-radius: 0.625rem;
-  --db-access-sticky-header-surface: #161e33;
+  /* DB Access sticky surfaces: light values here; the dark navy originals
+     moved to `.dark` (dark resolves pixel-identical). */
+  --db-access-sticky-header-surface: var(--muted);
+  --db-access-row-selector-surface: var(--muted);
+  /* Main action surface (DB Access / logs overlay): light is a plain chrome
+     sheet; `.dark` swaps in the canvas navy base + blue glow. */
+  --main-action-surface-bg: var(--background);
+  --main-action-surface-glow-color: transparent;
   --color-canvas-glow: var(--color-blue-700);
   --color-canvas-dot: color-mix(
     in oklab,
@@ -260,6 +268,14 @@
   /** Project chrome surface base (was :root-only dark; paired here so dark
       resolves exactly as before while light follows the theme). */
   --project-chrome-surface-base: #080a11;
+
+  /** DB Access sticky surfaces (dark navy originals, now paired). */
+  --db-access-sticky-header-surface: #161e33;
+  --db-access-row-selector-surface: #0c1120;
+
+  /** Main action surface: dark keeps the canvas navy base + blue glow. */
+  --main-action-surface-bg: var(--color-canvas-surface);
+  --main-action-surface-glow-color: var(--color-canvas-glow);
 }
 
 @layer base {
@@ -798,7 +814,7 @@ html[data-sealai-theme-vt="active"]::view-transition-new(root) {
 
   .main-action-surface-background {
     overflow: hidden;
-    background-color: var(--color-canvas-surface);
+    background-color: var(--main-action-surface-bg);
     isolation: isolate;
   }
 
@@ -813,7 +829,7 @@ html[data-sealai-theme-vt="active"]::view-transition-new(root) {
     content: "";
     background: radial-gradient(
       ellipse closest-side at center,
-      var(--color-canvas-glow) 0%,
+      var(--main-action-surface-glow-color) 0%,
       transparent 100%
     );
     mix-blend-mode: screen;


### PR DESCRIPTION
## Parent spec / tickets

- Spec: https://github.com/labring/sealos-private/issues/138
- Tickets: #139 (unlock + toggler) · #140 (DataBrowser) · #141 (Billing) · #142 (site-wide verification)

## What

- Unlock next-themes (light+dark, default dark, persisted); no more `forcedTheme`.
- Port magicui `AnimatedThemeToggler` into `@workspace/ui` (controlled via next-themes; View Transitions circular reveal + motion Sun/Moon crossfade; graceful direct-switch fallback without VT).
- Sidebar footer row above the account entry, matching nav-row geometry (hover sheet, w-9 icon column, collapsed-rail tooltip).
- Shell color literals paired for light mode with pixel-identical dark resolution (`neutral-50/400` → semantic `foreground/muted-foreground`; blues get `blue-600 dark:blue-400`).
- DB Access: dropped hard-coded `dark` wrappers; `--db-access-sticky-header-surface` / new `--db-access-row-selector-surface` / `--main-action-surface-bg` + glow tokens paired (light sheet, dark canvas navy pixel-identical).
- Billing: canvas-glow material shares the paired surface/glow tokens; forced-dark tooltip removed; white overlays/blue accents paired.
- Canvas (`.canvas-surface` tokens) and registry previews keep their intentional dark appearance (untouched; chart palette theme-invariant).

## Evidence

- `packages/ui` component tests: 147 pass / 0 fail (7 new toggler tests).
- `bun typecheck` 6/6 green; `bun check` green.
- Browser verification (local dev, 1440×900, computed-style probes):
  - Dark zero-regression: body `lab(2.75381 0 0)` = neutral-950; sidebar text `lab(98.26 0 0)` = neutral-50; DB Access sticky `#161e33`; row selector `#0c1120`; chrome base `#080a11`; billing glow `lab(36.9089 …)` = blue-700 — all pixel-identical to pre-change values.
  - Light: body white; sidebar/DB Access/Billing readable (muted surfaces, transparent glow); canvas tokens stay dark by design; chart-1 `#49aeff` theme-invariant.
  - Toggle: class flip + `localStorage` persistence + `colorScheme`; VT lifecycle verified (scoped attrs set/cleared, re-entrancy guarded).
- apps/ui suites: failure sets byte-identical to clean `origin/main` baseline (pre-existing, none introduced).

## Screenshot evidence (#142)

18 Playwright captures (branch dark/light + origin/main dark baseline, dev-mock fixtures) with pixelmatch diff: every page differs by 59–72 px, all inside the sidebar footer = the new theme-toggle row's sun glyph. No other dark pixel changed. Gist: https://gist.github.com/zjy365/9d322a1c39513f6cd14beea9d68e72b3

## Fixed during verification

`TooltipTrigger render` injects its own `onClick` into the toggle button; the toggler now composes caller `onClick` instead of being silenced by it.

🤖 Generated with [ZCode](https://zcode.dev)

