### PR TITLE
fix(chat): report the allowance wall with the last free turn, pin the ai_quota contract (ADR-0073)

### DIFF
--- a/apps/ui/src/app/api/chat/route.test.ts
+++ b/apps/ui/src/app/api/chat/route.test.ts
@@ -1741,6 +1741,12 @@ test("a non-trial workspace bills user from its first message, allowance untouch
 test("the turn spending the last free message reports the next user-billed posture", async () => {
   freeTierSnapshot = { limit: 5, remaining: 1, used: 4 };
   trialJudgment = "trial";
+  billingStanding = {
+    ...billingStanding,
+    accountDebt: false,
+    aiCredits: { totalMicroUnits: 3_000_000, usedMicroUnits: 1_200_000 },
+    paidSource: "ai-credits",
+  };
 
   const response = await POST(
     chatRequest(userMessage("user-last-free", "inspect the cluster"))
@@ -1749,10 +1755,64 @@ test("the turn spending the last free message reports the next user-billed postu
   expect(response.headers.get("X-Chat-Billing")).toBe("user");
   expect(response.headers.get("X-Chat-Free-Remaining")).toBe("0");
   expect(response.headers.get("X-Chat-Free-Limit")).toBe("5");
+  expect(response.headers.get("X-Chat-Paid-Source")).toBe("ai-credits");
+  expect(response.headers.get("X-Chat-Wall")).toBe("");
   await drain(response);
 
   expect(reserveCalls).toBe(1);
   expect(releaseCalls).toBe(0);
+  expect(connectionBillingCalls).toEqual(["free"]);
+});
+
+test("the turn spending the last free message on a zero-allowance plan already reports the allowance wall", async () => {
+  // ADR-0073: headers and session bootstrap must agree, so the pane locks the
+  // moment the allowance is spent — while this reply still runs on the
+  // platform model.
+  freeTierSnapshot = { limit: 5, remaining: 1, used: 4 };
+  trialJudgment = "trial";
+  billingStanding = {
+    ...billingStanding,
+    accountDebt: false,
+    aiCredits: { totalMicroUnits: 0, usedMicroUnits: 0 },
+    paidSource: "ai-credits",
+  };
+
+  const response = await POST(
+    chatRequest(userMessage("user-last-free-walled", "inspect the cluster"))
+  );
+  expect(response.status).toBe(200);
+  expect(response.headers.get("X-Chat-Billing")).toBe("user");
+  expect(response.headers.get("X-Chat-Free-Remaining")).toBe("0");
+  expect(response.headers.get("X-Chat-Paid-Source")).toBe("ai-credits");
+  expect(response.headers.get("X-Chat-Wall")).toBe("allowance-trial");
+  await drain(response);
+
+  expect(reserveCalls).toBe(1);
+  expect(releaseCalls).toBe(0);
+  expect(connectionBillingCalls).toEqual(["free"]);
+});
+
+test("a free turn with turns to spare never reports the wall its standing would earn", async () => {
+  freeTierSnapshot = { limit: 5, remaining: 2, used: 3 };
+  trialJudgment = "trial";
+  billingStanding = {
+    ...billingStanding,
+    accountDebt: false,
+    aiCredits: { totalMicroUnits: 0, usedMicroUnits: 0 },
+    paidSource: "ai-credits",
+  };
+
+  const response = await POST(
+    chatRequest(userMessage("user-free-open", "inspect the cluster"))
+  );
+  expect(response.status).toBe(200);
+  expect(response.headers.get("X-Chat-Billing")).toBe("free");
+  expect(response.headers.get("X-Chat-Free-Remaining")).toBe("1");
+  expect(response.headers.get("X-Chat-Paid-Source")).toBe("");
+  expect(response.headers.get("X-Chat-Wall")).toBe("");
+  await drain(response);
+
+  expect(reserveCalls).toBe(1);
   expect(connectionBillingCalls).toEqual(["free"]);
 });
 

--- a/apps/ui/src/app/api/chat/route.ts
+++ b/apps/ui/src/app/api/chat/route.ts
@@ -647,14 +647,16 @@ async function settleTurnBillingPosture(actor: ChatBillingActor): Promise<
 
   if (await reserveFreeTurnIfAvailable(actor.namespace)) {
     // Headers carry the POST-turn posture: the turn spending the last free
-    // turn already reports `user`, so the next request uses the caller's AI
-    // Proxy without one-message-late client inference.
+    // turn already reports `user`, walled the way session bootstrap would
+    // wall it, so headers and bootstrap agree and the pane locks the moment
+    // the allowance is spent (ADR-0073) — not one refused send later. Any
+    // earlier free turn keeps its `free` posture and never awaits the
+    // standing.
     return {
       billing: "free",
-      clientFreeTier: freeTierPostureAfterTurn(
-        freeTier,
-        systemModelConfigured,
-        trial
+      clientFreeTier: await withPaidChatWall(
+        freeTierPostureAfterTurn(freeTier, systemModelConfigured, trial),
+        judgment
       ),
       reserved: true,
     };

--- a/apps/ui/src/features/billing/server/billing-standing-core.test.ts
+++ b/apps/ui/src/features/billing/server/billing-standing-core.test.ts
@@ -131,6 +131,41 @@ describe("judgeWorkspaceBillingStanding", () => {
     });
   });
 
+  it("reads a zero AI allowance as a fact — the production Free plan's quota shape (ADR-0073)", () => {
+    const standing = judgeWorkspaceBillingStanding({
+      account: HEALTHY_ACCOUNT,
+      credits: NO_CREDITS,
+      quota: quota({ aiHard: 0, aiUsed: 0 }),
+      subscription: {
+        subscription: {
+          PlanName: "Free",
+          Status: "NORMAL",
+          type: "SUBSCRIPTION",
+        },
+      },
+    });
+    expect(standing.paidSource).toBe("ai-credits");
+    expect(standing.aiCredits).toEqual({
+      totalMicroUnits: 0,
+      usedMicroUnits: 0,
+    });
+  });
+
+  it("leaves AI Credits unknown when a subscribed workspace's quota omits ai_quota — fail open, never a missing allowance", () => {
+    // account-service writes the key for every annotated subscription
+    // namespace; its absence means the annotation and the subscription record
+    // disagree, and aiproxy would charge the balance instead.
+    const standing = judgeWorkspaceBillingStanding({
+      account: HEALTHY_ACCOUNT,
+      credits: NO_CREDITS,
+      quota: quota({}),
+      subscription: HOBBY,
+    });
+    expect(standing.paidSource).toBe("ai-credits");
+    expect(standing.quotaKnown).toBe(true);
+    expect(standing.aiCredits).toBeNull();
+  });
+
   it("reads a DELETED subscription record as Pay-As-You-Go", () => {
     const standing = judgeWorkspaceBillingStanding({
       account: DEBT_ACCOUNT,

--- a/apps/ui/src/features/billing/server/billing-standing-core.ts
+++ b/apps/ui/src/features/billing/server/billing-standing-core.ts
@@ -192,6 +192,19 @@ function subscriptionFacts(subscription: unknown): {
   };
 }
 
+/**
+ * The subscription's AI Credits, read from `get-resource-quota`. For every
+ * namespace carrying the `subscription.sealos.io/status` annotation,
+ * account-service writes `hard.ai_quota` and `used.ai_quota` unconditionally
+ * (`service/account/api/workspace.go`), summing the workspace's active quota
+ * packages — a plan that granted none reads `0`, never an absent key
+ * (ADR-0073). An absent key on a workspace whose subscription record says
+ * "subscription" therefore means upstream's annotation disagrees with that
+ * record, and aiproxy would charge the balance rather than the quota: the
+ * read stays null so the wall fails open (ADR-0068) instead of claiming a
+ * missing allowance. The display-side reader (`loadAiCredits`) shows the
+ * same absence as 0 — a rendering choice, not a judgment.
+ */
 function aiCreditsFromQuota(quota: unknown): WorkspaceAiCredits | null {
   const parsed = aiQuotaSchema.safeParse(quota);
   if (!parsed.success) {

--- a/apps/ui/src/features/billing/server/dev-fixtures/dev-fixtures.test.ts
+++ b/apps/ui/src/features/billing/server/dev-fixtures/dev-fixtures.test.ts
@@ -18,6 +18,7 @@ import {
   BILLING_DEV_SCENARIOS,
   formatBillingDevMockCookie,
 } from "../../dev-mock-cookie";
+import { judgeWorkspaceBillingStanding } from "../billing-standing-core";
 import { billingDevMockResponse, freeChatTurnsFixture } from "./index";
 import { scenarioTestFetch } from "./scenario-test-fetch";
 
@@ -111,6 +112,46 @@ test("the free-turns fixture spends the trial's allowance with the scenario (ADR
     remaining: 0,
     used: 5,
   });
+});
+
+test("the free scenarios' standing grants no AI allowance — the fact the allowance wall judges (ADR-0073)", async () => {
+  // Mirrors production: account-service writes `ai_quota` for every
+  // subscribed namespace, `0` when the plan created no quota package.
+  const standingFor = async (scenario: string) => {
+    const read = async (pathname: string) => {
+      const response = await billingDevMockResponse(
+        pathname,
+        mockRequest(pathname, scenario)
+      );
+      assert.ok(response, `${scenario} answers ${pathname}`);
+      return response.json();
+    };
+    return judgeWorkspaceBillingStanding({
+      account: await read("/account/v1alpha1/account"),
+      credits: await read("/payment/v1alpha1/credits/info"),
+      quota: await read("/account/v1alpha1/workspace/get-resource-quota"),
+      subscription: await read("/account/v1alpha1/workspace-subscription/info"),
+    });
+  };
+  for (const scenario of ["free", "free-expiring", "free-expired"]) {
+    const standing = await standingFor(scenario);
+    assert.equal(
+      standing.paidSource,
+      "ai-credits",
+      `${scenario} pays from AI Credits`
+    );
+    assert.equal(
+      standing.aiCredits?.totalMicroUnits,
+      0,
+      `${scenario} grants no AI allowance`
+    );
+  }
+  const hobby = await standingFor("active");
+  assert.equal(hobby.paidSource, "ai-credits");
+  assert.equal(hobby.aiCredits?.totalMicroUnits, 3_000_000);
+  const payg = await standingFor("payg");
+  assert.equal(payg.paidSource, "balance");
+  assert.equal(payg.aiCredits, null);
 });
 
 test("every scenario passes every loader's schemas", async () => {

--- a/apps/ui/src/features/chat/chat-billing-interruption.test.ts
+++ b/apps/ui/src/features/chat/chat-billing-interruption.test.ts
@@ -75,7 +75,7 @@ describe("chatBillingInterruptionFromError", () => {
 describe("copy forks by Chat Billing Mode", () => {
   it("speaks AI Credits and an upgrade for a subscribed workspace", () => {
     expect(chatBillingWallCopy("ai-credits")).toEqual({
-      body: "This workspace's AI Credits are exhausted. Upgrade the plan to keep chatting.",
+      body: "This workspace's AI Credits have dropped below the minimum a reply needs. Upgrade the plan to keep chatting.",
       cta: { destination: "upgrade", label: "Upgrade plan" },
       title: "AI Credits used up",
     });

--- a/apps/ui/src/features/chat/chat-billing-interruption.ts
+++ b/apps/ui/src/features/chat/chat-billing-interruption.ts
@@ -90,7 +90,7 @@ export function chatBillingWallCopy(cause: ChatWallCause): ChatBillingCopy {
   }
   if (cause === "ai-credits") {
     return {
-      body: "This workspace's AI Credits are exhausted. Upgrade the plan to keep chatting.",
+      body: "This workspace's AI Credits have dropped below the minimum a reply needs. Upgrade the plan to keep chatting.",
       cta: { destination: "upgrade", label: "Upgrade plan" },
       title: "AI Credits used up",
     };

--- a/apps/ui/src/features/chat/persistence/chat-billing-judgment.test.ts
+++ b/apps/ui/src/features/chat/persistence/chat-billing-judgment.test.ts
@@ -19,6 +19,13 @@ const OPEN_PAYG: WorkspaceBillingStanding = {
   quotaKnown: true,
 };
 
+/** The production Free plan's standing: subscribed, no AI allowance at all. */
+const ZERO_ALLOWANCE: WorkspaceBillingStanding = {
+  ...OPEN_PAYG,
+  aiCredits: { totalMicroUnits: 0, usedMicroUnits: 0 },
+  paidSource: "ai-credits",
+};
+
 const ACTOR = {
   accountUserId: "user-1",
   cookieHeader: null,
@@ -135,6 +142,44 @@ describe("resolveFreeTierPosture", () => {
       paidSource: "balance",
       remaining: 2,
       wall: "balance",
+    });
+  });
+
+  it("reports the allowance wall at bootstrap, in the trial voice, once an Active Free Trial on a zero-allowance plan has spent its turns", async () => {
+    // ADR-0073: the pane locks on load, before any send is refused.
+    const posture = await resolveFreeTierPosture(ACTOR, {
+      isSystemOpenAiConfigured: () => true,
+      judgeActiveFreeTrialForWorkspace: () => Promise.resolve("trial"),
+      judgeWorkspaceBillingStandingForActor: () =>
+        Promise.resolve(ZERO_ALLOWANCE),
+      readFreeTierSnapshot: () =>
+        Promise.resolve({ limit: 5, remaining: 0, used: 5 }),
+    });
+    expect(posture).toEqual({
+      billing: "user",
+      limit: 5,
+      paidSource: "ai-credits",
+      remaining: 0,
+      wall: "allowance-trial",
+    });
+  });
+
+  it("voices the allowance wall as the plan's when the workspace never had a trial", async () => {
+    // Turns remaining do not matter: without a trial nothing spends them.
+    const posture = await resolveFreeTierPosture(ACTOR, {
+      isSystemOpenAiConfigured: () => true,
+      judgeActiveFreeTrialForWorkspace: () => Promise.resolve("not-trial"),
+      judgeWorkspaceBillingStandingForActor: () =>
+        Promise.resolve(ZERO_ALLOWANCE),
+      readFreeTierSnapshot: () =>
+        Promise.resolve({ limit: 5, remaining: 5, used: 0 }),
+    });
+    expect(posture).toEqual({
+      billing: "user",
+      limit: 5,
+      paidSource: "ai-credits",
+      remaining: 5,
+      wall: "allowance-plan",
     });
   });
 });

--- a/apps/ui/src/features/chat/persistence/chat-billing-judgment.ts
+++ b/apps/ui/src/features/chat/persistence/chat-billing-judgment.ts
@@ -18,11 +18,12 @@ import type { FreeTierState } from "./types";
 /**
  * The live billing facts one chat request is judged on (ADR-0065, ADR-0068,
  * ADR-0069): the local free-turn snapshot, the Active Free Trial judgment,
- * and — for the `user` posture only — the Paid Chat Wall. The trial
- * judgment and the four standing reads leave together under ONE budget, so
- * an unanswering account service costs the request at most that budget
- * before every read fails open; a `free` turn simply never consults the
- * standing it read.
+ * and — for a `user` posture only, whether this turn's or the post-turn one
+ * the last free turn reports — the Paid Chat Wall. The trial judgment and
+ * the four standing reads leave together under ONE budget, so an
+ * unanswering account service costs the request at most that budget before
+ * every read fails open; a `free` turn with turns to spare simply never
+ * consults the standing it read.
  */
 
 export interface ChatBillingActor {

--- a/apps/ui/src/features/chat/persistence/types.ts
+++ b/apps/ui/src/features/chat/persistence/types.ts
@@ -62,11 +62,6 @@ export const assistantThreadDTOSchema = z.object({
 }) satisfies z.ZodType<AssistantThreadDTO>;
 
 /**
- * Read-side snapshot of a workspace's Chat Billing Posture, seeded into the
- * pane on load. Computed server-side only (ADR-0065/0069): bootstrap payload
- * and `X-Chat-*` headers agree; clients render, never derive.
- */
-/**
  * What a `user` turn spends (CONTEXT.md): a subscribed workspace's AI
  * Credits, a Pay-As-You-Go workspace's Account Balance.
  */
@@ -86,6 +81,11 @@ export type ChatWallCause =
   | "allowance-trial"
   | "allowance-plan";
 
+/**
+ * Read-side snapshot of a workspace's Chat Billing Posture, seeded into the
+ * pane on load. Computed server-side only (ADR-0065/0069): bootstrap payload
+ * and `X-Chat-*` headers agree; clients render, never derive.
+ */
 export interface FreeTierState {
   billing: "free" | "user";
   limit: number;

--- a/docs/adr/0069-separate-platform-ai-credentials-and-hand-off-free-chat.md
+++ b/docs/adr/0069-separate-platform-ai-credentials-and-hand-off-free-chat.md
@@ -5,7 +5,9 @@
 Exhaustion consequence revised by ADR-0073: the handoff stands, but a plan
 that grants no AI allowance (the production Free plan's `ai_quota` is 0)
 meets the Paid Chat Wall's allowance cause instead of a spendable Paid
-Source.
+Source. The turn that spends the last Free Chat Turn already reports that
+wall in its `X-Chat-*` headers, so the composer locks with the fifth reply;
+the sixth send is refused, never silently handed off.
 
 Chat Agent and GitHub Deployment Tasks are different workloads with different
 platform funding. Their environment variables must select only their own

--- a/docs/adr/0073-wall-zero-allowance-plans-with-a-truthful-cause.md
+++ b/docs/adr/0073-wall-zero-allowance-plans-with-a-truthful-cause.md
@@ -12,7 +12,10 @@ ADR-0068's Paid Chat Wall with a truthful cause.
 - **The production Free plan grants no AI Credits.** Its `ai_quota` is 0,
   and account-service skips creating a quota package entirely when
   `ai_quota <= 0` — so an Active Free Trial workspace's `user` turns are refused by
-  aiproxy unconditionally, on every turn.
+  aiproxy unconditionally, on every turn. `get-resource-quota` still writes
+  `hard.ai_quota` for every namespace carrying the subscription annotation
+  (`service/account/api/workspace.go`, summing the active packages), so that
+  workspace reads `ai_quota: 0` — a fact, not an absent key.
 - **A subscribed workspace never spends the Account Balance on AI.** For a
   namespace carrying the `subscription.sealos.io/status` annotation, the
   aiproxy pre-check reads only `remainAIQuota`; account-service's response
@@ -35,6 +38,13 @@ read shows AI Credits with `total <= 0`, the Paid Chat Wall's cause is
 wall behaves as every Paid Chat Wall does under ADR-0068: the pre-send gate
 refuses with `402 ai_allowance_missing`, the card names the cause and the
 Upgrade CTA, and the composer locks at once with a placeholder stating why.
+
+**The lock arrives with the last Free Chat Turn, not one send later.** The
+turn that spends the last Free Chat Turn already reports the post-turn
+`user` posture in its `X-Chat-*` headers (ADR-0069); that posture is walled
+on the standing read for the same turn, so the headers and the session
+bootstrap payload agree and the pane locks as the fifth reply starts — no
+refused send, no reload. Earlier free turns never consult the standing.
 
 **The exhaustion floor mirrors aiproxy.** AI Credits are exhausted below
 `AI_PROXY_MINIMUM_BALANCE_MICRO_UNITS = 300_000` (0.3 currency units at the
@@ -73,6 +83,15 @@ Plan view's allowance card follow the scenario.
   production Free plan the sixth turn meets the allowance wall instead.
 - The 0.3 floor is a deliberate copy of an upstream constant and can drift;
   it lives in one exported constant beside the wall judgment.
+- The floor is 30 displayed AI Credits (`MICRO_UNITS_PER_AI_CREDIT =
+  10_000`), so the Plan view can still show a small remainder while chat is
+  walled. The wall card's body names the minimum rather than claiming zero,
+  so the two surfaces read together.
+- An absent `ai_quota` on a workspace the subscription record calls
+  subscribed means upstream's namespace annotation disagrees with that
+  record; aiproxy would charge the balance there, so the credits read stays
+  unknown and the wall fails open (ADR-0068) instead of claiming a missing
+  allowance.
 - A refusal that bypasses the gate (a credits read that failed open, then
   aiproxy refusing the turn) is still voiced as a Billing Interruption from
   the Paid Source the pane knows — AI Credits, for a zero-allowance


### PR DESCRIPTION
## Why

#321 merged with its review still open: two blocking items and three nits from the cursor review. This PR settles them.

## What

**Last-free-turn headers now carry the wall (review item 1).** `settleTurnBillingPosture` walled only a `user` *request*. The turn spending the last Free Chat Turn reported `user` / `remaining=0` with empty `X-Chat-Paid-Source` and `X-Chat-Wall`, while session bootstrap for the same standing walled. The free branch now runs the post-turn posture through `withPaidChatWall` (a no-op for every earlier free turn), so headers and bootstrap agree and the composer locks with the fifth reply. The pane's session refetch on stream finish already recovered this in practice; the headers are now self-sufficient, as ADR-0069's "clients render, never derive" requires.

**Missing `hard.ai_quota` stays fail-open, now on record (review item 2).** account-service's `get-resource-quota` (`labring/sealos`, `service/account/api/workspace.go`) writes `hard.ai_quota` and `used.ai_quota` unconditionally for every namespace carrying the `subscription.sealos.io/status` annotation, summing the active quota packages — a Free workspace with no package reads `0`, never an absent key, so the fixtures' shape is production's. An absent key on a workspace the subscription record calls subscribed therefore means upstream's annotation disagrees with that record, and aiproxy charges the balance there, so walling on allowance would be wrong. `aiCreditsFromQuota` documents this and why it differs from the display-side `loadAiCredits`; the judgment is unchanged.

**Nits.** The orphan JSDoc in `persistence/types.ts` moves onto `FreeTierState`. The `ai-credits` wall card body names the minimum a reply needs instead of claiming zero: the 0.3 floor is 30 displayed AI Credits, and the Plan view can still show that remainder. ADR-0073 records the header timing, the `ai_quota: 0` shape, the 30-credit floor and the absent-key stance; ADR-0069's Status names when the lock arrives.

**Tests.** The route's last free turn carries `allowance-trial` on a zero-allowance plan and the Paid Source on a funded one; a free turn with turns to spare never reports a wall. `resolveFreeTierPosture` reports both allowance voices at bootstrap. The `free` / `free-expiring` / `free-expired` dev-mock scenarios judge to `totalMicroUnits === 0` through `judgeWorkspaceBillingStanding`; a subscribed quota row with `ai_quota` omitted stays unknown with `quotaKnown: true`.

## Verified

- `bun typecheck` (only the pre-existing `preview-canvas-perf` error remains), `bun check`.
- `bun test` on the chat route, the billing judgment, the standing core, the dev fixtures, the wall copy and the wall card: 138 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QusL551FaquK8wCUXm7x9g
