### PR TITLE
fix(deploy): second template_ready in a managed turn no longer fails with claim_exhausted

### DIFF
--- a/apps/ui/src/features/deploy/task/agent-tools/store.test.ts
+++ b/apps/ui/src/features/deploy/task/agent-tools/store.test.ts
@@ -283,6 +283,56 @@ describe("deployment Agent durable tool inbox", () => {
     expect(exhausted?.attempt).toBe(3);
   });
 
+  it("reports the last retried error code when claims are exhausted", async () => {
+    const { task } = await activeMcpTask("agent-exhausted-with-code-task");
+    await store.enqueueAgentToolCall({
+      callId: "call-exhausted-code",
+      request: { sha256: "d".repeat(64) },
+      task,
+      toolName: "template_ready",
+    });
+    const claim = () =>
+      store.claimNextAgentToolCall({
+        claimOwner: "proc-1:3",
+        leaseEpoch: task.leaseEpoch,
+        taskId: task.id,
+      });
+    const retry = (errorCode: string) =>
+      store.retryAgentToolCall({
+        callId: "call-exhausted-code",
+        claimOwner: "proc-1:3",
+        errorCode,
+        taskId: task.id,
+      });
+
+    expect((await claim())?.attempt).toBe(1);
+    expect(await retry("agent_tool_failed")).toBe(true);
+    const second = await claim();
+    expect(second?.state).toBe("running");
+    expect(second?.errorCode).toBe("agent_tool_failed");
+    expect(await retry("agent_tool_failed")).toBe(true);
+    const exhausted = await claim();
+
+    expect(exhausted?.state).toBe("failed");
+    expect(exhausted?.errorCode).toBe("claim_exhausted:agent_tool_failed");
+    expect(exhausted?.attempt).toBe(3);
+    expect(await claim()).toBeNull();
+    const result = await store.waitForAgentToolCall({
+      callId: "call-exhausted-code",
+      taskId: task.id,
+      timeoutMs: 100,
+    });
+    expect(result.errorCode).toBe("claim_exhausted:agent_tool_failed");
+  });
+
+  it("formats the exhausted code with and without a prior error", () => {
+    expect(store.agentControlClaimExhaustedCode(null)).toBe("claim_exhausted");
+    expect(store.agentControlClaimExhaustedCode("")).toBe("claim_exhausted");
+    expect(
+      store.agentControlClaimExhaustedCode("template_digest_mismatch")
+    ).toBe("claim_exhausted:template_digest_mismatch");
+  });
+
   it("resolves only for the current claim owner", async () => {
     const { task } = await activeMcpTask("agent-failover-fence-task");
     const now = new Date();

--- a/apps/ui/src/features/deploy/task/agent-tools/store.ts
+++ b/apps/ui/src/features/deploy/task/agent-tools/store.ts
@@ -22,6 +22,19 @@ export const AGENT_CONTROL_CALL_MAX_ATTEMPTS = 3;
 export const AGENT_CONTROL_CALL_CLAIM_EXHAUSTED = "claim_exhausted" as const;
 export const AGENT_DEPLOYMENT_COMPLETED_MIN_INTERVAL_MS = 5000;
 
+/**
+ * `claim_exhausted` alone tells the Agent nothing actionable; when a retried
+ * call carried a (safe, runner-allowlisted) error code, the exhausted verdict
+ * keeps it as a suffix: `claim_exhausted:<code>`.
+ */
+export function agentControlClaimExhaustedCode(
+  lastErrorCode: string | null | undefined
+): string {
+  return lastErrorCode == null || lastErrorCode === ""
+    ? AGENT_CONTROL_CALL_CLAIM_EXHAUSTED
+    : `${AGENT_CONTROL_CALL_CLAIM_EXHAUSTED}:${lastErrorCode}`;
+}
+
 export function hashAgentControlCapability(token: string): string {
   return createHash("sha256").update(token, "utf8").digest("hex");
 }
@@ -153,8 +166,9 @@ export async function lastAgentToolCallAt(input: {
  * is only claimable after its `claimExpiresAt` passes (the previous Runner
  * crashed or stalled), at which point the lease epoch is taken over and the
  * attempt counter is bumped. When attempts reach the configured maximum the
- * call is failed with `claim_exhausted` so the MCP client can retry instead
- * of waiting forever.
+ * call is failed with `claim_exhausted[:<last error code>]` so the MCP client
+ * can retry instead of waiting forever; callers must not run the handler for
+ * a row returned in the `failed` state.
  */
 export async function claimNextAgentToolCall(input: {
   taskId: string;
@@ -198,7 +212,9 @@ export async function claimNextAgentToolCall(input: {
       attempt: row.attempt + 1,
       claimExpiresAt,
       claimOwner: input.claimOwner,
-      errorCode: exhausted ? AGENT_CONTROL_CALL_CLAIM_EXHAUSTED : row.errorCode,
+      errorCode: exhausted
+        ? agentControlClaimExhaustedCode(row.errorCode)
+        : row.errorCode,
       leaseEpoch: input.leaseEpoch,
       state: exhausted ? "failed" : "running",
       updatedAt: now,
@@ -245,11 +261,14 @@ export async function resolveAgentToolCall(input: {
 /**
  * Return a transiently failed control call to the durable inbox. The same
  * MCP request remains open while the runner makes another bounded attempt.
+ * `errorCode` records why this attempt failed so an eventual exhaustion can
+ * report it; it must already be a safe (allowlisted) code.
  */
 export async function retryAgentToolCall(input: {
   taskId: string;
   callId: string;
   claimOwner: string;
+  errorCode?: string;
 }): Promise<boolean> {
   const db = getDeploymentTaskDb();
   const rows = await db
@@ -258,7 +277,7 @@ export async function retryAgentToolCall(input: {
       claimExpiresAt: null,
       claimOwner: null,
       completedAt: null,
-      errorCode: null,
+      errorCode: input.errorCode ?? null,
       response: null,
       state: "pending",
       updatedAt: new Date(),

--- a/apps/ui/src/features/deploy/task/runner.managed-agent-tools.test.ts
+++ b/apps/ui/src/features/deploy/task/runner.managed-agent-tools.test.ts
@@ -1,0 +1,335 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
+import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
+
+import { and, eq } from "drizzle-orm";
+import { DeployTaskRunSupersededError } from "./engine/errors";
+import { insertTaskRow } from "./engine/testing/fixtures";
+import {
+  createDeployTaskTestHarness,
+  type DeployTaskTestHarness,
+} from "./engine/testing/harness";
+import {
+  type DeployTaskAgentCallRow,
+  type DeployTaskRow,
+  deployTaskAgentCalls,
+  deployTasks,
+} from "./schema";
+
+// Drives the real managed control-call dispatch (claim → handler → resolve /
+// retry) against the PGlite-backed durable inbox, with only the Devbox exec
+// and the engine write surface faked. Everything loads synchronously via
+// require and every module mock is restored in afterAll — see
+// runner.template-preserve.test.ts for why.
+
+const requireModule = createRequire(import.meta.url);
+let harness: DeployTaskTestHarness;
+
+interface DevboxExecResult {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+}
+let devboxExecImpl: () => Promise<DevboxExecResult>;
+let devboxExecCalls = 0;
+const beginApplyingCalls: string[] = [];
+const runController = new AbortController();
+
+mock.module("server-only", () => ({}));
+
+const realDb = requireModule("./db");
+const realDevboxClient = requireModule("@/lib/devbox/client");
+const realRunnerWrites = requireModule("./runner-writes");
+
+afterAll(async () => {
+  mock.module("./db", () => ({ ...realDb }));
+  mock.module("@/lib/devbox/client", () => ({ ...realDevboxClient }));
+  mock.module("./runner-writes", () => ({ ...realRunnerWrites }));
+  await harness.close();
+});
+
+mock.module("./db", () => ({
+  getDeploymentTaskDb: () => harness.db,
+}));
+
+mock.module("@/lib/devbox/client", () => ({
+  ...realDevboxClient,
+  execDevbox: async () => {
+    devboxExecCalls += 1;
+    return { data: await devboxExecImpl() };
+  },
+}));
+
+mock.module("./runner-writes", () => ({
+  ...realRunnerWrites,
+  // Mirrors the engine's guarded transition (`from: ["running"]`): a second
+  // beginApplying against an `applying` row loses the write and is reported
+  // as a supersession, exactly like DeployTaskHandle.beginApplying.
+  deployTaskBeginApplying: async (taskId: string) => {
+    beginApplyingCalls.push(taskId);
+    const rows = await harness.db
+      .update(deployTasks)
+      .set({ phase: "apply", status: "applying" })
+      .where(and(eq(deployTasks.id, taskId), eq(deployTasks.status, "running")))
+      .returning({ id: deployTasks.id });
+    if (rows.length === 0) {
+      throw new DeployTaskRunSupersededError();
+    }
+  },
+  deployTaskRunSignal: () => runController.signal,
+  throwIfDeployTaskAborted: () => undefined,
+  updateDeployTaskState: async (
+    taskId: string,
+    fields: Record<string, unknown>
+  ) => {
+    await harness.db
+      .update(deployTasks)
+      .set(fields)
+      .where(eq(deployTasks.id, taskId));
+  },
+}));
+
+const { processPendingManagedAgentToolCalls } = requireModule(
+  "./runner"
+) as typeof import("./runner");
+const store = requireModule(
+  "./agent-tools/store"
+) as typeof import("./agent-tools/store");
+
+function templateYaml(version: string): string {
+  return `apiVersion: app.sealos.io/v1
+kind: Template
+metadata:
+  name: demo-app
+spec:
+  templateType: inline
+  defaults:
+    app_name:
+      type: string
+      value: demo-app
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: \${{ defaults.app_name }}
+data:
+  version: ${version}
+`;
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+function serveTemplate(yaml: string): void {
+  devboxExecImpl = () =>
+    Promise.resolve({ exitCode: 0, stderr: "", stdout: yaml });
+}
+
+async function activeManagedTask(id: string): Promise<DeployTaskRow> {
+  return await insertTaskRow(harness.db, {
+    id,
+    leaseEpoch: 3,
+    leaseOwner: "proc-1",
+    phase: "plan",
+    runner: { kind: "ai", runtimeProvider: "devbox" },
+    status: "running",
+  });
+}
+
+async function callRow(
+  taskId: string,
+  callId: string
+): Promise<DeployTaskAgentCallRow> {
+  const rows = await harness.db
+    .select()
+    .from(deployTaskAgentCalls)
+    .where(
+      and(
+        eq(deployTaskAgentCalls.taskId, taskId),
+        eq(deployTaskAgentCalls.callId, callId)
+      )
+    );
+  const row = rows[0];
+  if (row == null) {
+    throw new Error(`Missing agent call ${callId}`);
+  }
+  return row;
+}
+
+async function taskRow(taskId: string): Promise<DeployTaskRow> {
+  const rows = await harness.db
+    .select()
+    .from(deployTasks)
+    .where(eq(deployTasks.id, taskId));
+  const row = rows[0];
+  if (row == null) {
+    throw new Error(`Missing task ${taskId}`);
+  }
+  return row;
+}
+
+function processCalls(
+  task: DeployTaskRow,
+  signals: Parameters<
+    typeof processPendingManagedAgentToolCalls
+  >[0]["signals"] = {}
+) {
+  return processPendingManagedAgentToolCalls({
+    allowedDomain: "example.test",
+    deadlineAtMs: Date.now() + 60_000,
+    inputsSubmitted: false,
+    namespace: task.namespace,
+    runtimeName: "sealai-deploy-demo",
+    signals,
+    task,
+  });
+}
+
+beforeAll(async () => {
+  harness = await createDeployTaskTestHarness();
+});
+
+beforeEach(() => {
+  beginApplyingCalls.length = 0;
+  devboxExecCalls = 0;
+  serveTemplate(templateYaml("v1"));
+});
+
+describe("managed deployment Agent control calls", () => {
+  it("answers template_ready twice in one turn with continue when the digest changes", async () => {
+    const task = await activeManagedTask("mcp-template-ready-twice");
+    const signals = {};
+    const first = templateYaml("v1");
+    const second = templateYaml("v2");
+
+    serveTemplate(first);
+    await store.enqueueAgentToolCall({
+      callId: "ready-1",
+      request: { sha256: sha256(first) },
+      task,
+      toolName: "template_ready",
+    });
+    await processCalls(task, signals);
+
+    const firstResult = await callRow(task.id, "ready-1");
+    expect(firstResult.state).toBe("succeeded");
+    expect(firstResult.response?.decision).toBe("continue");
+    expect(firstResult.response?.sha256).toBe(sha256(first));
+    expect((await taskRow(task.id)).status).toBe("applying");
+
+    // Same turn: the runner still holds the `running` snapshot it started with.
+    serveTemplate(second);
+    await store.enqueueAgentToolCall({
+      callId: "ready-2",
+      request: { sha256: sha256(second) },
+      task,
+      toolName: "template_ready",
+    });
+    await processCalls(task, signals);
+
+    const secondResult = await callRow(task.id, "ready-2");
+    expect(secondResult.state).toBe("succeeded");
+    expect(secondResult.errorCode).toBeNull();
+    expect(secondResult.response?.decision).toBe("continue");
+    expect(secondResult.response?.sha256).toBe(sha256(second));
+    expect(secondResult.attempt).toBe(1);
+    expect(beginApplyingCalls).toEqual([task.id]);
+    const persisted = await taskRow(task.id);
+    expect(persisted.status).toBe("applying");
+    expect(persisted.agentTemplateDigest).toBe(sha256(second));
+  });
+
+  it("fails a contract violation on the first attempt without retrying", async () => {
+    const task = await activeManagedTask("mcp-digest-mismatch");
+    await store.enqueueAgentToolCall({
+      callId: "ready-mismatch",
+      request: { sha256: "a".repeat(64) },
+      task,
+      toolName: "template_ready",
+    });
+
+    await processCalls(task);
+
+    const result = await callRow(task.id, "ready-mismatch");
+    expect(result.state).toBe("failed");
+    expect(result.errorCode).toBe("template_digest_mismatch");
+    expect(result.attempt).toBe(1);
+    expect(devboxExecCalls).toBe(1);
+  });
+
+  it("fails a malformed deployment_completed request once with a safe code", async () => {
+    const task = await activeManagedTask("mcp-invalid-request");
+    await store.enqueueAgentToolCall({
+      callId: "completed-invalid",
+      request: { workloads: "not-a-list", extra: "s3cret-value" },
+      task,
+      toolName: "deployment_completed",
+    });
+
+    await processCalls(task, {
+      templateReady: {
+        awaitingUser: false,
+        blockingInputs: [],
+        checkpointId: "checkpoint",
+      },
+    });
+
+    const result = await callRow(task.id, "completed-invalid");
+    expect(result.state).toBe("failed");
+    expect(result.errorCode).toBe("invalid_request");
+    expect(result.attempt).toBe(1);
+  });
+
+  it("exhausts transient failures with the last safe error code", async () => {
+    const task = await activeManagedTask("mcp-transient-exhausted");
+    const yaml = templateYaml("v1");
+    devboxExecImpl = () =>
+      Promise.reject(new Error("exec failed: token=provider-secret-value"));
+    await store.enqueueAgentToolCall({
+      callId: "ready-transient",
+      request: { sha256: sha256(yaml) },
+      task,
+      toolName: "template_ready",
+    });
+
+    await processCalls(task);
+
+    const result = await callRow(task.id, "ready-transient");
+    expect(result.state).toBe("failed");
+    expect(result.errorCode).toBe("claim_exhausted:agent_tool_failed");
+    expect(result.errorCode).not.toContain("provider-secret-value");
+    expect(result.attempt).toBe(3);
+    // The exhausting claim never runs the handler again.
+    expect(devboxExecCalls).toBe(2);
+  });
+
+  it("rethrows a superseded run instead of failing the call", async () => {
+    const task = await activeManagedTask("mcp-superseded");
+    const yaml = templateYaml("v1");
+    devboxExecImpl = () => Promise.reject(new DeployTaskRunSupersededError());
+    await store.enqueueAgentToolCall({
+      callId: "ready-superseded",
+      request: { sha256: sha256(yaml) },
+      task,
+      toolName: "template_ready",
+    });
+
+    await expect(processCalls(task)).rejects.toBeInstanceOf(
+      DeployTaskRunSupersededError
+    );
+
+    const result = await callRow(task.id, "ready-superseded");
+    expect(result.state).toBe("running");
+    expect(result.attempt).toBe(1);
+    expect(result.errorCode).toBeNull();
+  });
+});

--- a/apps/ui/src/features/deploy/task/runner.ts
+++ b/apps/ui/src/features/deploy/task/runner.ts
@@ -6,6 +6,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { API_ROUTES } from "@workspace/api/constants";
 import { fetcher } from "@workspace/api/fetch";
 import { ApiUrl } from "@workspace/api/utils";
+import { ZodError } from "zod";
 import type {
   DatabaseDeploymentChoice,
   DatabaseDeploymentSettings,
@@ -3326,6 +3327,22 @@ async function observeManagedWorkloadReadiness(input: {
   };
 }
 
+/**
+ * running → applying at most once per run. `task` is the snapshot taken at
+ * turn start, so after the first transition only the turn signal knows the
+ * row is already `applying`; re-running the guarded transition would be
+ * rejected by the engine (`from: ["running"]`) as a supersession.
+ */
+async function ensureManagedApplyingStarted(
+  input: ManagedAgentToolContext
+): Promise<void> {
+  if (input.task.status !== "running" || input.signals.applyingStarted) {
+    return;
+  }
+  await deployTaskBeginApplying(input.task.id);
+  input.signals.applyingStarted = true;
+}
+
 async function handleManagedTemplateReadyCall(
   input: ManagedAgentToolContext,
   call: DeployTaskAgentCallRow
@@ -3371,11 +3388,8 @@ async function handleManagedTemplateReadyCall(
         publicProjectionVersion:
           CURRENT_AI_BLOCKING_INPUT_PUBLIC_PROJECTION_VERSION,
       }));
-  const applyingStarted =
-    blockingInputs.length === 0 && input.task.status === "running";
-  if (applyingStarted) {
-    await deployTaskBeginApplying(input.task.id);
-    input.signals.applyingStarted = true;
+  if (blockingInputs.length === 0) {
+    await ensureManagedApplyingStarted(input);
   }
   await updateDeployTaskState(input.task.id, {
     agentCheckpointId: checkpointId,
@@ -3425,10 +3439,7 @@ async function handleManagedDeploymentCompletedCall(
   ) {
     throw new Error("deployment_completed_throttled");
   }
-  if (input.task.status === "running" && !input.signals.applyingStarted) {
-    await deployTaskBeginApplying(input.task.id);
-    input.signals.applyingStarted = true;
-  }
+  await ensureManagedApplyingStarted(input);
   let readiness: ManagedIdentityGateResult;
   try {
     readiness = await observeManagedWorkloadReadiness({
@@ -3479,7 +3490,41 @@ async function handleManagedDeploymentCompletedCall(
   });
 }
 
-async function processPendingManagedAgentToolCalls(input: {
+const MANAGED_AGENT_TOOL_CONTRACT_ERROR_CODES: ReadonlySet<string> = new Set([
+  "deployment_completed_before_template_ready",
+  "deployment_completed_throttled",
+  "input_schema_changed_after_submission",
+  "invalid_template_digest",
+  "template_digest_mismatch",
+]);
+const MANAGED_AGENT_TOOL_INVALID_REQUEST_CODE = "invalid_request";
+const MANAGED_AGENT_TOOL_FAILED_CODE = "agent_tool_failed";
+
+interface ManagedAgentToolFailure {
+  code: string;
+  retryable: boolean;
+}
+
+/**
+ * Only allowlisted codes reach the Agent: raw messages may quote template or
+ * cluster content. Contract and request-schema violations are deterministic
+ * and fail the call on the first attempt; anything else (Devbox exec, DB) is
+ * treated as transient and retried within the claim budget.
+ */
+function classifyManagedAgentToolError(
+  error: unknown
+): ManagedAgentToolFailure {
+  if (error instanceof ZodError) {
+    return { code: MANAGED_AGENT_TOOL_INVALID_REQUEST_CODE, retryable: false };
+  }
+  const message = error instanceof Error ? error.message : "";
+  if (MANAGED_AGENT_TOOL_CONTRACT_ERROR_CODES.has(message)) {
+    return { code: message, retryable: false };
+  }
+  return { code: MANAGED_AGENT_TOOL_FAILED_CODE, retryable: true };
+}
+
+export async function processPendingManagedAgentToolCalls(input: {
   allowedDomain: string;
   deadlineAtMs: number;
   inputsSubmitted: boolean;
@@ -3489,18 +3534,6 @@ async function processPendingManagedAgentToolCalls(input: {
   task: DeployTaskRow;
 }): Promise<void> {
   const claimOwner = `${input.task.leaseOwner ?? "runner"}:${input.task.leaseEpoch}`;
-  const safeErrorCode = (error: unknown): string => {
-    const message = error instanceof Error ? error.message : "";
-    return [
-      "deployment_completed_before_template_ready",
-      "deployment_completed_throttled",
-      "input_schema_changed_after_submission",
-      "invalid_template_digest",
-      "template_digest_mismatch",
-    ].includes(message)
-      ? message
-      : "agent_tool_failed";
-  };
   while (true) {
     const call = await claimNextAgentToolCall({
       claimOwner,
@@ -3510,6 +3543,11 @@ async function processPendingManagedAgentToolCalls(input: {
     if (call == null) {
       return;
     }
+    if (call.state === "failed") {
+      // The claim itself exhausted the attempt budget and recorded the
+      // verdict; running the handler would only produce discarded side effects.
+      continue;
+    }
     try {
       const handlerContext = { ...input, claimOwner };
       if (call.toolName === "template_ready") {
@@ -3518,13 +3556,19 @@ async function processPendingManagedAgentToolCalls(input: {
       }
       await handleManagedDeploymentCompletedCall(handlerContext, call);
     } catch (error) {
-      const errorCode = safeErrorCode(error);
+      if (isDeployTaskAbortError(error)) {
+        // Not this call's failure: the run lost its fence or was cancelled.
+        // Leave the claim for lease failover and let the turn unwind.
+        throw error;
+      }
+      const failure = classifyManagedAgentToolError(error);
       if (
-        errorCode === "agent_tool_failed" &&
+        failure.retryable &&
         call.attempt < AGENT_CONTROL_CALL_MAX_ATTEMPTS &&
         (await retryAgentToolCall({
           callId: call.callId,
           claimOwner,
+          errorCode: failure.code,
           taskId: call.taskId,
         }))
       ) {
@@ -3534,7 +3578,7 @@ async function processPendingManagedAgentToolCalls(input: {
         claimOwner,
         taskId: call.taskId,
         callId: call.callId,
-        errorCode,
+        errorCode: failure.code,
       });
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug

A second `template_ready` MCP call in the same managed deployment turn always failed with a bare `claim_exhausted` (confirmed via Langfuse sessions), and every later `template_ready` in that turn failed the same way.

Root cause chain in `apps/ui/src/features/deploy/task/`:

1. `runner.ts` `handleManagedTemplateReadyCall` decided whether to call `deployTaskBeginApplying` from the task snapshot captured at turn start. After the first call moved the row to `applying`, the snapshot still said `running`, so the second call re-ran the transition.
2. `engine/handle.ts` `beginApplying` is a guarded transition `from: ["running"]`; the row was already `applying`, so it threw `DeployTaskRunSupersededError`.
3. `processPendingManagedAgentToolCalls` mapped that to `agent_tool_failed`, retried via `retryAgentToolCall` (which also wiped `error_code`), and the store failed the call with `claim_exhausted` on the 3rd claim, hiding the real error.

## Changes

**`runner.ts`**
- `ensureManagedApplyingStarted` gates `running → applying` on the per-turn `ManagedMcpTurnSignals.applyingStarted` (as `deployment_completed` already did) and is shared by both handlers. Engine transition semantics and lease-epoch fencing are untouched.
- Control-call failures are classified: abort errors (`DeployTaskRunSupersededError` / cancelled / timeout) are rethrown so the turn unwinds and the claim is left for lease failover; `ZodError` request-schema violations fail once as `invalid_request`; contract codes keep failing once; only the remaining (Devbox exec / DB) failures are retried, and the retry carries the safe code.
- A call returned by the store already in `failed` (exhausted) state no longer runs the handler (its result was silently dropped before).
- `processPendingManagedAgentToolCalls` is exported for the test.

**`agent-tools/store.ts`**
- `retryAgentToolCall` accepts the attempt's (allowlisted) `errorCode` instead of nulling it.
- Exhaustion reports `claim_exhausted:<last code>` via `agentControlClaimExhaustedCode`; bare `claim_exhausted` is preserved when no prior code exists (crash failover).

The safe-error allowlist is unchanged; raw handler messages still never reach the Agent.

## Tests

- New `runner.managed-agent-tools.test.ts` (PGlite-backed real store, faked Devbox exec + engine write surface whose `beginApplying` mirrors the `from: ["running"]` guard):
  - `template_ready` twice in one turn with a changed digest → `continue` both times, `beginApplying` called once, digest persisted from the second call. **Fails on `main`'s logic, passes with the fix.**
  - contract violation and malformed `deployment_completed` fail on attempt 1 with no retry (`template_digest_mismatch`, `invalid_request`).
  - transient exec failure → `claim_exhausted:agent_tool_failed`, handler runs exactly twice, secret-bearing message not surfaced.
  - superseded run rethrows and leaves the claim `running`.
- `store.test.ts`: retried error code survives to exhaustion (`claim_exhausted:agent_tool_failed`); formatting helper.

`bun typecheck`, `bun check`, and `bun test ./src/features/deploy/task` (408 pass) are green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f099f101-0e6e-5695-94ee-a366bc290a08?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f099f101-0e6e-5695-94ee-a366bc290a08&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

