### PR TITLE
docs(release): prepare v2.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,73 @@
 
 All notable changes to Brain are documented in this file.
 
+## [2.0.11] - 2026-09-03
+
+### Added
+
+- Adopted external Template Instances as Brain Projects via
+  `POST /api/projects/adopt-template-instance`, so a Sealos Skills apply
+  (and any other non-Brain apply) can be claimed after the fact: one
+  Project, `brain.io/*` ownership labels, identity by Instance UID.
+  Brain's own GitHub extraLabels-at-create path is unchanged.
+- Grew the Plan view's cancel dialog into a Cancellation Survey. Cancelling
+  a paid Workspace Subscription still goes through account-service; Brain
+  now also asks why (optional reason chips and free text), stores the
+  answers as feedback in its own Postgres, and confirms the plan stays
+  active until period end. Keep Plan / close / Escape all keep the plan;
+  the undoing control is now Resume Plan.
+- Walled zero-allowance plans with a truthful Paid Chat Wall cause:
+  `allowance-trial` ("Free trial messages used up") on an Active Free
+  Trial, `allowance-plan` ("AI usage not included") otherwise, instead of
+  letting the composer stay open and die as a generic error.
+- Forwarded optional Langfuse credentials (`LANGFUSE_PUBLIC_KEY`,
+  `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`) into newly created GitHub Deploy
+  Devboxes so Codex Gateway can trace those sessions.
+
+### Changed
+
+- Softened the Deploy Billing Wall into the Deploy Billing Notice. The
+  four deployment panes keep the form usable under Account Debt, a full
+  cpu/memory/pod quota, or a payment-due subscription; only the
+  assistant's deploy tool still refuses. Billing CTAs are plan-first:
+  top-up goes to the Sealos Desktop cost center, quota reminders lead
+  with Upgrade plan / Subscribe, and Account Debt titles unify as
+  "in debt".
+- Separated Chat Agent platform credentials (`SYSTEM_OPENAI_*`) from
+  GitHub Deploy (`GITHUB_DEPLOY_OPENAI_*`). Free-trial allowance turns
+  use the platform key; exhausted or missing platform config falls back
+  to the caller's AI Proxy. GitHub Deploy uses its own pair when both
+  are set, the caller's AI Proxy when both are blank, and fails closed
+  on a partial pair — it never reuses Chat Agent or host Codex
+  credentials.
+
+### Fixed
+
+- Classified the platform's `debt.sealos.io` admission denial at the
+  apply boundary (`subscription-expired` / `balance-exhausted`) and sent
+  the App Token on every deployment source, so a docker/template/database
+  run that dies on billing gets a Billing Interruption card instead of
+  raw JSON.
+- Made the last Free Chat Turn report the allowance wall in the response
+  headers, so the composer locks with that reply without waiting for a
+  session refetch.
+- Made Dev Mocks read their cookie directly and register app-globally, so
+  panel toggles actually flip and an enabled mock stays visible across
+  routes.
+
+### Upgrade Notes
+
+- Run UI database migrations `0016` (cancellation survey) and `0017`
+  (template instance adoptions). Boot-time migrate still covers this
+  unless `APP_POSTGRES_SKIP_MIGRATIONS` is set.
+- New optional environment variables for GitHub Deploy tracing:
+  `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`. Leave
+  empty to disable; both keys must be set for Codex Gateway to export
+  traces. Only newly created Devboxes pick this up.
+- `GITHUB_DEPLOY_OPENAI_API_KEY` / `GITHUB_DEPLOY_OPENAI_BASE_URL` now
+  fail closed when only one is set, and never fall back to
+  `SYSTEM_OPENAI_*` or host Codex credentials.
+
 ## [2.0.10] - 2026-08-31
 
 ### Changed
@@ -407,6 +474,7 @@ databases, and day-to-day operations into one Project workspace.
 - Added Project Assistant for understanding the current Project context and
   starting supported operations.
 
+[2.0.11]: https://github.com/labring/brain/compare/v2.0.10...v2.0.11
 [2.0.10]: https://github.com/labring/brain/compare/v2.0.9...v2.0.10
 [2.0.9]: https://github.com/labring/brain/compare/v2.0.8...v2.0.9
 [2.0.8]: https://github.com/labring/brain/compare/v2.0.7...v2.0.8


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the `v2.0.11` changelog entry. After merge, tag `v2.0.11` on that commit and publish the GitHub Release with the copy below (same format as `v2.0.9` / `v2.0.10`).

Range: `v2.0.10` → `main` (2026-08-31 → 2026-09-03). Images publish to GHCR on the `v*` tag.

## GitHub Release copy

**Title:** `Brain v2.0.11`  
**Tag:** `v2.0.11`

```markdown
**Brain v2.0.11**

This release tells the truth about billing walls, lets a Sealos Skills
apply become a Brain Project, and asks why someone cancels.

**Template Instances as Brain Projects**
- A Template Instance created outside Brain (Sealos Skills, or any other
  apply path) can now be claimed as a Brain Project: one Project, ownership
  labels on the Instance and its children, identity by Instance UID.
- Retrying the same UID is idempotent. A reused name with a new UID is a
  new Project. Brain's own GitHub deploy path is unchanged.

**Cancellation Survey**
- Cancelling a paid plan from the Plan view now asks *why* (optional
  reason chips and free text) before the cancel goes through.
- After account-service confirms, the dialog itself says the cancellation
  is scheduled, names the period end, and how to Resume Plan. Every way
  out of the survey keeps the plan.
- Answers live in Brain as feedback, not as billing state.

**Deploy Billing Notice**
- The pre-deploy billing wall no longer replaces the form. A notice sits
  above a still-submittable GitHub / Docker / Database / Template pane;
  only the assistant's deploy tool still refuses.
- Top-up CTAs go to the Sealos Desktop cost center. Quota reminders lead
  with Upgrade plan / Subscribe. Account Debt titles unify as "in debt".
- A platform `debt.sealos.io` denial at apply time is now classified as
  `subscription-expired` or `balance-exhausted`, so the timeline shows a
  Billing Interruption card instead of raw JSON. Every deployment source
  sends the App Token, not only GitHub.

**Chat allowance wall**
- A plan with no AI Credits now walls with a truthful cause: "Free trial
  messages used up" on an Active Free Trial, "AI usage not included"
  otherwise — instead of leaving the composer open to die as a generic
  error.
- The turn that spends the last Free Chat Turn reports the wall in the
  same response, so the composer locks with that reply.

Images are published to GHCR (`ghcr.io/labring/brain-*`, tag `v2.0.11`).
```

## After merge

1. Tag `v2.0.11` on the changelog commit on `main`.
2. Publish the GitHub Release with the copy above.
3. Confirm GHCR images for `ghcr.io/labring/brain-*` at `v2.0.11`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65bf4fd4-9efb-4b93-85b5-35c80d4d10bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65bf4fd4-9efb-4b93-85b5-35c80d4d10bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

