### PR TITLE
fix: capture chat traces and correct endpoint readiness

### DIFF
--- a/apps/api/route/ap/check_ready.go
+++ b/apps/api/route/ap/check_ready.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -263,7 +264,8 @@ func apCheckReadyDialContext(ctx context.Context, network string, address string
 	}
 	var target netip.Addr
 	for _, ip := range ips {
-		if apCheckReadyPublicAddr(ip) {
+		if apCheckReadyPublicAddr(ip) ||
+			(os.Getenv("NODE_ENV") == "development" && (ip.IsPrivate() || ip.IsLoopback())) {
 			target = ip
 			break
 		}

--- a/apps/api/route/ap/routes_test.go
+++ b/apps/api/route/ap/routes_test.go
@@ -204,15 +204,26 @@ func TestAPCheckReadyTargetsWithClientSkipsPreconditionFailures(t *testing.T) {
 	}
 }
 
-func TestAPCheckReadyURLRejectsPrivateTargets(t *testing.T) {
+func TestAPCheckReadyURLAllowsLocalTargetsOnlyInDevelopment(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
-	got := apCheckReadyURL(context.Background(), newAPCheckReadyHTTPClient(), server.URL)
-	if got.Ready || got.Error != "fetch error" {
-		t.Fatalf("result = %#v, want private target fetch error", got)
+	for _, environment := range []string{"", "production", "test", "dev", "development"} {
+		t.Run("NODE_ENV="+environment, func(t *testing.T) {
+			t.Setenv("NODE_ENV", environment)
+			client := newAPCheckReadyHTTPClient()
+			defer client.CloseIdleConnections()
+			got := apCheckReadyURL(context.Background(), client, server.URL)
+			if environment == "development" {
+				if !got.Ready || got.Error != "" {
+					t.Fatalf("result = %#v, want successful local development probe", got)
+				}
+			} else if got.Ready || got.Error != "fetch error" {
+				t.Fatalf("result = %#v, want private target fetch error", got)
+			}
+		})
 	}
 }
 

--- a/apps/ui/src/app/api/chat/route.ts
+++ b/apps/ui/src/app/api/chat/route.ts
@@ -919,8 +919,8 @@ async function runChatPipeline(input: {
           tools,
           telemetry: {
             functionId: "project-assistant-chat",
-            recordInputs: false,
-            recordOutputs: false,
+            recordInputs: true,
+            recordOutputs: true,
           },
           stopWhen: isStepCount(CHAT_MAX_STEPS),
           experimental_transform: createInjectToolDurationStreamTransform(

--- a/apps/ui/src/features/chat/persistence/title.ts
+++ b/apps/ui/src/features/chat/persistence/title.ts
@@ -151,8 +151,8 @@ export async function deriveThreadTitle(input: {
       maxOutputTokens: TITLE_MAX_OUTPUT_TOKENS,
       telemetry: {
         functionId: "project-assistant-thread-title",
-        recordInputs: false,
-        recordOutputs: false,
+        recordInputs: true,
+        recordOutputs: true,
       },
     });
     const raw = rawTitleFromGenerateTextResult(generated);

--- a/apps/ui/src/features/deploy/task/managed-public-probe.ts
+++ b/apps/ui/src/features/deploy/task/managed-public-probe.ts
@@ -84,6 +84,16 @@ async function probeWebSocketUrl(url: URL, signal: AbortSignal): Promise<void> {
   });
 }
 
+export class AccessEndpointHttpError extends Error {
+  readonly status: number;
+
+  constructor(status: number) {
+    super(`Access endpoint probe returned ${status}.`);
+    this.name = "AccessEndpointHttpError";
+    this.status = status;
+  }
+}
+
 export async function probeManagedPublicUrl(input: {
   allowedDomain: string;
   deadlineAtMs: number;
@@ -113,7 +123,7 @@ export async function probeManagedPublicUrl(input: {
       continue;
     }
     if (!response.ok) {
-      throw new Error(`Access endpoint probe returned ${response.status}.`);
+      throw new AccessEndpointHttpError(response.status);
     }
     return;
   }

--- a/apps/ui/src/features/deploy/task/result-readiness.test.ts
+++ b/apps/ui/src/features/deploy/task/result-readiness.test.ts
@@ -221,3 +221,88 @@ it("resolves and verifies an AP-backed access endpoint before marking it running
     "https://nginx.example.sealos.run/"
   );
 });
+
+it.each([
+  {
+    observer: "ingress",
+    pathStatus: 404,
+    rootStatus: 200,
+    ready: true,
+    calls: 2,
+  },
+  {
+    observer: "ingress",
+    pathStatus: 404,
+    rootStatus: 404,
+    ready: false,
+    calls: 2,
+  },
+  {
+    observer: "ingress",
+    pathStatus: 503,
+    rootStatus: 200,
+    ready: false,
+    calls: 1,
+  },
+  {
+    observer: "declared",
+    pathStatus: 404,
+    rootStatus: 200,
+    ready: false,
+    calls: 1,
+  },
+] as const)("probes a root fallback only for inferred Ingress 404s: %j", async ({
+  observer,
+  pathStatus,
+  rootStatus,
+  ready,
+  calls,
+}) => {
+  const requests: string[] = [];
+  globalThis.fetch = ((url: RequestInfo | URL) => {
+    requests.push(String(url));
+    return Promise.resolve(
+      new Response(null, {
+        status:
+          new URL(String(url)).pathname === "/api" ? pathStatus : rootStatus,
+      })
+    );
+  }) as typeof fetch;
+  const endpoint: DeploymentResultResourceCard = {
+    events: [],
+    id: "inferred-api",
+    required: true,
+    resultRef: {
+      id: "inferred-api",
+      kind: "AccessEndpoint",
+      label: "Web address /api",
+      namespace: "ns-demo",
+      observer:
+        observer === "ingress"
+          ? { kind: "ingress", name: "demo-admin" }
+          : { kind: "declared" },
+      protocol: "https",
+      url: "https://demo.example.sealos.run/api",
+    },
+    status: "creating",
+    title: "Web address /api",
+  };
+  const observed = await observeDeploymentResultCardReadiness({
+    allowedDomain: "example.sealos.run",
+    card: endpoint,
+    kubeconfig: "kubeconfig",
+  });
+  expect(observed.running).toBe(ready);
+  expect(requests).toHaveLength(calls);
+  expect(observed.card.id).toBe(endpoint.id);
+  if (ready) {
+    expect(observed.card.title).toBe("Web address");
+    expect(observed.card.resultRef).toMatchObject({
+      label: "Web address",
+      url: "https://demo.example.sealos.run/",
+    });
+    expect(observed.eventMessage).toBe("Web address is reachable.");
+  } else {
+    expect(observed.card.resultRef).toEqual(endpoint.resultRef);
+  }
+});

--- a/apps/ui/src/features/deploy/task/result-readiness.ts
+++ b/apps/ui/src/features/deploy/task/result-readiness.ts
@@ -3,7 +3,10 @@ import "server-only";
 import { API_ROUTES } from "@workspace/api/constants";
 import { fetcher } from "@workspace/api/fetch";
 import { ApiUrl } from "@workspace/api/utils";
-import { probeManagedPublicUrl } from "./managed-public-probe";
+import {
+  AccessEndpointHttpError,
+  probeManagedPublicUrl,
+} from "./managed-public-probe";
 import {
   apWorkloadReadinessFromProductView,
   type DeploymentResultReadiness,
@@ -18,6 +21,7 @@ import type {
 } from "./timeline";
 
 interface DeploymentResultObservation extends DeploymentResultReadiness {
+  resolvedLabel?: string;
   resolvedProtocol?: DeploymentAccessEndpointProtocol;
   resolvedUrl?: string;
 }
@@ -155,6 +159,7 @@ function applyReadinessToResultCard(
     card.resultRef.kind === "AccessEndpoint" && readiness.resolvedUrl != null
       ? {
           ...card.resultRef,
+          label: readiness.resolvedLabel ?? card.resultRef.label,
           protocol: readiness.resolvedProtocol ?? card.resultRef.protocol,
           url: readiness.resolvedUrl,
         }
@@ -162,6 +167,7 @@ function applyReadinessToResultCard(
   return {
     ...card,
     latestStatusText: readiness.latestStatusText,
+    title: readiness.resolvedLabel ?? card.title,
     resultRef,
     status: readiness.status,
   };
@@ -200,6 +206,7 @@ export function resultReadinessForPresentation(
       break;
   }
   return {
+    ...readiness,
     eventMessage: statusText,
     latestStatusText: statusText,
     status: readiness.status,
@@ -268,6 +275,41 @@ export function waitingForResultObservationStatus(
   return options.surfaceObservationError !== false && error instanceof Error
     ? `Waiting for ${resultReadinessLabel(card)} observation: ${error.message}`
     : `Waiting for ${resultReadinessLabel(card)} observation.`;
+}
+
+function canDiscoverIngressRoot(
+  ref: DeploymentResultResourceRef,
+  url: URL,
+  error: unknown
+): boolean {
+  return (
+    ref.kind === "AccessEndpoint" &&
+    ref.observer.kind === "ingress" &&
+    error instanceof AccessEndpointHttpError &&
+    error.status === 404 &&
+    url.pathname !== "/"
+  );
+}
+
+async function probeAccessEndpoint(
+  ref: Extract<DeploymentResultResourceRef, { kind: "AccessEndpoint" }>,
+  publicUrl: string,
+  options: Omit<Parameters<typeof probeManagedPublicUrl>[0], "publicUrl">
+): Promise<{ url: string; label: string }> {
+  try {
+    await probeManagedPublicUrl({ ...options, publicUrl });
+    return { url: publicUrl, label: ref.label };
+  } catch (error) {
+    // Ingress paths are routing candidates, not declared health checks.
+    // Keep the same deadline and tenant boundary when discovering the root.
+    const parsed = new URL(publicUrl);
+    if (!canDiscoverIngressRoot(ref, parsed, error)) {
+      throw error;
+    }
+    const rootUrl = new URL("/", parsed).href;
+    await probeManagedPublicUrl({ ...options, publicUrl: rootUrl });
+    return { url: rootUrl, label: "Web address" };
+  }
 }
 
 async function resultCardReadiness(input: {
@@ -347,15 +389,22 @@ async function resultCardReadiness(input: {
       ) {
         throw new Error("The access endpoint protocol is unsupported.");
       }
-      await probeManagedPublicUrl({
+      const probeOptions = {
         allowedDomain: input.allowedDomain,
         deadlineAtMs: input.deadlineAtMs ?? Date.now() + 15_000,
-        publicUrl,
         signal: input.signal,
-      });
+      };
+      const resolved = await probeAccessEndpoint(
+        resultRef,
+        publicUrl,
+        probeOptions
+      );
+      publicUrl = resolved.url;
+      const resolvedLabel = resolved.label;
       return {
-        eventMessage: `${resultRef.label} is reachable.`,
-        latestStatusText: `${resultRef.label} is reachable.`,
+        eventMessage: `${resolvedLabel} is reachable.`,
+        latestStatusText: `${resolvedLabel} is reachable.`,
+        resolvedLabel,
         resolvedProtocol,
         resolvedUrl: publicUrl,
         status: "running",

--- a/apps/ui/src/features/resource-settings/ap/ap-settings-sections.test.tsx
+++ b/apps/ui/src/features/resource-settings/ap/ap-settings-sections.test.tsx
@@ -1,3 +1,4 @@
+import { spyOn } from "bun:test";
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
@@ -1171,7 +1172,10 @@ test("read-only network view renders addresses without mutation controls", () =>
 test("AP network preserves WebSocket and web addresses on separate ports", async () => {
   const dom = await installTestDom();
   const previous = setActEnvironment(true);
-  const view = render(
+  const consoleError = spyOn(console, "error").mockImplementation(
+    () => undefined
+  );
+  const content = (
     <TestApSettingsSections
       cpuQuota={{ onValueChange: noop, value: 1 }}
       env={[]}
@@ -1191,13 +1195,13 @@ test("AP network preserves WebSocket and web addresses on separate ports", async
         privatePort: 5200,
         publicAddresses: [
           {
-            id: "game",
+            host: "game.example.com",
             port: 5200,
             status: "accessible",
             url: "wss://game.example.com/",
           },
           {
-            id: "admin",
+            host: "game.example.com",
             port: 5201,
             status: "accessible",
             url: "https://game.example.com/",
@@ -1210,6 +1214,7 @@ test("AP network preserves WebSocket and web addresses on separate ports", async
       readOnly
     />
   );
+  const view = render(content);
   try {
     assert.ok(view.getByText("wss://game.example.com/"));
     assert.ok(view.getByText("https://game.example.com/"));
@@ -1221,7 +1226,22 @@ test("AP network preserves WebSocket and web addresses on separate ports", async
     assert.ok(
       view.container.querySelector('a[href="https://game.example.com/"]')
     );
+    const webRow = view.getByText("https://game.example.com/");
+    const socketRow = view.getByText("wss://game.example.com/");
+    view.rerender(
+      <TestApSettingsSections
+        {...content.props}
+        network={{
+          ...content.props.network,
+          publicAddresses: [...content.props.network.publicAddresses].reverse(),
+        }}
+      />
+    );
+    assert.equal(view.getByText("https://game.example.com/"), webRow);
+    assert.equal(view.getByText("wss://game.example.com/"), socketRow);
+    assert.equal(consoleError.mock.calls.length, 0);
   } finally {
+    consoleError.mockRestore();
     view.unmount();
     restoreActEnvironment(previous);
     await dom.restore();

--- a/apps/ui/src/features/resource-settings/ap/network-section.tsx
+++ b/apps/ui/src/features/resource-settings/ap/network-section.tsx
@@ -310,11 +310,17 @@ function publicAddressKey(
   address: ApNetworkPublicAddress,
   index: number
 ): string {
-  return (
-    address.id?.trim() ||
-    address.host?.trim().toLowerCase() ||
-    `pending-${index}`
-  );
+  const id = publicAddressIdValue(address);
+  if (id !== "") {
+    return `public-id:${id}`;
+  }
+  // Observed addresses may share a host across protocols and target ports.
+  // Keep their row identity stable when the list is reordered or filtered.
+  const url = address.url?.trim() ?? "";
+  const host = address.host?.trim().toLowerCase() ?? "";
+  return url !== "" || host !== ""
+    ? `public-endpoint:${JSON.stringify([url, host, address.port])}`
+    : `public-pending:${index}`;
 }
 
 function customDomainKey(domain: ApNetworkCustomDomain, index: number): string {

--- a/apps/ui/src/lib/observability/chat-langfuse-span-processor.test.ts
+++ b/apps/ui/src/lib/observability/chat-langfuse-span-processor.test.ts
@@ -111,7 +111,7 @@ test("Langfuse exports error codes and metrics without remote error content", as
           stream: simulateReadableStream({
             chunks: [
               { type: "text-start" as const, id: "text-1" },
-              { type: "text-delta" as const, id: "text-1", delta: SECRET },
+              { type: "text-delta" as const, id: "text-1", delta: "Hello!" },
               { type: "text-end" as const, id: "text-1" },
               {
                 type: "finish" as const,
@@ -122,10 +122,16 @@ test("Langfuse exports error codes and metrics without remote error content", as
           }),
         }),
       }),
-      prompt: SECRET,
-      telemetry,
+      prompt: "hello from the user",
+      telemetry: { ...telemetry, recordInputs: true, recordOutputs: true },
     });
-    assert.equal(await success.text, SECRET);
+    assert.equal(await success.text, "Hello!");
+    await processor.forceFlush();
+    const capturedContent = JSON.stringify(
+      exported.map((span) => span.attributes)
+    );
+    assert.ok(capturedContent.includes("hello from the user"));
+    assert.ok(capturedContent.includes("Hello!"));
     let releaseTitle: () => void = () => undefined;
     let titleStarted: () => void = () => undefined;
     const titleGate = new Promise<void>((resolve) => {

--- a/docs/adr/0056-bind-personal-resources-to-verified-workspace-actors.md
+++ b/docs/adr/0056-bind-personal-resources-to-verified-workspace-actors.md
@@ -142,7 +142,15 @@ Client fields such as `userId`, `actorUserId`, and `githubConnectionId` may be
 tolerated for one compatibility release, but their values never influence the
 resolved actor or credential owner. Logs, telemetry, API responses, and audit
 records must not expose kubeconfig tokens, OAuth tokens, connection ciphertext,
-or conversation content.
+or other credentials. Conversation content is excluded from ordinary logs,
+audit records, and unrelated API responses.
+
+Revision (2026-09-07): configured Langfuse tracing may record Assistant
+Conversation model inputs and outputs, including chat and thread-title
+generation, for debugging. These records remain associated with the owning
+user and session; this does not grant workspace members access to another
+actor's conversation. The credential prohibition remains in force, and raw
+exception events and status messages remain excluded from the exporter.
 
 This decision revises ADR-0036's GitHub Connection owner identity and ADR-0047's
 Assistant Conversation boundary, and supplements ADR-0038 with Redeploy

--- a/docs/adr/0059-key-personal-resources-by-global-user-uid.md
+++ b/docs/adr/0059-key-personal-resources-by-global-user-uid.md
@@ -191,11 +191,13 @@ Personal-resource ownership survives kubeconfig rotation (as before), and now
 also region moves and account merges; support attribution can run on the
 global uid. Free Chat Turns remain a namespace-shared allowance.
 
-Identifiers may be recorded; credentials and content may not. `userUid` and
+Identifiers may be recorded; credentials may not. `userUid` and
 `crName` are permitted in logs, telemetry, audit records, and API responses.
-ADR-0056's prohibition list is unchanged and extends to the app token:
-kubeconfig bearer tokens, app tokens, OAuth tokens, connection ciphertext, and
-conversation content never appear in any of those channels.
+ADR-0056's credential prohibition extends to the app token: kubeconfig bearer
+tokens, app tokens, OAuth tokens, and connection ciphertext never appear in any
+of those channels. Conversation content follows ADR-0056's 2026-09-07 revision:
+configured Langfuse tracing may record chat and thread-title model inputs and
+outputs; ordinary logs, audit records, and unrelated API responses may not.
 
 Personal APIs keep failing closed, and ADR-0056's distinct error conditions
 are preserved. After re-key, rows carry only the uid key: no degraded path may

--- a/docs/adr/0079-model-public-entry-points-as-deployment-access-endpoints.md
+++ b/docs/adr/0079-model-public-entry-points-as-deployment-access-endpoints.md
@@ -44,6 +44,13 @@ are probed and gate completion. This keeps `/api`, static assets, and secondary
 admin routes from becoming deployment requirements when the primary app is
 already usable.
 
+For an inferred non-root HTTP(S) Ingress candidate returning 404, observation
+may verify `/` on the same origin. Only a successful root probe replaces the
+candidate URL and label in the running task; its card identity stays stable.
+This is endpoint discovery, not acceptance of a 404 as healthy. Root failures,
+other HTTP errors, explicit URL declarations, and AP-assigned addresses retain
+their existing gates. Completed task history is not rewritten.
+
 Some existing catalog templates use `backend-protocol: WS|WSS` as a legacy
 marker for a public WebSocket entry. Brain preserves that marker narrowly for
 compatibility and verifies one matching WS or WSS address; it is not treated as


### PR DESCRIPTION
## Summary

Fix missing chat trace content and incorrect endpoint behavior encountered during local development:

- Record chat and thread-title model inputs/outputs in Langfuse; update ADR-0056 and ADR-0059 while retaining exception filtering.
- Give observed public addresses without IDs stable URL/host/port keys so HTTP and WebSocket entries sharing a host remain distinct across reordering.
- Allow private and loopback readiness targets only when the Go API runs with `NODE_ENV=development`. Other environments retain the restriction.
- When an inferred non-root Ingress entry returns 404, verify the same-origin root. Only a successful root probe updates the Timeline URL/label and satisfies readiness; explicit endpoints, 503s, and failed roots remain blocked. Preserve the original deadline, tenant boundary, and card identity. Document this discovery rule in ADR-0079.

## Validation

- `bun typecheck` and `bun check`
- `go test ./...` in `apps/api`
- 54 AP settings tests, including same-host row identity across reordering
- 33 deployment readiness, probe, and runner tests
- Chat route, title generation, and observability tests (isolated where module mocks interfere)

The existing live deployment task has not been verified to resume after this change. Previously omitted Langfuse content is not backfilled.
